### PR TITLE
Replace "Gift" book machine translation with official translation

### DIFF
--- a/bus_stop_1.json
+++ b/bus_stop_1.json
@@ -15,25 +15,25 @@
 		"type": "MSGSET",
 		"MessageID": 155580,
 		"TextJPN": "某地方の山奥。@k@r村の外れのバスの停留所「@bひなみざわていりゅうじょ.@<雛見沢停留所@>」。",
-		"TextENG": "The scene is set deep within the mountains of a certain region,@k@rwhere there is a bus stop on the outskirts of a village - the ``Hinamizawa Bus Stop``."
+		"TextENG": "The scene is set deep within the mountains@rof a certain region,@k@rwhere there is a bus stop on the outskirts@rof a village - the ``Hinamizawa Bus Stop``."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155581,
 		"TextJPN": "周辺に民家の類はなく人気もない寂しい場所。@k@r外は雨で陰鬱な雰囲気に支配されている。",
-		"TextENG": "It is a lonely place devoid of people, with hardly any private homes nearby.@k@rRain is pouring outside, and a gloomy mood hangs over the area."
+		"TextENG": "It is a lonely place devoid of people,@rwith hardly any private homes nearby.@k@rRain is pouring outside,@rand a gloomy mood hangs over the area."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155582,
 		"TextJPN": "待合所は粗末な木製の屋台造りで、@rかろうじて雨露をしのげる程度でしかない。@k@r中には３人掛けのベンチが２つと@r町会の掲示板しかない。",
-		"TextENG": "That bus stop is a stand made from crude wood@rthat only just barely keeps out of the rain.@k@rInside, there is a bench only wide enough for three people,@rand two town bulletin boards."
+		"TextENG": "That bus stop is a stand made from crude wood@rthat only just barely keeps out of the rain.@k@rInside, there is a bench only wide enough@rfor three people, and two town bulletin boards."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155583,
 		"TextJPN": "掲示板には村祭りの義援金や@r国勢調査等のポスターが張ってあり、@rなかでも「雛見沢ダム計画絶対反対」等の@rダム計画反対の住民チラシが目立つ。",
-		"TextENG": "The bulletin boards hold posters, including one concerning a national census and one about donations to the village festival.@rThe poster that stands out the most, however, is the one reading, ``Oppose the Hinamizawa Dam Project`` made by the residents protesting it."
+		"TextENG": "The bulletin boards hold posters, including one concerning a national census and one about donations to the village festival.@rThe poster that stands out the most, however,@ris the one reading, ``Oppose the Hinamizawa Dam Project`` made by the residents protesting it."
 	},
 	{
 		"type": "MSGSET",
@@ -273,7 +273,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0150.",
 		"TextJPN": "「『来週の水曜日学校をさぼらない？』なんて言われた日にゃもー、休むしか！　ってカンジでー！」",
 		"NamesENG": "Mion",
-		"TextENG": "Want to skip school next Wednesday?' Well, when that day came, I just had to skip! You know?!``"
+		"TextENG": "'Want to skip school next Wednesday?' Well, when that day came, I just had to skip! You know?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -768,7 +768,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0320.",
 		"TextJPN": "「…へー、梨花さんよくわかりますねぇ。…いわゆるあれですかー？　『簡単な推理だよワトソン君』ってヤツー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Wow, I'm surprised! This time, Mion hits the ground. It's elementary, Watson!' sorta things?!``"
+		"TextENG": "``...Wow, I'm surprised!  ...Is this one of those, 'It's elementary, Watson!' sorta things?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1677,7 +1677,7 @@
 		"PreTextTags": "@vS26/55/TARA_0220.",
 		"TextJPN": "「…すみません…。…すぐ…おさまりますから…。………………」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...I'm sorry... ...It'll... settle down soon... ............``"
+		"TextENG": "``...I'm sorry... ...It'll... settle down soon...``"
 	},
 	{
 		"type": "MSGSET",

--- a/bus_stop_1.json
+++ b/bus_stop_1.json
@@ -15,31 +15,31 @@
 		"type": "MSGSET",
 		"MessageID": 155580,
 		"TextJPN": "某地方の山奥。@k@r村の外れのバスの停留所「@bひなみざわていりゅうじょ.@<雛見沢停留所@>」。",
-		"TextENG": "In the heart of a certain region in the mountains.@k@rAt the bus stop of a particular village,@r``Hinamizawa Bus Stop``."
+		"TextENG": "The scene is set deep within the mountains of a certain region,@k@rwhere there is a bus stop on the outskirts of a village - the ``Hinamizawa Bus Stop``."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155581,
 		"TextJPN": "周辺に民家の類はなく人気もない寂しい場所。@k@r外は雨で陰鬱な雰囲気に支配されている。",
-		"TextENG": "It's a lonely place with no houses around and no popularity.@k@rIt was raining outside and the atmosphere was gloomy."
+		"TextENG": "It is a lonely place devoid of people, with hardly any private homes nearby.@k@rRain is pouring outside, and a gloomy mood hangs over the area."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155582,
 		"TextJPN": "待合所は粗末な木製の屋台造りで、@rかろうじて雨露をしのげる程度でしかない。@k@r中には３人掛けのベンチが２つと@r町会の掲示板しかない。",
-		"TextENG": "The waiting area was a crude wooden stall,@rbarely able to keep out the rain and dew.@k@rInside, there were only two benches@r for three people and a bulletin board for the town council."
+		"TextENG": "That bus stop is a stand made from crude wood@rthat only just barely keeps out of the rain.@k@rInside, there is a bench only wide enough for three people,@rand two town bulletin boards."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155583,
 		"TextJPN": "掲示板には村祭りの義援金や@r国勢調査等のポスターが張ってあり、@rなかでも「雛見沢ダム計画絶対反対」等の@rダム計画反対の住民チラシが目立つ。",
-		"TextENG": "And on the bulletin board, are posters@rof village festival donations and census@rstretched across. But above all,@ra conspicuous ``Absolutely oppose the Hinamizawa@rdam project`` poster directly opposite@rthe residents flyers."
+		"TextENG": "The bulletin boards hold posters, including one concerning a national census and one about donations to the village festival.@rThe poster that stands out the most, however, is the one reading, ``Oppose the Hinamizawa Dam Project`` made by the residents protesting it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155584,
 		"TextJPN": "雨の音しか聞こえない無人の「雛見沢停留所」に、@r２人の学生（@bみおん.@<魅音@>・@bりか.@<梨花@>）がやってくる。",
-		"TextENG": "Now, two girls (Mion and Rika) come to this@runinhabited ``Hinamizawa Bus Stop``@r to hear only the sound of the rain."
+		"TextENG": "Two young students (Mion and Rika) approach@rthe empty Hinamizawa Bus Stop with only@rthe sound of rain to be heard."
 	},
 	{
 		"type": "MSGSET",
@@ -48,7 +48,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0000.",
 		"TextJPN": "「あはははは！　あーっはっはっはっは！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah ha ha ha ha! Ahh ha ha ha ha ha!!``"
+		"TextENG": "``Ahahahaha! Ahhhahahaha!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -57,7 +57,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0000.",
 		"TextJPN": "「盛大に降って来ちゃったわね。だから言ったのに…カサ持って行こうって」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's coming down rather grandly. Even though I told you... we should have taken an umbrella.``"
+		"TextENG": "``It's really coming down, isn't it? This is why I told you... we should've brought umbrellas.``"
 	},
 	{
 		"type": "MSGSET",
@@ -66,7 +66,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0010.",
 		"TextJPN": "「手荷物なんかあったら盛大に遊べないじゃないですかー！　…まま！　降って来ちゃったのは仕方ないってコトで！」",
 		"NamesENG": "Mion",
-		"TextENG": "``If we brought any baggage like that they'd only get in the way! ...Oh well! We'll just have to live with the fact that it came down!``"
+		"TextENG": "``But we couldn't play as hard if we had our hands full of stuff, could we?! ...Oh well! Nothing we can do about it now!``"
 	},
 	{
 		"type": "MSGSET",
@@ -75,7 +75,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0010.",
 		"TextJPN": "「…でもすごい降りね。…やむといいんだけど」",
 		"NamesENG": "Rika",
-		"TextENG": "``...But, it is raining heavy. I hope it stops soon.``"
+		"TextENG": "``...Still, it's really pouring. ...I hope it stops soon.``"
 	},
 	{
 		"type": "MSGSET",
@@ -84,7 +84,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0020.",
 		"TextJPN": "「大丈夫大丈夫！　人類の歴史始まって以来、やまなかった雨と昇らなかった太陽はありませーんって！」",
 		"NamesENG": "Mion",
-		"TextENG": "``It's okay, it's okay! Not since the beginning of human history has there ever been a rain that doesn't stop nor a sun that doesn't rise!``"
+		"TextENG": "``It's fine, it's fine! There's never been an unending rain or a day the sun didn't rise throughout all of human history!``"
 	},
 	{
 		"type": "MSGSET",
@@ -93,7 +93,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0030.",
 		"TextJPN": "「……あはははは！　何か私、カッコいいコト言っちゃったー！　あーっはっはっはっは！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Ah ha ha ha ha! I said something cool just now! Ahh ha ha ha ha ha!``"
+		"TextENG": "``......Ahahahaha! I think I just said something cool! Ahhhahahaha!``"
 	},
 	{
 		"type": "MSGSET",
@@ -102,7 +102,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0020.",
 		"TextJPN": "「笑いで死ねたらあなた、もう死んでるわね…」",
 		"NamesENG": "Rika",
-		"TextENG": "``If you could be killed by laughter, you'd already be dead...``"
+		"TextENG": "``If people could die from laughing, you'd be a pile of ash by now...``"
 	},
 	{
 		"type": "MSGSET",
@@ -111,7 +111,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0040.",
 		"TextJPN": "「あっはっはっは！　笑い死ねたらそれこそ本望ってもんすよ！　あーっはっはっは！　…げほげほげほッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah ha ha ha!! Then to die laughing will become by long-cherished ambition! Ahh ha ha ha! ...*Cough* *cough* *cough* *cough*!``"
+		"TextENG": "``Ahahaha! I'd love nothing more than to die laughing! Ahhhahaha! ...Ghoh, ghoh, ghoh!``"
 	},
 	{
 		"type": "MSGSET",
@@ -120,7 +120,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0030.",
 		"TextJPN": "「…はしゃぎ過ぎだってば。…大丈夫？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...You're in high spirits today. ...Are you alright?``"
+		"TextENG": "``...See, I told you. ...You alright?``"
 	},
 	{
 		"type": "MSGSET",
@@ -129,7 +129,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0050.",
 		"TextJPN": "「あーげほんげほん！　…ははは！　すんません」",
 		"NamesENG": "Mion",
-		"TextENG": "``Nahaha *Cough* *cough*! ...Ha ha ha! I'm sorry.``"
+		"TextENG": "``Yeah, ghoh, ghoh! ...Hahaha! Sorry.``"
 	},
 	{
 		"type": "MSGSET",
@@ -138,7 +138,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0040.",
 		"TextJPN": "「でも、…喜んでくれてよかった。こんなに楽しんでもらえるなんて思わなかったわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``But... I'm glad. I didn't think I could enjoy myself like this.``"
+		"TextENG": "``Still... I'm glad you're enjoying yourself. I didn't think you'd find it this fun.``"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0060.",
 		"TextJPN": "「いや！　今日は本当に！　それこそもーしっちゃかめっちゃかむっちゃくちゃに楽しかったです！　いやぁーホントもー…あーっはっはっはっは！」",
 		"NamesENG": "Mion",
-		"TextENG": "``No! Today really was Super duper mega ultra crazy fun! No, really it was... ahh ha ha ha ha!``"
+		"TextENG": "``Man! Seriously, though! Today I had a buttload ton of fun! Man, seriously... ahhhahahaha!``"
 	},
 	{
 		"type": "MSGSET",
@@ -156,7 +156,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0050.",
 		"TextJPN": "「…大袈裟に喜び過ぎよ。…悪い気はしないけどね…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...You're exaggerating too much. ...But, it wasn't too bad...``"
+		"TextENG": "``...You're exaggerating your enjoyment now. ...Not that it feels bad, though...``"
 	},
 	{
 		"type": "MSGSET",
@@ -165,7 +165,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0070.",
 		"TextJPN": "「…そのー…なんてゆーんですかね、…私ってほら、こーゆう性格じゃないですか」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Well... umm... How do I explain this... Look at me, and my unique personality.``"
+		"TextENG": "``...Well... What do I say? ...I'm just, you know? This is who I am, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -174,7 +174,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0080.",
 		"TextJPN": "「いっつも一人で騒いで外しまくって。…梨花さんも私の事、うるさいヤツだと思ってんだろーなぁ…、って思ってたんですよ…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Always going crazy making noise by myself. ...It's just, Rika-san, I bet you think I'm kinda annoying... that's what I've been wondering...``"
+		"TextENG": "``I'm always going off the rails all by myself. ...I always thought... that you considered me annoying, Rika-san...``"
 	},
 	{
 		"type": "MSGSET",
@@ -183,7 +183,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0060.",
 		"TextJPN": "「…私は魅音の事をうるさいなんて思った事はないわよ。…いつもの騒がしいあなたが好きよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I don't think you're annoying at all, Mion. I like how you're always noisy.``"
+		"TextENG": "``...I've never once thought you were annoying. ...I love how lively you always are.``"
 	},
 	{
 		"type": "MSGSET",
@@ -192,7 +192,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0090.",
 		"TextJPN": "「…ははは！　…だから梨花さんの方から遊びに行こうって誘ってくれた時、ものすごく嬉しかったんですよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Ha ha ha! ...When you invited me to hang out with you, Rika-san, I was extremely happy.``"
+		"TextENG": "``...Hahaha! ...So, that's why I was really happy when you invited me to come out and play.``"
 	},
 	{
 		"type": "MSGSET",
@@ -201,7 +201,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0100.",
 		"TextJPN": "「梨花さんに誘われたらもー！　予定なんかオールキャンセル！　学校なんかないも同然ですよ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``I mean, it was you, Rika-san! So I cancelled all my plans! Same with school, too!``"
+		"TextENG": "``When I got your invitation, man! All my plans, bam, canceled! Forget about school too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -210,7 +210,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0070.",
 		"TextJPN": "「…やっぱり学校さぼって遊びに行こうなんて、良くなかったかしら」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I still can't believe you skipped school just to hang out with me, I wonder if that was a bad idea.``"
+		"TextENG": "``...It probably wasn't a good thing that we skipped school to go and play.``"
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0110.",
 		"TextJPN": "「いーんですいーんです！　どうせ藤嶋の授業なんか１日さぼったって大して変わんないんですから！　…それに平日じゃなかったらここまで盛大に遊び倒せませんでしたよ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``It's fine, it's fine! Skipping Fujishima's class for a day won't change anything! ...And if it weren't a weekday, we couldn't play grandly to our hearts content!``"
+		"TextENG": "``It's fine, it's fine! It's not like missing a day of Fujishima's classes will make that much difference! ...Besides, we couldn't have worn ourselves out playing around like this if it wasn't a weekday, right?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,7 +228,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0080.",
 		"TextJPN": "「…学校をさぼって遊びに行った価値はあった…かな…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Was skipping school to hang out... worth it...?``"
+		"TextENG": "``...You think it really was worth skipping school to go play... then...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -237,7 +237,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0120.",
 		"TextJPN": "「ありありありあり！　ありまくりでしたよ！　…正直な所、真面目っぽい梨花さんが学校さぼって遊びに行こうって言い出した時はかなり意外でしたけどねー」",
 		"NamesENG": "Mion",
-		"TextENG": "``It was, it was! Yes it was! Honestly, when you started talking about skipping school to hang out with you, Rika-san, I was a little surprised.``"
+		"TextENG": "``Yeah, yeah, yeah, yeah! Absolutely, yeah! ...Though to be honest, I was really surprised when you suggested we should, as diligent as you seem to be and all.``"
 	},
 	{
 		"type": "MSGSET",
@@ -246,7 +246,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0090.",
 		"TextJPN": "「…私が言うと意外？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...You were surprised that I said that?``"
+		"TextENG": "``...It was a surprise for me to say that?``"
 	},
 	{
 		"type": "MSGSET",
@@ -255,7 +255,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0130.",
 		"TextJPN": "「だって梨花さん、優等生ーってカンジじゃないすかー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Because you, Rika-san, are considered a model student!``"
+		"TextENG": "``I mean, Rika-san, you come off as a real teacher's pet, you know!``"
 	},
 	{
 		"type": "MSGSET",
@@ -264,7 +264,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0140.",
 		"TextJPN": "「その梨花さんが内緒でこっそり耳元で」",
 		"NamesENG": "Mion",
-		"TextENG": "``As when you secretly whispered into my ear, Rika-san...``"
+		"TextENG": "``So when you secretly whispered into my ear,"
 	},
 	{
 		"type": "MSGSET",
@@ -273,7 +273,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0150.",
 		"TextJPN": "「『来週の水曜日学校をさぼらない？』なんて言われた日にゃもー、休むしか！　ってカンジでー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``'Want to skip school next Wednesday?' I was already planning on doing that! You know!``"
+		"TextENG": "Want to skip school next Wednesday?' Well, when that day came, I just had to skip! You know?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -282,7 +282,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0160.",
 		"TextJPN": "「ひょっとしてコクられちゃうのかな！？　なんてーッ！　いつしか二人は友情からもう一歩上の感情へステップアーップ！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``So I was wondering, by any chance, did you want me here to declare your undying love for me!? Well, what is it! Because at some point, two people with deep friendship always have to step up their feelings of emotion!!``"
+		"TextENG": "``I even thought you might be confessing to me! Just kidding! But before we know it, maybe our emotions will take us one step up from friendship!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0100.",
 		"TextJPN": "「……それは絶対ないから安心して」",
 		"NamesENG": "Rika",
-		"TextENG": "``......That would never happen, you can be sure of that.``"
+		"TextENG": "``......That's never happening, so don't worry.``"
 	},
 	{
 		"type": "MSGSET",
@@ -300,13 +300,13 @@
 		"PreTextTags": "@vS26/53/TMIO_0170.",
 		"TextJPN": "「どーして絶対ないなんて言い切れますー！？　本気で人が愛し合ったら性の壁なんて簡単に越えられちゃうんですよー！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Why did you say that for!? If two people truly love one another, can't they easily overcome barriers like gender!?``"
+		"TextENG": "``How can you be so sure?! When you seriously fall in love with someone, gender is an easy hurdle to overcome!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155614,
 		"TextJPN": "怪しく、にやにや笑いながら詰め寄る魅音。@k@rじりじりとベンチの端へ逃げる梨花。",
-		"TextENG": "Mion grins while smirking strangely.@k Rika begins@rto slowly move away to the other side of the bench."
+		"TextENG": "Mion draws close to her with an ominous grin.@k@rRika inches back on the bench, trying to get away from her."
 	},
 	{
 		"type": "MSGSET",
@@ -315,7 +315,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0110.",
 		"TextJPN": "「……越えなくて結構よ。……結構だったら」",
 		"NamesENG": "Rika",
-		"TextENG": "``......There's no need to overcome anything. ......I feel fine.``"
+		"TextENG": "``......We don't need to overcome anything. ......I'm fine as is.``"
 	},
 	{
 		"type": "MSGSET",
@@ -324,7 +324,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0180.",
 		"TextJPN": "「…こんな辺鄙な所ですからねぇ…。次のバスは１時間も先ですよねぇ…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...But this is such a remote place... And doesn't the next bus come in an hour...?``"
+		"TextENG": "``...Since we live in such a remote place... the next bus won't be here for another hour, you know...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -333,7 +333,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0120.",
 		"TextJPN": "「…しかも今日は雨だからね…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...That's because it's raining today...``"
+		"TextENG": "``...Not to mention, it's also raining today...``"
 	},
 	{
 		"type": "MSGSET",
@@ -342,7 +342,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0190.",
 		"TextJPN": "「…しかもこの停留所、滅多に人の来ない寂しーい所なんですよねぇ」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Besides, this stop is such a lonely place that nobody will even pass by.``"
+		"TextENG": "``...Plus, this bus stop is the sort of place people rarely ever visit.``"
 	},
 	{
 		"type": "MSGSET",
@@ -351,7 +351,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0130.",
 		"TextJPN": "「…しかも今日は雨だからね…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...That's because it's raining today...``"
+		"TextENG": "``...Not to mention, it's also raining today...``"
 	},
 	{
 		"type": "MSGSET",
@@ -360,7 +360,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0200.",
 		"TextJPN": "「…って事はぁ…、最低１時間！　…二人の邪魔をする者は現れないって事ですよねぇ？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...So that gives us... at least one hour! ...So nobody's gonna get in the way of us two, right?``"
+		"TextENG": "``...Which means... we have at least an hour! ...Where no one will come by to disturb us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -369,7 +369,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0140.",
 		"TextJPN": "「…しかも今日は雨だからね…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...That's because it's raining today...``"
+		"TextENG": "``...Not to mention, it's also raining today...``"
 	},
 	{
 		"type": "MSGSET",
@@ -378,13 +378,13 @@
 		"PreTextTags": "@vS26/53/TMIO_0210.",
 		"TextJPN": "「…雨ですからぁ…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Because of the rain...!``"
+		"TextENG": "``...And because of the rain...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155623,
 		"TextJPN": "まさに魅音が梨花に飛び掛かろうとした時、@r２人の男（@bとねがわ.@<利根川@>・@bあらかわ.@<荒川@>）が登場する。@k@r魅音あわてて離れる。",
-		"TextENG": "Exactly when Mion was going to pounce on Rika,@rtwo men (Tonegawa and Arakawa) appear.@k@rMion stops in a hurry."
+		"TextENG": "As Mion prepares to launch herself on Rika, two men (Tonegawa and Arakawa) appear.@k@rMion hastily moves away from Rika."
 	},
 	{
 		"type": "MSGSET",
@@ -393,7 +393,7 @@
 		"PreTextTags": "@vS26/56/TTON_0000.",
 		"TextJPN": "「いやぁー！　助かった助かった」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Wow! We're saved, we're saved.``"
+		"TextENG": "``Maaan! Thank goodness, thank goodness!``"
 	},
 	{
 		"type": "MSGSET",
@@ -402,7 +402,7 @@
 		"PreTextTags": "@vS26/55/TARA_0000.",
 		"TextJPN": "「本当にひどい雨になっちゃいましたね。ずぶ濡れですよ」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``That was some really severe rain. I'm dripping wet.``"
+		"TextENG": "``It really is raining awfully hard out there. I'm soaked.``"
 	},
 	{
 		"type": "MSGSET",
@@ -411,7 +411,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0220.",
 		"TextJPN": "「雨ですからーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Because of the rain...!``"
+		"TextENG": "``And because of the rain!``"
 	},
 	{
 		"type": "MSGSET",
@@ -420,7 +420,7 @@
 		"PreTextTags": "@vS26/56/TTON_0010.",
 		"TextJPN": "「？？　……ははは！　いやいや、仰る通りですね。…荒川君、次のバスは何時に来るんだい？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``?? ......Ha ha! No no, it seems you're right. ...Arakawa-kun, what time does the next bus come at?``"
+		"TextENG": "``?? ......Hahaha! You said it. ...Arakawa-kun, when's the next bus due?``"
 	},
 	{
 		"type": "MSGSET",
@@ -429,7 +429,7 @@
 		"PreTextTags": "@vS26/55/TARA_0010.",
 		"TextJPN": "「えー…小一時間は来ないですね。ついさっき行っちゃったばかりみたいです。…こんな大雨の中で１時間もバス待ちとはついてないですよ」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Eh... It won't come for at least another hour. It seems the last one just passed by a few minutes ago. ...So we'll have to wait another hour in this heavy rain for the next bus.``"
+		"TextENG": "``Uhh... in a little under an hour. Looks like it just passed through a little while ago. ...We've got no luck, getting stuck at this bus stop in the heavy rain for an hour.``"
 	},
 	{
 		"type": "MSGSET",
@@ -438,7 +438,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0230.",
 		"TextJPN": "「雨ですからーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Because of the rain...!``"
+		"TextENG": "``And because of the rain!``"
 	},
 	{
 		"type": "MSGSET",
@@ -447,7 +447,7 @@
 		"PreTextTags": "@vS26/55/TARA_0020.",
 		"TextJPN": "「…？？　…私ら、何かしましたかね…？」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...?? ...Did we do something...?``"
+		"TextENG": "``...?? ...Did we do something to you...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -456,7 +456,7 @@
 		"PreTextTags": "@vS26/56/TTON_0020.",
 		"TextJPN": "「…ここしばらくフロ入ってないからなぁ。…臭うかな…？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...I haven't taken a bath in a while. ...Do I stink...?``"
+		"TextENG": "``...It's been a while since I took a bath. ...Do I smell...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -465,7 +465,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0150.",
 		"TextJPN": "「…お邪魔が入っちゃって残念？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...It's too bad their arrival stopped you, huh?``"
+		"TextENG": "``...Regretting the interruption?``"
 	},
 	{
 		"type": "MSGSET",
@@ -474,7 +474,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0240.",
 		"TextJPN": "「ちきしょー！　…隙見てあいつらスマキにするっすー。…梨花さん、続きはその後ってことで」",
 		"NamesENG": "Mion",
-		"TextENG": "``Damn it! I'll roll'em up in a mat and throw'em into a river when I get the chance. ...Rika-san, we'll continue this later.``"
+		"TextENG": "``Dammit! ...When I get my chance, I'll bury the two of 'em. ...Rika-san, we'll continue afterward.``"
 	},
 	{
 		"type": "MSGSET",
@@ -483,13 +483,13 @@
 		"PreTextTags": "@vS26/52/TRIK_0160.",
 		"TextJPN": "「……そうねぇ。……本当にやったらいいわよ。……許してあ・げ・る」",
 		"NamesENG": "Rika",
-		"TextENG": "``......You're right. I really think you should. ......You have my permission.``"
+		"TextENG": "``......Sure. ......If you really do it. ......I'll forgive you.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155635,
 		"TextJPN": "怪しいぎらぎらとした目つきで２人の男を凝視する魅音。あまりの異様さに思わず後退る利根川と荒川。",
-		"TextENG": "Mion glaringly stares at the two strange men with suspicious and flashy eyes. Tonegawa and Arakawa look behind them and unintentionally take a few steps back."
+		"TextENG": "Mion glares at both men with a suspicious, burning look. Both Tonegawa and Arakawa feel forced to take a step backward."
 	},
 	{
 		"type": "MSGSET",
@@ -498,7 +498,7 @@
 		"PreTextTags": "@vS26/56/TTON_0030.",
 		"TextJPN": "「……お嬢さん方、…やっぱり臭うかい…？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``......Hey missy... Do I smell after all...?``"
+		"TextENG": "``......Ladies... do I really smell...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -507,7 +507,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0250.",
 		"TextJPN": "「臭う臭う！　臭いますよッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Yes, yes! I smell it!``"
+		"TextENG": "``You smell, you smell! You stink to high heaven!``"
 	},
 	{
 		"type": "MSGSET",
@@ -516,7 +516,7 @@
 		"PreTextTags": "@vS26/55/TARA_0030.",
 		"TextJPN": "「ほら、だから言ったじゃないですか！　大酒飲むと体臭に出ちゃうんですよ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Hey, told you didn't I! Your body gives off an odor when you drink lots of sake!``"
+		"TextENG": "``See? This is why I told you to lay off! You sweat more when you drink a lot!``"
 	},
 	{
 		"type": "MSGSET",
@@ -525,7 +525,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0170.",
 		"TextJPN": "「…そんなに臭う？　…私、わかんないけど」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Do you really smell it? ...I don't know.``"
+		"TextENG": "``...Does he smell that bad? ...I can't tell myself.``"
 	},
 	{
 		"type": "MSGSET",
@@ -534,7 +534,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0260.",
 		"TextJPN": "「臭いますよ！　ぷんぷんじゃないですかぁ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``I smell it! It doesn't matter if you can't!``"
+		"TextENG": "``He does! He reeks!``"
 	},
 	{
 		"type": "MSGSET",
@@ -543,7 +543,7 @@
 		"PreTextTags": "@vS26/55/TARA_0040.",
 		"TextJPN": "「ね！？　男にだって身だしなみは必要なんですよぅ！　…あーもー！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Huh!? Even a man need to think about his appearance! ...Damn it!``"
+		"TextENG": "``Right?! Even men need to take care of their appearance! Come on, now!``"
 	},
 	{
 		"type": "MSGSET",
@@ -552,7 +552,7 @@
 		"PreTextTags": "@vS26/56/TTON_0040.",
 		"TextJPN": "「はっは…。今度から気をつけるよ。だけど、あの子が言うほど臭ったりはしないだろう！？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``I'll try to be more careful from now on. ...But, didn't that kid say she smelled it!?``"
+		"TextENG": "``I'll be more careful. ...But I don't smell as bad as she's claiming, right?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -570,7 +570,7 @@
 		"PreTextTags": "@vS26/55/TARA_0050.",
 		"TextJPN": "「…私もあんまりわからないですね」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...I don't know if I can either.``"
+		"TextENG": "``...I don't notice much either.``"
 	},
 	{
 		"type": "MSGSET",
@@ -579,7 +579,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0270.",
 		"TextJPN": "「臭いますよッ！　見てわかりませんかね！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``I smell it! I can even see it, can't you!?``"
+		"TextENG": "``You smell, all right! You can tell by looking!``"
 	},
 	{
 		"type": "MSGSET",
@@ -588,7 +588,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0190.",
 		"TextJPN": "「…見て？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...See it?``"
+		"TextENG": "``...By looking?``"
 	},
 	{
 		"type": "MSGSET",
@@ -597,7 +597,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0280.",
 		"TextJPN": "「こんな人気のない所に怪しい二人組がやって来るなんて、理由は一個しかないに決まってるじゃないですかーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Two suspicious men coming to a deserted place like this, there can only be one reason!``"
+		"TextENG": "``For a suspicious pair of men to come to an isolated place like this... there can only be one reason!``"
 	},
 	{
 		"type": "MSGSET",
@@ -606,13 +606,13 @@
 		"PreTextTags": "@vS26/56/TTON_0050.",
 		"TextJPN": "「…理由って？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Reason?``"
+		"TextENG": "``...What reason?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155649,
 		"TextJPN": "間髪入れずに魅音の下腹部に拳を埋め込む梨花。魅音、沈黙しうずくまる。",
-		"TextENG": "Rika buries her fist in Mion's stomach. Mion crouches down in silence."
+		"TextENG": "Rika buries her fist into Mion's stomach without a moment's pause. Mion curls up and falls silent after that."
 	},
 	{
 		"type": "MSGSET",
@@ -621,7 +621,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0200.",
 		"TextJPN": "「…気にしないで下さい。…この子、ちょっとオカシイんです」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Please don't mind her. ...She's a little weird.``"
+		"TextENG": "``...Please don't let it bother you. ...This girl's a little crazy.``"
 	},
 	{
 		"type": "MSGSET",
@@ -630,13 +630,13 @@
 		"PreTextTags": "@vS26/53/TMIO_0290.",
 		"TextJPN": "「……り…梨花さん…、…すっげぇ痛いんですけど。……このお腹の中には私と梨花さんの赤ちゃんがいるんですよー…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Ri...Rika-san... ...that really hurt. ......Don't you know I'm carrying our child in my belly, Rika-san...?``"
+		"TextENG": "``......Ri...Rika-san... ...That really hurt, you know. ......I'm carrying our baby in this stomach, remember...?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155652,
 		"TextJPN": "魅音の首を小脇で締め上げる梨花。",
-		"TextENG": "Rika tightens her arm around Mion's neck."
+		"TextENG": "Rika wraps her arm around Mion's neck and strangles her in her armpit."
 	},
 	{
 		"type": "MSGSET",
@@ -645,7 +645,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0210.",
 		"TextJPN": "「…このまま落としてもいいのかしら？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Do you want to be hurt so badly you can't have a baby?``"
+		"TextENG": "``...Want me to make it so your body can never bear children?``"
 	},
 	{
 		"type": "MSGSET",
@@ -654,7 +654,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0300.",
 		"TextJPN": "「梨花さん痛いっす、それマジで痛い…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Rika-san, that hurts, it's really painful...``"
+		"TextENG": "``Rika-san, that hurts! That seriously hurts...``"
 	},
 	{
 		"type": "MSGSET",
@@ -663,7 +663,7 @@
 		"PreTextTags": "@vS26/56/TTON_0060.",
 		"TextJPN": "「……何だか、とっても仲良しさんみたいだねぇ。…お友達ですか？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``......Somehow, you two seem very close. ...Are you friends?``"
+		"TextENG": "``......Looks like you two get along really well. ...You friends?``"
 	},
 	{
 		"type": "MSGSET",
@@ -672,13 +672,13 @@
 		"PreTextTags": "@vS26/53/TMIO_0310.",
 		"TextJPN": "「お友達なんてとんでもない！　私と梨花お姉さまはそれ以上のッ！@k@|@y@vS26/53/TMIO_0311.　ゲホッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Of course we're not just friends! Me and Rika-oneesama are much closer than that!@k@|@y@vS26/53/TMIO_0311. Ghh!``"
+		"TextENG": "``Friends? Heavens no! There's much more than that between me and Rika-onee-sama!@k@|@y@vS26/53/TMIO_0311. *cough*``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155657,
 		"TextJPN": "即座に魅音の下腹部に拳を叩き込む梨花。たまらず今度こそダウンする魅音。",
-		"TextENG": "Immediately, Rika again hammers her fist down into Mion's stomach. Mion this time falls and doesn't stand back up."
+		"TextENG": "Rika immediately slams her fist into Mion's stomach again. This time, Mion hits the ground."
 	},
 	{
 		"type": "MSGSET",
@@ -687,7 +687,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0220.",
 		"TextJPN": "「お友達です。…私は梨花。古手梨花。…この子は魅音。…園崎魅音」",
 		"NamesENG": "Rika",
-		"TextENG": "``We're friends. ...I'm Rika. Rika Furude. ...And she is Mion. ...Mion Sonozaki.``"
+		"TextENG": "``We're friends. ...I'm Rika. Rika Furude. ...This girl's Mion. ...Mion Sonozaki.``"
 	},
 	{
 		"type": "MSGSET",
@@ -696,7 +696,7 @@
 		"PreTextTags": "@vS26/56/TTON_0070.",
 		"TextJPN": "「あぁどうも。私は利根川と申します。こっちは荒川君。ちなみに、彼はまだ独身なんですよー」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Ah, nice to meet you. My name is Tonegawa. This is Arakawa-kun. By the way, he's still single.``"
+		"TextENG": "``Yeah, nice to meet you. I'm Tonegawa. This is Arakawa-kun. By the way, he's still single.``"
 	},
 	{
 		"type": "MSGSET",
@@ -705,7 +705,7 @@
 		"PreTextTags": "@vS26/55/TARA_0060.",
 		"TextJPN": "「利根川さん、余計なこと言わないで下さいよ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Tonegawa-san, please don't say unnecessary things like that!``"
+		"TextENG": "``Tonegawa-san, please don't add more details than you need to!``"
 	},
 	{
 		"type": "MSGSET",
@@ -714,7 +714,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0230.",
 		"TextJPN": "「……荒川さんはご趣味とご職業は何ですか？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Arakawa-san, what are your hobbies and occupation?``"
+		"TextENG": "``...What are your hobbies, Arakawa-san? What do you do for a living?``"
 	},
 	{
 		"type": "MSGSET",
@@ -723,7 +723,7 @@
 		"PreTextTags": "@vS26/56/TTON_0080.",
 		"TextJPN": "「ほら来たぞ！　カッコ良く答えなきゃ！」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Hey, come on! You have to answer properly!``"
+		"TextENG": "``See, here it comes! Be cool with your answer, man!``"
 	},
 	{
 		"type": "MSGSET",
@@ -732,7 +732,7 @@
 		"PreTextTags": "@vS26/55/TARA_0070.",
 		"TextJPN": "「え、あー、しゅ趣味は、スキーなんかを少々！　…えーと職業はですねぇ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Eh, ah, my hobbies, I, I like a little bit of skiing! ...Eh, my occupation!``"
+		"TextENG": "``Huh? Uhh, f-for my hobbies, I like skiing, sometimes! ...Uhh, and my career's, uh!``"
 	},
 	{
 		"type": "MSGSET",
@@ -741,7 +741,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0240.",
 		"TextJPN": "「…建設省。……河川局の方ですね？　…ダム計画の」",
 		"NamesENG": "Rika",
-		"TextENG": "``...The Ministry of Construction. ......Is it the River Bureau? ...You're from the dam project.``"
+		"TextENG": "``...With the Ministry of Construction. ......You're with the River Bureau, right? ...Working on the dam project.``"
 	},
 	{
 		"type": "MSGSET",
@@ -750,7 +750,7 @@
 		"PreTextTags": "@vS26/55/TARA_0080.",
 		"TextJPN": "「え？　…えぇ、まぁ…！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Eh? ...Eh, well...!``"
+		"TextENG": "``Huh? ...Well, yes...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -759,7 +759,7 @@
 		"PreTextTags": "@vS26/56/TTON_0090.",
 		"TextJPN": "「ご存知でしたか」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``So you know us.``"
+		"TextENG": "``You already knew?``"
 	},
 	{
 		"type": "MSGSET",
@@ -768,7 +768,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0320.",
 		"TextJPN": "「…へー、梨花さんよくわかりますねぇ。…いわゆるあれですかー？　『簡単な推理だよワトソン君』ってヤツー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Heh, your very knowledgeable, Rika-san. ...How this went? Elementary, my dear Watson!``"
+		"TextENG": "``...Wow, I'm surprised! This time, Mion hits the ground. It's elementary, Watson!' sorta things?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -777,7 +777,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0250.",
 		"TextJPN": "「…推理も何も。…そんな格好して歩いてるのはダム計画の関係者だけよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``...There's no deduction involved. ...Only people involved in the dam project dress like that.``"
+		"TextENG": "``...There's not much to deduce. ...Only people involved with the dam project walk around in an outfit like that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -786,7 +786,7 @@
 		"PreTextTags": "@vS26/56/TTON_0100.",
 		"TextJPN": "「はっはっは！　…仰る通りですよ。名探偵さんには感服しました。改めて自己紹介しましょう」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Ha ha ha! ...We were about to say that. You have my admiration Miss Great detective. Let's reintroduce ourselves.``"
+		"TextENG": "``Hahaha! ...It's just as you say. I'm impressed, detective. Allow me to introduce myself once more.``"
 	},
 	{
 		"type": "MSGSET",
@@ -795,7 +795,7 @@
 		"PreTextTags": "@vS26/56/TTON_0110.",
 		"TextJPN": "「この４月に砂防部傾斜地保全課から参りました、建設省河川局都市河川の利根川です」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``I come from the Slope Conservation, Erosion and Sediment control department, I've been here since April. I'm Tonegawa of the Ministry of Construction River Bureau Urban River office.``"
+		"TextENG": "``I'm Tonegawa from the Ministry of Construction, River Bureau, Urban River Office. I left the Erosion and Sediment Control Department in April.``"
 	},
 	{
 		"type": "MSGSET",
@@ -804,7 +804,7 @@
 		"PreTextTags": "@vS26/55/TARA_0090.",
 		"TextJPN": "「同じく都市河川の荒川です」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Likewise, Arakawa of the Urban River office.``"
+		"TextENG": "``Arakawa from the same Urban River Office.``"
 	},
 	{
 		"type": "MSGSET",
@@ -813,7 +813,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0330.",
 		"TextJPN": "「同じくワカリマセンの園崎です」",
 		"NamesENG": "Mion",
-		"TextENG": "``Same here, I'm not really sure but I'm Mion Sonozaki.``"
+		"TextENG": "``Sonozaki from the same makes-no-sense-to-me.``"
 	},
 	{
 		"type": "MSGSET",
@@ -822,13 +822,13 @@
 		"PreTextTags": "@vS26/52/TRIK_0260.",
 		"TextJPN": "「同じくワカンナイのはあんたの脳ミソよ…」",
 		"NamesENG": "Rika",
-		"TextENG": "``I think you've got a few screws loose in that brain of yours...``"
+		"TextENG": "``What makes no sense to me is your brain...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155674,
 		"TextJPN": "ほんのしばらくの沈黙。梨花は差し出される手に握手しようとしない。",
-		"TextENG": "After a few moments of silence, Rika chooses not to shake the hands held out before her."
+		"TextENG": "A moment of silence passes. Rika makes no attempt to shake the hands offered to her."
 	},
 	{
 		"type": "MSGSET",
@@ -837,7 +837,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0270.",
 		"TextJPN": "「…握手なんかすると思う？　…雛見沢を滅ぼそうとする人間と」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Do you think I'll shake your hand? ...When you're the people trying to destroy Hinamizawa.``"
+		"TextENG": "``...Did you really think I'd shake your hand? ...When you're one of the ones trying to destroy Hinamizawa?``"
 	},
 	{
 		"type": "MSGSET",
@@ -855,7 +855,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0280.",
 		"TextJPN": "「…握手なんかすると思う？　…雛見沢を汚そうとする人間と」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Do you think I'll shake your hand? ...When you're the people trying to dirty Hinamizawa.``"
+		"TextENG": "``...Did you think I'd shake your hand? ...When you're one of the ones trying to defile Hinamizawa?``"
 	},
 	{
 		"type": "MSGSET",
@@ -873,7 +873,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0340.",
 		"TextJPN": "「…へっへっへー…！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Heh heh heh...!``"
+		"TextENG": "``...Hehehe...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -882,7 +882,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0290.",
 		"TextJPN": "「……雛見沢にダムなんて許さない」",
 		"NamesENG": "Rika",
-		"TextENG": "``......I'd never allow something like a dam in Hinamizawa.``"
+		"TextENG": "``......We won't allow there to be a dam here in Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -891,7 +891,7 @@
 		"PreTextTags": "@vS26/56/TTON_0130.",
 		"TextJPN": "「雛見川にダムは必要なんです。下流地域の利水と治水事業にこの上なく貢献できるでしょう」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``But a dam is necessary in Hinamizawa. It will greatly contribute to the irrigation and flood control projects of the downstream regions.``"
+		"TextENG": "``Hinami River needs a dam. It will provide extraordinary contributions to the irrigation of the regions downstream, as well as flood control operations.``"
 	},
 	{
 		"type": "MSGSET",
@@ -909,7 +909,7 @@
 		"PreTextTags": "@vS26/55/TARA_0110.",
 		"TextJPN": "「ダムで発電できる電力も重要です。最大３５万キロワットの大電力は日本の高度経済成長の追い風となります」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``The electricity that will be generated by the dam is very important. A large amount of electricity up to 350,000 kilowatts will benefit Japan's rapid economic growth.``"
+		"TextENG": "``We also need the electricity that a dam could generate. A generator outputting up to 350,000 kilowatts will be a boon to Japan's rapid economic growth.``"
 	},
 	{
 		"type": "MSGSET",
@@ -927,7 +927,7 @@
 		"PreTextTags": "@vS26/56/TTON_0140.",
 		"TextJPN": "「ダムの地域開発効果も無視する事はできません。地元はもちろん、沿線各都市の産業文化の向上に大いに貢献するでしょう」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``We also can't ignore the regional development the effect of the dam will bring. Not to mention your hometown will greatly contribute to the rise of industrial culture in each city along the railway line.``"
+		"TextENG": "``You can't ignore the effects a dam would have on development of the region either. It would be a huge contribution not only locally, but also to the advancement of industries in the railway cities around here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -942,19 +942,19 @@
 		"type": "MSGSET",
 		"MessageID": 155687,
 		"TextJPN": "相変わらず魅音は握手を求めたまま固まっている。",
-		"TextENG": "Mion hardens as ever, still waiting for a handshake."
+		"TextENG": "Mion remains frozen, looking for a handshake."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155688,
 		"TextJPN": "呆れながら魅音と握手する梨花。",
-		"TextENG": "Amazed, Rika shakes her hand."
+		"TextENG": "Exasperated, Rika shakes her hand."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155689,
 		"TextJPN": "無言で妙に嬉しがる魅音。",
-		"TextENG": "Mion, strangely overjoyed, thinks to herself in silence."
+		"TextENG": "Mion is silently overjoyed."
 	},
 	{
 		"type": "MSGSET",
@@ -963,7 +963,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0330.",
 		"TextJPN": "「…どんな綺麗事を並べたって。雛見沢をダム湖に沈める理由になんかならない」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I'll never agree no matter what you say. Because those reasons don't justify sinking Hinamizawa into a lake just to build a dam.``"
+		"TextENG": "``...You can list all the niceties you want. None of them are a good reason to submerge Hinamizawa under a reservoir.``"
 	},
 	{
 		"type": "MSGSET",
@@ -972,7 +972,7 @@
 		"PreTextTags": "@vS26/56/TTON_0150.",
 		"TextJPN": "「…もちろんお気持ちはわかります。ですが雛見沢はダム工事に有利な条件をいくつも持っているのです」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Of course, we understand your feelings. But Hinamizawa has a number of favorable conditions for dam construction.``"
+		"TextENG": "``...Of course we understand how you feel. However, there are still several conditions that make Hinamizawa most suitable for construction of the dam.``"
 	},
 	{
 		"type": "MSGSET",
@@ -981,7 +981,7 @@
 		"PreTextTags": "@vS26/55/TARA_0120.",
 		"TextJPN": "「ひとつは地形条件です。雛見沢は雛見川の川幅が極端に狭まった場所で、しかも岩盤は花崗岩。…ダムの設置場所としては最高の条件なのです」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``One is the terrain condition. The width of the Hinamigawa river is extremely narrow in Hinamizawa, moreover, the bedrock is granite. ...And thus these conditions make it the best location for the installation of a dam.``"
+		"TextENG": "``The first is the layout of the terrain. Hinamizawa is where the Hinami River comes to its narrowest point, and the bedrock here is granite. ...Those are both perfect conditions for the construction of a dam.``"
 	},
 	{
 		"type": "MSGSET",
@@ -990,7 +990,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0340.",
 		"TextJPN": "「それで？」",
 		"NamesENG": "Rika",
-		"TextENG": "``And?``"
+		"TextENG": "``So?``"
 	},
 	{
 		"type": "MSGSET",
@@ -999,7 +999,7 @@
 		"PreTextTags": "@vS26/56/TTON_0160.",
 		"TextJPN": "「電気の需要中心地に近く、送電ロスが少ない事も重要です。先程申し上げた通り、最大の発電力は３５万キロワット」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``It's close to centers where the demand for electricity is high, so reducing the transmission losses is important too. And as I mentioned earlier, the maximum power-generation capacity is 350,000 kilowatts.``"
+		"TextENG": "``Another important factor is its proximity to a center of demand for electricity, so there's little lost in transmission. Also, as I mentioned before, it could generate up to 350,000 kilowatts.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1008,7 +1008,7 @@
 		"PreTextTags": "@vS26/55/TARA_0130.",
 		"TextJPN": "「これは一昔前の四国全土の消費電力量に当たります」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``This power will also supply electricity to all of Shikoku for years to come.``"
+		"TextENG": "``That's the same amount of energy that used to be consumed by all of Shikoku.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1017,7 +1017,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0350.",
 		"TextJPN": "「それで？」",
 		"NamesENG": "Rika",
-		"TextENG": "``And?``"
+		"TextENG": "``So?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1026,7 +1026,7 @@
 		"PreTextTags": "@vS26/56/TTON_0170.",
 		"TextJPN": "「貯水効率の高さも挙げられます。雛見沢ダムの場合、貯水効率は２００」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``The height of water storage efficiency counts as well. In the case of Hinamizawa dam, water storage efficiency is 200.``"
+		"TextENG": "``It can also raise our water storage efficiency. The Hinamizawa dam will have a storage efficiency of 200.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1035,7 +1035,7 @@
 		"PreTextTags": "@vS26/55/TARA_0140.",
 		"TextJPN": "「これはダム体積の２００倍に当たります」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``This will increase the dam's capacity 200 times.``"
+		"TextENG": "``That means 200 times the dam capacity.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1044,7 +1044,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0360.",
 		"TextJPN": "「それで？」",
 		"NamesENG": "Rika",
-		"TextENG": "``And?``"
+		"TextENG": "``So?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1053,7 +1053,7 @@
 		"PreTextTags": "@vS26/56/TTON_0180.",
 		"TextJPN": "「つまり雛見沢にダムを築けば水位が上がり、ダム湖としては全長３０キロ以上のものになります」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``In other words, if we build a damn in Hinamizawa, the water levels will rise, and then we'll have a dam lake with a total length of 30 kilometers.``"
+		"TextENG": "``In other words, once the Hinamizawa dam is built, the water level will rise and the reservoir will span over a full 30 kilometers.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1062,7 +1062,7 @@
 		"PreTextTags": "@vS26/55/TARA_0150.",
 		"TextJPN": "「これは東京から大宮までの距離に当たります」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``That will cover the distance from Tokyo to Omiya.``"
+		"TextENG": "``That's about the distance from Tokyo to Oomiya.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1071,7 +1071,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0370.",
 		"TextJPN": "「それで？」",
 		"NamesENG": "Rika",
-		"TextENG": "``And?``"
+		"TextENG": "``So?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1080,7 +1080,7 @@
 		"PreTextTags": "@vS26/56/TTON_0190.",
 		"TextJPN": "「骨材の調達の利便性も重要です。雛見沢ダムには容積１５０万立方メートルの骨材が必要と計算されています」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``And then there's the convenience of procuring an aggregate supply, which is also important. Hinamizawa dam has also been calculated to have a capacity of 1,500,000 cubic meters worth of aggregate.``"
+		"TextENG": "``The convenience of acquiring construction aggregate is also an important factor. We've calculated that the Hinamizawa dam will require 1,500,000 cubic meters of aggregate.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1089,7 +1089,7 @@
 		"PreTextTags": "@vS26/55/TARA_0160.",
 		"TextJPN": "「これは丸ビル６杯分に当たります」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``That's enough for six Marunouchi Buildings.``"
+		"TextENG": "``That's enough for six buildings.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1098,7 +1098,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0350.",
 		"TextJPN": "「ついでに温泉旅行が当たります」",
 		"NamesENG": "Mion",
-		"TextENG": "``While you're at it, throw in a trip to the hot springs.``"
+		"TextENG": "``We could also win a hot springs trip, too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1107,13 +1107,13 @@
 		"PreTextTags": "@vS26/52/TRIK_0380.",
 		"TextJPN": "「…それで？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...And?``"
+		"TextENG": "``...So?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155707,
 		"TextJPN": "ぎょろりと魅音に振り返る梨花。真面目な話に水をさす魅音をどんどん追い詰めていく。",
-		"TextENG": "Rika snaps back around and looks at Mion. Rapidly cornering Mion, dampening her spirit."
+		"TextENG": "Rika turns and glares at Mion. She stomps even closer to Mion, who has just interrupted their serious discussion."
 	},
 	{
 		"type": "MSGSET",
@@ -1122,7 +1122,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0360.",
 		"TextJPN": "「へ？　…ははははは！　当たったらいいなぁ！　なんてーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Heh? ...Ha ha ha ha ha! It would be nice if we got that! I bet!``"
+		"TextENG": "``Huh? ...Hahahahaha! I hope we win one! You know?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1131,7 +1131,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0390.",
 		"TextJPN": "「それで？」",
 		"NamesENG": "Rika",
-		"TextENG": "``And?``"
+		"TextENG": "``So?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1140,7 +1140,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0370.",
 		"TextJPN": "「普通はペアでご招待なんですよねぇ！　…当たったら一緒に行きましょうねー…温泉ー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Normally they'd give an invitation to a couple, right! So if we get them, we'll go together... to the hot springs!``"
+		"TextENG": "``Normally you win a pair of tickets, right? ...So let's go together if we win! ...To the hot springs!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1149,7 +1149,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0400.",
 		"TextJPN": "「それで？」",
 		"NamesENG": "Rika",
-		"TextENG": "``And?``"
+		"TextENG": "``So?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1158,7 +1158,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0380.",
 		"TextJPN": "「お、温泉行ったら背中の流しっこしましょーねーッ！　んで出たら浴衣で卓球ー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``And when we go to the h-hot spring, we can pour water down each others backs like kids! Then after that, we'll play table tennis in yukata's!``"
+		"TextENG": "``W-When we go to the hot springs, we can wash each other's backs! Then when we're done, we can play ping pong in yukata!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1167,7 +1167,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0410.",
 		"TextJPN": "「それでぇええ！？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Anddddd!?``"
+		"TextENG": "``Soooo?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1176,13 +1176,13 @@
 		"PreTextTags": "@vS26/53/TMIO_0390.",
 		"TextJPN": "「その後は窓から河原の花火大会を眺めてー！　いい雰囲気に盛り上がって来た所でふと絡みつく私の指ー！　梨花さんは恥じらいつつも身を委ねーッ…！」",
 		"NamesENG": "Mion",
-		"TextENG": "``After that, we'll watch the fireworks display from a window on the riverbank! Then, when the atmosphere gets goods my fingers will suddenly twine for you! And then Rika-san will surrender herself in shyness...!``"
+		"TextENG": "``Then afterward, we'll gaze at the fireworks show by the river through our window! Then once we've gotten into a nice mood, our fingers will suddenly entwine! And while it embarrasses you, you'll lean into me...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155715,
 		"TextJPN": "ずんずんと追い詰められ、上記セリフを叫びながら２人退場。何の事やら理解できず立ち尽くす建設省の２人。",
-		"TextENG": "Rapidly getting closer to one another, the two girls were shouting the above lines. While the two men from the Ministry of Construction stood there, not understanding what was going on."
+		"TextENG": "Rika rapidly closes in on Mion and the two exit the scene while screaming her usual line. The two from the Ministry of Construction stand there dumbstruck, unable to understand what was happening."
 	},
 	{
 		"type": "MSGSET",
@@ -1191,7 +1191,7 @@
 		"PreTextTags": "@vS26/56/TTON_0200.",
 		"TextJPN": "「……最近の若い子は仲がいいねぇ」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``......Young children these days really are close.``"
+		"TextENG": "``......Young girls nowadays sure get along well.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1200,25 +1200,25 @@
 		"PreTextTags": "@vS26/55/TARA_0170.",
 		"TextJPN": "「…ちと違うんじゃないですかねぇ…」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...I think this may be a little different...``"
+		"TextENG": "``...I think that was slightly different than getting along...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155718,
 		"TextJPN": "どっかん！　ばっかん！　と数回の打撲音。",
-		"TextENG": "Bang! Crash! Several bruising noises are heard many times."
+		"TextENG": "Bang! Thud! Several more sounds of blows pass."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155719,
 		"TextJPN": "建設省の２人、ぎょっとして顔を見合わせる。",
-		"TextENG": "The two men from the Ministry of Construction look at each other with frightened faces."
+		"TextENG": "The two Ministry men look at each other in shock."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155720,
 		"TextJPN": "その後に手をぱんぱんとはたきながら梨花が戻ってくる。",
-		"TextENG": "After a while, Rika returns while slapping dust off herself."
+		"TextENG": "Afterwards, Rika returns to the scene, smacking her hands clean."
 	},
 	{
 		"type": "MSGSET",
@@ -1227,7 +1227,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0420.",
 		"TextJPN": "「…とにかくダムは反対よ」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Anyway, I object the dam.``"
+		"TextENG": "``...Anyway, I'm opposed to the dam.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1236,7 +1236,7 @@
 		"PreTextTags": "@vS26/56/TTON_0210.",
 		"TextJPN": "「ぼぼぼ暴力はいかん！」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Vi-Vi-Vi-Violence is wrong!``"
+		"TextENG": "``Y-Y-Y-You can't resort to violence!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1245,7 +1245,7 @@
 		"PreTextTags": "@vS26/55/TARA_0180.",
 		"TextJPN": "「いいい、いやぁ！　僕は最初っからダムは反対だったんですよーッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``N-N-N-No! I was against the dam in the first place!``"
+		"TextENG": "``W-W-W-Well! I was opposed to the dam at first too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1263,13 +1263,13 @@
 		"PreTextTags": "@vS26/55/TARA_0190.",
 		"TextJPN": "「ダムは環境破壊の根源ですよねー！　ねーッ！？　ひぃいいいいいー！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``A dam is nothing but the root of environmental destruction! Right!? Eeeeeek!``"
+		"TextENG": "``Dams cause destruction to the environment, after all! Right?! Hiiiii!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155726,
 		"TextJPN": "下腹部を押さえながらよろよろと魅音が戻ってくる。",
-		"TextENG": "Mion returns while wobbling as she holds her stomach."
+		"TextENG": "Mion returns to the scene clutching her stomach and staggering."
 	},
 	{
 		"type": "MSGSET",
@@ -1278,7 +1278,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0400.",
 		"TextJPN": "「…今のパンチ、効いたっす…。すい臓破裂したらどーすんすかー？　…うぅ」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Just one punch had this much effect... What will I do if my pancreas is ruptured? ...Uuu.``"
+		"TextENG": "``...That punch just now... it really hurt... What would you do if it had ruptured my pancreas? ...Nngh.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1287,7 +1287,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0430.",
 		"TextJPN": "「とにかくダムはだめ。絶対にだめ」",
 		"NamesENG": "Rika",
-		"TextENG": "``Anyway, there's no point in a dam. It's absolutely useless.``"
+		"TextENG": "``Anyway, the dam is no good. In fact, it's absolutely bad.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1296,7 +1296,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0410.",
 		"TextJPN": "「どーしてだめなんですかー？」",
 		"NamesENG": "Mion",
-		"TextENG": "``What do you mean there's no point?``"
+		"TextENG": "``Why is it a bad thing?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1305,7 +1305,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0440.",
 		"TextJPN": "「…だめ。…理由なんか必要ない」",
 		"NamesENG": "Rika",
-		"TextENG": "``...No. ...A reason isn't necessary.``"
+		"TextENG": "``...No. ...There doesn't need to be a reason for that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1314,13 +1314,13 @@
 		"PreTextTags": "@vS26/53/TMIO_0420.",
 		"TextJPN": "「そりゃー反論としては良くないですよ梨花さん。ちゃんとだめな理由を挙げなくちゃー」",
 		"NamesENG": "Mion",
-		"TextENG": "``That's not a good argument, Rika. You need a decent reason to say no.``"
+		"TextENG": "``That's not a very good rebuttal then, Rika-san. You gotta have some reason, right?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155732,
 		"TextJPN": "これ以降、魅音がダム賛成意見を述べる度に、建設省の２人は大仰に頷く。たまに梨花に睨まれ、抱き合ったまますくみ上がる。",
-		"TextENG": "After this, Mion was in favor with the view of the dam, the two men from the Ministry of Construction look exaggerated and nod. Rika frequently glares at them, and they jump back into each others arms."
+		"TextENG": "Henceforth, the two Ministry men add exaggerated nods every time Mion expresses agreement with the dam. Occasionally Rika glares at them, and they cower while still holding each other."
 	},
 	{
 		"type": "MSGSET",
@@ -1329,7 +1329,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0430.",
 		"TextJPN": "「ダムって悪いもんじゃないと思うんですよ。社会で習ったじゃないですか。洪水を防いでくれるって」",
 		"NamesENG": "Mion",
-		"TextENG": "``I don't think the dam's a bad idea. We have learned from society. It's something that helps prevent floods.``"
+		"TextENG": "``I don't think the dam is really a bad thing. We learned about this in social studies, right? That it helps prevent flooding.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1338,7 +1338,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0450.",
 		"TextJPN": "「詭弁よ。集中豪雨時に一度に放水し、逆に鉄砲水を引き起こしているわ。…結構、操作規定がずさんなの、知ってた？」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's deception. They'll discharge the water at a time of torrential rain, causing a flash flood in reverse. ...Really, your operation provisions are kinda sloppy, did you know that?``"
+		"TextENG": "``That's blatant sophistry. When the area receives heavy rainfall they have to drain it out, which actually causes flash floods. ...Did you know their operating standards are pretty lax?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1347,7 +1347,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0440.",
 		"TextJPN": "「で…電気だっていっぱい発電できていいじゃないですか。３５万キロでしたっけ？　すごい発電量じゃないですかー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...B-But it'll be able to generate alot of electricity. Wasn't it something around 350,000 kilowatts? Isn't that an amazing quantity of power generation!``"
+		"TextENG": "``B...But the fact that it generates lots of electricity is good, isn't it? 350,000 kilowatts, was it? That's an incredible amount of power!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1356,7 +1356,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0460.",
 		"TextJPN": "「詭弁よ。実際は堆砂のせいで年々発電量は下がる一方。豪雨時には岩石が混じるからタービンを痛めるって理由で発電機、回してないの、知ってた？」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's deception. Because actually, the amount of electricity generated every year will fall due to sedimentation. This reason is why rocks get mixed in with the turbines causing damage to the generator, so it won't turn, did you know that?``"
+		"TextENG": "``That's blatant sophistry. The truth is that their electrical output only goes down with every year, due to sediment. Did you know they don't run the generators during heavy rainfall because rocks can slip in and damage the turbines?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1365,7 +1365,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0450.",
 		"TextJPN": "「そ！　それにほら！　一度造っちゃえばもーホント、末永ーくニッポンの役に立つじゃないですかー…！」",
 		"NamesENG": "Mion",
-		"TextENG": "``B-Besides, once the dam will be constructed, it'll be really useful for Japan in the long run...!``"
+		"TextENG": "``But! But also! Once it's built, it really will contribute to Japan for a long time...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1374,7 +1374,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0470.",
 		"TextJPN": "「詭弁よ。土砂がどんどん溜まっていって、最後には泥が詰まっただけのダムになってしまうのよ。…ダムには寿命があるの、知ってた？」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's deception. The earth and sand will still steadily build up, it'll only be a matter of time before the dam is eventually clogged with mud. ...So the dam won't be there forever, did you know that?``"
+		"TextENG": "``That's blatant sophistry. Sediment only continues to build up, ultimately leaving the dam clogged with mud. ...Did you know that all dams have a lifespan too?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1383,7 +1383,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0460.",
 		"TextJPN": "「…えーとえぇーと…！　……深川弁当にイカ飯弁当ー…。…なんちてー…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Eh, umm...! ......Is that an Ikameshi and Fukagawa lunch... ...Well, is it...``"
+		"TextENG": "``...Uhh, uhh...! ......We could have a Cuban or a Reuben... ...or something...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1392,13 +1392,13 @@
 		"PreTextTags": "@vS26/55/TARA_0200.",
 		"TextJPN": "「それは駅弁…」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It's a station lunch...``"
+		"TextENG": "``That's sandwich artistry...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155741,
 		"TextJPN": "キッと周囲を睨み付ける梨花。魅音と荒川、しゅんとする。",
-		"TextENG": "Rika scowls at the people surrounding her. Mion and Arakawa fell silent."
+		"TextENG": "Rika glares sharply at those around her. Both Mion and Arakawa shrivel up on the spot."
 	},
 	{
 		"type": "MSGSET",
@@ -1407,7 +1407,7 @@
 		"PreTextTags": "@vS26/56/TTON_0230.",
 		"TextJPN": "「…ダムの恩恵は下流が受け、上流はシワ寄せを受けるだけと言われております。…梨花さんのご意見はもっともとは思います」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Although the dam will benefit mostly the downstream areas, the upstream regions will receive something, but not much. We call that wrinkling. ...So I can understand that your opinion is reasonable, Rika-san.``"
+		"TextENG": "``...It's often said the benefits of a dam go downstream while those upstream foot the bill. ...I think your arguments are valid, Rika-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1416,7 +1416,7 @@
 		"PreTextTags": "@vS26/56/TTON_0240.",
 		"TextJPN": "「…ですが！　…どうか利水事業にご理解をいただきたいのです」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...But! ...Please understand that this is essential for the water utilization project.``"
+		"TextENG": "``...However! ...I really hope you'll appreciate its benefit toward irrigation works.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1425,7 +1425,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0480.",
 		"TextJPN": "「…どうあっても雛見沢を湖の底に沈めたいのね」",
 		"NamesENG": "Rika",
-		"TextENG": "``...No matter what, I know you want to sink Hinamizawa to the bottom of a lake.``"
+		"TextENG": "``...You want to submerge Hinamizawa under a reservoir no matter what, then.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1434,7 +1434,7 @@
 		"PreTextTags": "@vS26/55/TARA_0210.",
 		"TextJPN": "「…雛見沢の住民の皆さんの心の痛みは重々承知しております。もちろん相応の補償はさせていただくつもりです」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...We understand the pain this has been causing on the hearts of the people of Hinamizawa. Of course, we're also aiming to provide a reasonable compensation.``"
+		"TextENG": "``...We truly understand the grief this must be causing to everyone living in Hinamizawa. But of course that's why we're offering appropriate compensation.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1443,7 +1443,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0490.",
 		"TextJPN": "「立ち退き料のこと？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Compensation for eviction?``"
+		"TextENG": "``You mean the compensation money for our eviction?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1452,7 +1452,7 @@
 		"PreTextTags": "@vS26/56/TTON_0250.",
 		"TextJPN": "「もちろん市内の新築マンションを斡旋させていただきます。駅にも近く、公益施設も充実した素晴らしい環境です」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Of course, we'll be there to mediate you a new apartment in the city. It will also be close to the station, with a nice environment and access to public facilities and leisure.``"
+		"TextENG": "``Of course we're also working with others to see to the construction of new apartments in the city. They're wonderful places to live, with plenty of access to public services and close proximity to the station.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1461,7 +1461,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0470.",
 		"TextJPN": "「そうそうそれそれ！　それがおいしーんですよねー」",
 		"NamesENG": "Mion",
-		"TextENG": "``Yes, yes, yes, that's it! That sounds really delicious.``"
+		"TextENG": "``Uh-huh, that, that! That's a tempting offer, isn't it?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1470,7 +1470,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0480.",
 		"TextJPN": "「…そりゃー私だって生まれは雛見沢ですからね。愛着がないわけじゃないですよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Even though I was born in Hinamizawa. It's not like I have any attachment.``"
+		"TextENG": "``...I was born here in Hinamizawa too. So it's not like I don't have any attachment to the place.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1479,7 +1479,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0490.",
 		"TextJPN": "「…でもねぇ、世帯数数百のこんな山奥の村で青春時代を終えちゃうなんて寂しいじゃないですかー…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...But, it is lonely to finish my youth in a village in the heart of the mountains with only several hundred houses...``"
+		"TextENG": "``...But wouldn't it be kind of sad to spend my entire youth in this mountain village, with only a few hundred homes...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1488,7 +1488,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0500.",
 		"TextJPN": "「街はいいですよー。何でもあるんです。テレビでしか見たことのないあんな物やこんな物が本当にあるんですよー！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``So living in a city sounds really good. I'll take anything at this rate. It'll truly be like something you'd see on TV, don't you think so!?``"
+		"TextENG": "``Cities are great. They have everything. You can really find all sorts of things we've only ever seen on TV!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1497,7 +1497,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0500.",
 		"TextJPN": "「…テレビかぶれの東京かぶれね。…東京観光に行って以来そればっかり」",
 		"NamesENG": "Rika",
-		"TextENG": "``...You sound like a Tokyo wannabee infected by TV. ...You've been like this ever since you went on that sightseeing trip to Tokyo.``"
+		"TextENG": "``...TV this, Tokyo that. ...That's all I've heard from you since you went sightseeing there.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1506,7 +1506,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0510.",
 		"TextJPN": "「かぶれ者で結構ですよ！　でも考えて下さいよ！　…この雛見沢で一番高い建物って何か知ってます！？　…消防団の３階建てなんですよ！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Think of me what you like! But please give it some thought! ...Do you even know the tallest building in Hinamizawa!? ...It's a 3-storey high volunteer fire department!?``"
+		"TextENG": "``So what if I'm a wannabe! Just think about it! ...Do you know what the tallest building is here in Hinamizawa?! ...It's the three-story fire department!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1515,7 +1515,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0520.",
 		"TextJPN": "「雛見沢にエスカレーターのある建物なんてありますー！？　ないでしょッ！　ちなみにエレベーターはあるんですよねぇ！　小学校の給食運搬用のエレベーター」",
 		"NamesENG": "Mion",
-		"TextENG": "``And is there even a building with an escalator in Hinamizawa!? No there isn't! Although we do have an elevator! But all that elevator does is carry lunches for the elementary school.``"
+		"TextENG": "``Are there any buildings with an escalator here in Hinamizawa?! There aren't! There is an elevator, by the way! The elevator used to transport food for the elementary school.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1524,7 +1524,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0530.",
 		"TextJPN": "「…そんなのイヤですッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...And I don't like that!``"
+		"TextENG": "``...I'm sick of all that!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1533,7 +1533,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0510.",
 		"TextJPN": "「生まれ故郷より街の生活の方がいいって言うのね。…ご先祖さまも泣いてるわよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``So you're saying that city life is better than your hometown. ...You'll make our ancestors cry, too.``"
+		"TextENG": "``So you're saying life in the city would be better than in your hometown. ...Your ancestors must be crying.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1542,7 +1542,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0540.",
 		"TextJPN": "「こんな山奥の田舎で一生を終えるなんて絶対に嫌ッ！　私は普通の子みたいに普通の街に普通の物に囲まれて、普通に暮らしたいんですよッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``I don't want to end my life in the countryside deep in the heart of the mountains! I want to live in a normal city, surrounded by normal things like a normal child, I want to live a normal life!``"
+		"TextENG": "``I absolutely refuse to let my life end here, in some backwater mountains! I want to live a normal life like a normal girl in a normal city surrounded by normal things!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1551,7 +1551,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0520.",
 		"TextJPN": "「雛見沢の人間が街で生活なんかできると思う！？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Do you think that someone from Hinamizawa can even live in a city!?``"
+		"TextENG": "``Do you think the people in Hinamizawa are capable of living in a city?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1560,7 +1560,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0550.",
 		"TextJPN": "「余計なお世話ですよッ！　そんなにここが好きなら勝手に住んでればいいじゃないですか！　私を巻き込まないで下さいよッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Mind your own business! If you like it here so much, you don't need anyone's permission to stay! Just please don't drag me into it!``"
+		"TextENG": "``That's their problem! If they like this place so much, then they can stay here! Don't drag me into it!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1569,7 +1569,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0560.",
 		"TextJPN": "「…ウチは貧乏だから引っ越しなんかできなかったけど！　立ち退き料のおかげでやっと街へ引っ越せるお金が出来たんです！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...My family is poor, so we couldn't move anywhere! But thanks to the compensation we got from eviction, we can finally live in the city!``"
+		"TextENG": "``...My family's poor, so we couldn't move even if we wanted to! But thanks to the compensation money, we'll finally have enough to move into the city!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1578,7 +1578,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0570.",
 		"TextJPN": "「…ダム計画が中止になっちゃったらどうなるんですか！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...So if the dam project was cancelled, do you know what would happen to us!?``"
+		"TextENG": "``...What do you think will happen to us if the dam project's cancelled?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1587,19 +1587,19 @@
 		"PreTextTags": "@vS26/53/TMIO_0580.",
 		"TextJPN": "「…もう私をこんな山奥に縛りつけないでッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Don't tie me to a place deep in the mountains anymore!``"
+		"TextENG": "``...Don't tie me down to these mountains any longer!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155763,
 		"TextJPN": "激情に涙をためる魅音。@k@r言葉少なく立ち尽くす梨花。@k@rはらはらしながら見守る建設省の２人。",
-		"TextENG": "Mion earnestly cries tears in passion.@k@r Rika is speechless, and stands still.@k@r Meanwhile, the two men from@rthe Ministry of Construction watch nervously."
+		"TextENG": "Tears well in Mion's eyes, full of violent emotion,@k@rRika stands there with little to say,@k@rand the two Ministry men anxiously watch over both them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155764,
 		"TextJPN": "突然、踵を返して退場しようとする梨花。",
-		"TextENG": "Suddenly, Rika says she is going to leave,@rbut will return."
+		"TextENG": "Suddenly, Rika turns on her heel and exits the scene."
 	},
 	{
 		"type": "MSGSET",
@@ -1608,7 +1608,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0530.",
 		"TextJPN": "「…お手洗い行ってくる」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I'm going to the restroom.``"
+		"TextENG": "``...I'm going to the bathroom.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1617,13 +1617,13 @@
 		"PreTextTags": "@vS26/53/TMIO_0590.",
 		"TextJPN": "「り、梨花さん…！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ri-Rika-san...!``"
+		"TextENG": "``R-Rika-san...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155767,
 		"TextJPN": "足早に退場する梨花。@k@rはっと我に返り追おうとする魅音。@k@rその時突然、荒川が呻き出す。",
-		"TextENG": "Rika walks off at a quick pace.@k@rMion pulls herself together and tries to chase after her.@k@rBut Arakawa begins to groan suddenly."
+		"TextENG": "Rika exits quickly.@k@rMion gets a hold of herself and starts to follow after her,@k@rbut Arakawa suddenly lets out a groan."
 	},
 	{
 		"type": "MSGSET",
@@ -1641,7 +1641,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0600.",
 		"TextJPN": "「あの、……大丈夫ですかー…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Umm...... Is he alright...?``"
+		"TextENG": "``Umm...... are you all right...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1650,7 +1650,7 @@
 		"PreTextTags": "@vS26/56/TTON_0270.",
 		"TextJPN": "「休み明けから体調が悪くてね。…急に苦しくなるらしいんだよ」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``He hasn't been feeling well since after the holiday break. ...And it seems to have suddenly gotten alot more painful.``"
+		"TextENG": "``He's been feeling poorly since the weekend ended. ...Apparently, he keeps feeling pain all of a sudden.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1659,7 +1659,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0610.",
 		"TextJPN": "「あ、あのー…トイレなら裏にありますよー…？　…あ、でも今…梨花さんが入ってるしー…」",
 		"NamesENG": "Mion",
-		"TextENG": "``U-Umm... The toilets are in the back... ...Ah, but right now... Rika-san is in there...``"
+		"TextENG": "``U-Umm... there's a bathroom around back...? ...Oh, but right now... Rika-san's using it...``"
 	},
 	{
 		"type": "MSGSET",
@@ -1668,7 +1668,7 @@
 		"PreTextTags": "@vS26/56/TTON_0280.",
 		"TextJPN": "「腹痛ってわけじゃないんだよ。…大丈夫か！？　荒川君！」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``It's not abdominal pain. ...Are you alright!? Arakawa-kun!``"
+		"TextENG": "``It's not a stomach ache. ...Are you all right?! Arakawa-kun!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1677,7 +1677,7 @@
 		"PreTextTags": "@vS26/55/TARA_0220.",
 		"TextJPN": "「…すみません…。…すぐ…おさまりますから…。………………」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...I'm sorry... ...It will... go away soon...``"
+		"TextENG": "``...I'm sorry... ...It'll... settle down soon... ............``"
 	},
 	{
 		"type": "MSGSET",
@@ -1686,7 +1686,7 @@
 		"PreTextTags": "@vS26/56/TTON_0290.",
 		"TextJPN": "「働き過ぎなんだよ！　いっぺん医者に見せた方がいい」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``You overworked yourself! You should see a doctor sometime.``"
+		"TextENG": "``You're working yourself too hard! You should get yourself checked out by a doctor.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1695,7 +1695,7 @@
 		"PreTextTags": "@vS26/55/TARA_0230.",
 		"TextJPN": "「すみません。もう大丈夫です…。まだ頭ががんがんしますけど…。…はい」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I'm sorry. I'm alright now... My head's still pounding though... ...Yes.``"
+		"TextENG": "``I'm sorry. I'm fine now... Though my head's still throbbing... ...Yeah.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1704,7 +1704,7 @@
 		"PreTextTags": "@vS26/56/TTON_0300.",
 		"TextJPN": "「クモ膜下出血とかの前兆がそんなのじゃなかったかい！？　とにかく明日は休んで！　…大きな病院で医者に見てもらいなさい」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Isn't that a sign the subarachnoid hemorrhage is subsiding!? Anyway, take a day off tomorrow! ...Then go see a doctor in one of those big hospitals.``"
+		"TextENG": "``It almost sounds like subarachnoid hemorrhaging...! At any rate, you're resting tomorrow! ...Go have a doctor check you out at a major hospital.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1713,7 +1713,7 @@
 		"PreTextTags": "@vS26/55/TARA_0240.",
 		"TextJPN": "「……そうですね。…すみません。…本当に急に…痛み出して…」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......You're right. ...I'm sorry. ...Really suddenly... it's begun to ache again...``"
+		"TextENG": "``......You're right. ...Sorry. ...It really started hurting... all of a sudden...``"
 	},
 	{
 		"type": "MSGSET",
@@ -1722,7 +1722,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0620.",
 		"TextJPN": "「…そーいえば私も頭痛いですよ。…うん。がんがんする」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Now that you mention it, my head hurts, too. ...Yeah. It's pounding kinda hard.``"
+		"TextENG": "``...Now that you mention it, my head hurts too. ...Yeah. It's throbbing.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1731,7 +1731,7 @@
 		"PreTextTags": "@vS26/56/TTON_0310.",
 		"TextJPN": "「それはいけないな。風邪をひいたのかも知れない」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``That doesn't sound good. You may have caught a cold.``"
+		"TextENG": "``That's not good. You might have caught a cold.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1740,13 +1740,13 @@
 		"PreTextTags": "@vS26/53/TMIO_0630.",
 		"TextJPN": "「あっはっは…、雨ですからー」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Because of the rain.``"
+		"TextENG": "``...It is raining out.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155781,
 		"TextJPN": "舞台は真っ暗のまま。@k@r無線の声が聞こえる。",
-		"TextENG": "The stage remains dark.@k@rAs the voice from a radio is heard."
+		"TextENG": "The scene remains pitch black.@k@rA voice plays over the radio."
 	},
 	{
 		"type": "MSGSET",
@@ -1755,19 +1755,19 @@
 		"PreTextTags": "@vS26/61/THOT_0000.",
 		"TextJPN": "「……本部より１号車、応答願います。……１号車どうぞ…」",
 		"NamesENG": "Voice",
-		"TextENG": "``......Headquarters calling Car 1, please respond. ......Car 1, respond...``"
+		"TextENG": "``......This is Car One to HQ, do you read? ......Car One, over...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155783,
 		"TextJPN": "遠くで雷の音。@k@r徐々に舞台明るくなる。@k@rどしゃぶりの音、遠くなっていく。",
-		"TextENG": "The sound of thunder in the distance.@k@rThe stage gradually becomes brighter.@k@rThe sound of the downpour has now distanced itself."
+		"TextENG": "The sound of thunder echoes in the distance.@k@rThe stage slowly grows lighter.@k@rThe sound of rain fades into the distance."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155784,
 		"TextJPN": "建設省の２人の姿はない。@k@r男（@bよしむら.@<吉村@>）が駆けながら登場する。",
-		"TextENG": "The two men from the Ministry of Construction@rare nowhere to be seen.@k A new man (Yoshimura) appears."
+		"TextENG": "The two Ministry men are gone.@k@rA man (Yoshimura) appears, running on stage."
 	},
 	{
 		"type": "MSGSET",
@@ -1776,7 +1776,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0000.",
 		"TextJPN": "「…いやーっはっはっはっは！　…風呂桶をひっくり返したような雨だねぇ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Huh, ha ha ha ha ha! This rain feels like somebody overturned a bathtub on me!``"
+		"TextENG": "``...Man, hahahaha! ...It's like someone's dumping a bathtub on us out there!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1785,7 +1785,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0010.",
 		"TextJPN": "「これじゃ傘をさしてもささなくても同じだよ。いやーっはっはっはっは！　……うへぇ…パンツの中までぐっしょりだよ…。…見るかい？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``The umbrella didn't even make a difference. Huh, ha ha ha ha ha! ......Uh-heh... Even the insides of my underwear are dripping wet... Wanna take a look?``"
+		"TextENG": "``It doesn't matter if you've got an umbrella or not. Man, hahahaha! ......Blegh... even my underwear's soaked... ...Wanna see?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1794,7 +1794,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0640.",
 		"TextJPN": "「滅多に見れるもんじゃないのでぜひーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Sure, this is certainly a rare opportunity!``"
+		"TextENG": "``It's not something I get to see often, so absolutely!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1803,7 +1803,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0020.",
 		"TextJPN": "「…あ、いや、…そー来るとは思わなかったな」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Ah, no... I didn't expect you to say that.``"
+		"TextENG": "``...Oh, uhh... I didn't think you'd actually say yes.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1812,7 +1812,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0540.",
 		"TextJPN": "「……知ってる人…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Do you know this person...?``"
+		"TextENG": "``......Someone you know...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1821,7 +1821,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0650.",
 		"TextJPN": "「まっさかー、あんなオッサンに知り合いいないですよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``No way, I'd never want to know an old geezer like that.``"
+		"TextENG": "``No way. I don't know any old men like him.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1830,7 +1830,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0550.",
 		"TextJPN": "「だって今親しそうに話してたじゃない」",
 		"NamesENG": "Rika",
-		"TextENG": "``I mean, the two of you were talking rather intimately.``"
+		"TextENG": "``You seemed awfully close while talking to him just now, though.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1839,7 +1839,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0660.",
 		"TextJPN": "「やだなー、私の心は梨花さんだけのものですわーん！　寂しい中年の独り言に相づち打ってあげただけですよーぅ」",
 		"NamesENG": "Mion",
-		"TextENG": "``No no, my heart belongs to you alone, Rika-san! I just gave a supportive response to the lonely old geezer's soliloquy.``"
+		"TextENG": "``Oh no, my heart belongs solely to you, Rika-san! I was just making conversation with a lonely, middle-aged man who was babbling to himself.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1848,7 +1848,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0030.",
 		"TextJPN": "「中年とはひどいな！　これでもまだ２８なんだけどねぇ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Calling me an old geezer was terrible! Despite my appearance, I'm not even 28!``"
+		"TextENG": "``That's cruel! I'm still only 28, you know!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1857,7 +1857,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0670.",
 		"TextJPN": "「四捨五入すれば３０じゃーん？　３０ったらもう立派な中年だよねー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``If we round it off, isn't it 30? If you were already 30, then you'd be a respectable old geezer!``"
+		"TextENG": "``So when you round up, that's 30, right? At 30, you're well into middle age!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1866,7 +1866,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0040.",
 		"TextJPN": "「あのねぇ、男は三十路から味が出るもんなんだぜ？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Umm, but don't you think men get better in taste from 30?``"
+		"TextENG": "``Listen here, men get more mature and charming when they hit their thirties.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1875,7 +1875,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0680.",
 		"TextJPN": "「ミソから味ー！？　…わーわーッ！！　梨花さん、この人ヤバいー！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``You mean taste like in miso!? ...Ah ah!! Rika-san, this man is dangerous!!``"
+		"TextENG": "``They mate ant farms?! ...W-Wah!! Rika-san, this man's gone nuts!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1884,7 +1884,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0050.",
 		"TextJPN": "「ミソじゃなくて三十路だー！！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Men in their 30's are not like miso!!``"
+		"TextENG": "``They don't mate ants, they grow mature!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1893,7 +1893,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0690.",
 		"TextJPN": "「その上、痔なんすかーッ！？　…この人ヤバ過ぎーッ！！　あははははは！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Besides, wouldn't you have hemorrhoids!? ...This man is too dangerous!! Ah ha ha ha ha ha!!``"
+		"TextENG": "``They grow manure?! ...This man's pretty far gone!! Ahahahahahaha!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1902,7 +1902,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0060.",
 		"TextJPN": "「……負けたよ負けたよ。痔でいいよ…。…若い子にゃ勝てんねぇ…」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......I lost, I lost. You're right about the hemorrhoids...  ...I can't win against someone as young as you...``"
+		"TextENG": "``......You win, you win. Manure's fine... ...I can't beat you kids...``"
 	},
 	{
 		"type": "MSGSET",
@@ -1911,7 +1911,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0700.",
 		"TextJPN": "「梨花さん、あのオッサン結構面白いヤツですよー！　…おねだりしたらお小遣いくれるかもしれませんねー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Rika-san, that old guy's pretty funny! ...If we ask, maybe he'll give us spending money!``"
+		"TextENG": "``Rika-san, this old man's a pretty funny guy! ...Maybe he'll give us some money if we beg!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1920,7 +1920,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0560.",
 		"TextJPN": "「…本当に初対面？　…よく会話が弾むわね」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Are you really sure you only just met? ...Your conversation was kinda bouncy.``"
+		"TextENG": "``...You really only just met him? ...I'm surprised you can keep up a conversation.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1929,7 +1929,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0710.",
 		"TextJPN": "「それは私と梨花さんの時と同じ事。初対面だけどいっぱいお話したじゃないですかー」",
 		"NamesENG": "Mion",
-		"TextENG": "``It's the same thing for you and I, Rika-san. We talked alot for our first meeting, too.``"
+		"TextENG": "``It's the same as with you and me. I spoke a whole lot when we first met, didn't I?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1938,7 +1938,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0720.",
 		"TextJPN": "「…まーもっとも私が一方的に話しかけて一人ではしゃいでただけだったかも知れないですけどねぇ…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Even if I did most of the talking, or even if I was enjoying myself alone...``"
+		"TextENG": "``...Well, maybe that was more just me carrying on all by myself...``"
 	},
 	{
 		"type": "MSGSET",
@@ -1947,7 +1947,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0570.",
 		"TextJPN": "「……そんな事ない。…私も楽しかったわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Not at all. ...I had fun, too.``"
+		"TextENG": "``......That's not true. ...I had fun too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1956,7 +1956,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0730.",
 		"TextJPN": "「……さっきはすみません。…言い過ぎました」",
 		"NamesENG": "Mion",
-		"TextENG": "``......I'm sorry for a while ago. ...I said too much.``"
+		"TextENG": "``......Sorry about earlier. ...I went too far.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1965,7 +1965,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0580.",
 		"TextJPN": "「……うぅん。…私の方こそ。…ごめんね」",
 		"NamesENG": "Rika",
-		"TextENG": "``......No. ...I should be the one apologizing. ...I'm sorry.``"
+		"TextENG": "``......No. ...I should apologize. ...I'm sorry.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1974,7 +1974,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0070.",
 		"TextJPN": "「……へー…！　すごいオトし方だねぇ。そういう方向に持っていくとは思わなかったなぁ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Heh...! What an amazing resolution. I didn't think it would have taken such a direction!``"
+		"TextENG": "``......Wow...! You seduced her real good. I didn't think you'd take it in that direction!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1983,7 +1983,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0740.",
 		"TextJPN": "「うっさいなぁ！　今いいカンジだったのにーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Oh shut up! We were feeling just fine!``"
+		"TextENG": "``Shut up! We just got a good mood going here!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1992,7 +1992,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0080.",
 		"TextJPN": "「そうすごむなよ。わかったよわかった！　…もー一切口は挟まないから！　どーぞ好きなだけ、行くトコまで行っちゃってくれ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Don't threaten me like that. I know, I know! ...So whatever I saw, won't leave my mouth! Do as you like now, I won't come onto you any longer.``"
+		"TextENG": "``Don't look so menacing. Fine, fine! ...I won't say a single word more! You go ahead and take it as far as you can go.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2001,7 +2001,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0750.",
 		"TextJPN": "「えぇーッ！？　行くトコまでってなになにーッ！？　わーわー！　梨花さんこの人やーらしーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ehhhh!? What, what do you mean by 'come on'!? Ah ah! Rika-san, this man is dirty!``"
+		"TextENG": "``Huh?! What do you mean as far as I can go?! Whoa, whoa! Rika-san, this guy's a perv!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2010,7 +2010,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0090.",
 		"TextJPN": "「…梨花ちゃんって言うのかい？　…僕は吉村って言うんだ。よろしく」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Your name is Rika-chan, you say? ...I'm Yoshimura. Nice to meet you.``"
+		"TextENG": "``...You're Rika-chan, then? ...I'm Yoshimura. Nice to meet you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2019,7 +2019,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0590.",
 		"TextJPN": "「…吉村さんはご趣味とご職業は何ですか？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Yoshimura-san, what are your hobbies and occupation?``"
+		"TextENG": "``...What are your hobbies and career, Yoshimura-san?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2028,7 +2028,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0100.",
 		"TextJPN": "「あん！？　…いやーっはっはっは！　お見合いだってそこまで単刀直入じゃないぜー？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Ha!? ...No, ha ha ha! Even marriage interviews aren't that straightforward, right?``"
+		"TextENG": "``Huh?! ...Man, hahaha! No one's that blunt, even at formal marriage interviews.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2037,7 +2037,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0110.",
 		"TextJPN": "「趣味はいろいろ。職業はフリーライターってとこかな」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``My hobbies are a variety of things. And my occupation is a freelance writer.``"
+		"TextENG": "``I have many different hobbies. I guess you could say my career is in freelance writing.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2046,7 +2046,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0600.",
 		"TextJPN": "「フリーターの親戚…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Freelance writer, is that a part time job...?``"
+		"TextENG": "``Is that like, a freeloader...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2055,7 +2055,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0760.",
 		"TextJPN": "「…フリーの雑誌記者ですよぅ」",
 		"NamesENG": "Mion",
-		"TextENG": "``...He's a freelance magazine journalist.``"
+		"TextENG": "``...It means he writes articles freely for different places.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2064,13 +2064,13 @@
 		"PreTextTags": "@vS26/54/TYOS_0120.",
 		"TextJPN": "「…次のバスは……何だ。だいぶ時間があるじゃないか。…こいつはついてるなー！　…若い女の子たちと雨宿りとはねぇ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...The next bus is...... hmm. That's alot of time. ...What a lucky guy I am! ...I can take shelter with young girls!``"
+		"TextENG": "``...This next bus is in...... well. It's quite some time from now. ...Today's my lucky day! ...I get to share shelter from the rain with a pair of cute young girls!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155818,
 		"TextJPN": "利根川と荒川、トイレから戻ってくる。@k@r吉村はちょっと残念そう。",
-		"TextENG": "Tonegawa and Arakawa came back@rfrom the restroom.@kYoshimura seems slightly disappointed."
+		"TextENG": "Tonegawa and Arakawa return from the bathroom.@k@rYoshimura looks disappointed."
 	},
 	{
 		"type": "MSGSET",
@@ -2079,7 +2079,7 @@
 		"PreTextTags": "@vS26/56/TTON_0320.",
 		"TextJPN": "「…おや、お友達ですか？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Oh, is this a friend of yours?``"
+		"TextENG": "``...Oh? A friend of yours?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2088,7 +2088,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0770.",
 		"TextJPN": "「知らないオッサンです」",
 		"NamesENG": "Mion",
-		"TextENG": "``I don't know this old geezer.``"
+		"TextENG": "``Nah, just some strange old man.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2097,7 +2097,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0130.",
 		"TextJPN": "「キツいな！　……どうも、吉村です。バスが来るまで雨宿りに加えて下さい。…雛見沢ダムの関係の方ですね？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``That's harsh! ......Hi there, I'm Yoshimura. I'm just taking shelter until the bus comes. ...Are you guys connected to the Hinamizawa dam?``"
+		"TextENG": "``That's harsh! ...Hello, I'm Yoshimura. Please allow me take shelter from the rain in here too. ...You two are with the dam project, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2106,7 +2106,7 @@
 		"PreTextTags": "@vS26/56/TTON_0330.",
 		"TextJPN": "「どうも。建設省河川局、都市河川の利根川です」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Nice to meet you. I'm Tonegawa, from the Ministry of Construction River Bureau of the Urban River.``"
+		"TextENG": "``Hello. Tonegawa from the Ministry of Construction's River Bureau, Urban River Office.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2115,7 +2115,7 @@
 		"PreTextTags": "@vS26/55/TARA_0250.",
 		"TextJPN": "「どうも。都市河川の荒川です」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Nice to meet you. I'm Arakawa, also from the Urban River Office.``"
+		"TextENG": "``Hello. Arakawa, also from the Urban River Office.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2124,7 +2124,7 @@
 		"PreTextTags": "@o75.@vS26/53/TMIO_0780|S26/52/TRIK_0610.",
 		"TextJPN": "「どうも、ワカリマセンの園崎です」@r@t「どうも、ワカリマセンの古手です」",
 		"NamesENG": "Mion & Rika",
-		"TextENG": "``Nice to meet you. I'm Sonozaki, we've only just met.``@r@t``Nice to meet you. I'm Furude, we've only just met.``"
+		"TextENG": "``Hello. Sonozaki, also from makes-no-sense-to-me.``@r@t``Hello. Furude, also from makes-no-sense-to-me.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2133,13 +2133,13 @@
 		"PreTextTags": "@vS26/54/TYOS_0140.",
 		"TextJPN": "「…な、仲良しさんみたいだねぇ…。…みんなお友達なのかい…？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...S-Seems like you're all close friends... ...Is everyone friends here...?``"
+		"TextENG": "``...L-Looks like you're all getting along well... ...Are you all friends...?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155826,
 		"TextJPN": "４人、顔を見合わせてからゆっくりと首を横に振る。",
-		"TextENG": "All four of them slowly shake their heads."
+		"TextENG": "All four look at each other and slowly shake their heads."
 	},
 	{
 		"type": "MSGSET",
@@ -2148,7 +2148,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0150.",
 		"TextJPN": "「…充分、仲良しさんに見えるよ。…うん」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Sufficient enough, you all seem like good friends. ... Yeah.``"
+		"TextENG": "``...You look like awfully close friends though. ...You really do.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2157,7 +2157,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0160.",
 		"TextJPN": "「あー、みんなそのままでいいかな！　せっかくの仲良し４人組だから写真を撮ろう！　…はい笑って笑ってー！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Ah, I wonder if everyone thinks so! Let's take a group photo of four unique good friends! ...Yes, smile, smile!``"
+		"TextENG": "``Uhh, can you all stay like that for a moment? I want to take a picture of you four friends together! ...Okay, smile, smile!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2166,13 +2166,13 @@
 		"PreTextTags": "@vS26/54/TYOS_0170.",
 		"TextJPN": "「現役女子高生の乱れた実態。建設省職員、雛見沢で禁断の交際」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Active service high school girls and a disturbing nature. Ministry of Construction employees, compensated dating in Hinamizawa.``"
+		"TextENG": "``The disgraceful state of modern high school girls. Ministry of Construction employees engaged in compensated dating in Hinamizawa!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155830,
 		"TextJPN": "暗転。@k@r『どかどかどっかん！』と打撲音が響く。@k@rしばらくの沈黙。@k@r舞台は真っ暗のまま。@k@r無線の声が聞こえる。",
-		"TextENG": "A dark change.@k A noisy bang! Its sound echoes.@k@rAnd suddenly, silence.@k The stage remains dark.@k@rAs the voice from a radio is heard."
+		"TextENG": "Blackout.@k@rBam, bam, bam! The sound of pounding rings out.@k@rA moment of silence follows.@k@rThe scene remains pitch black.@k@rA voice plays over a radio."
 	},
 	{
 		"type": "MSGSET",
@@ -2181,13 +2181,13 @@
 		"PreTextTags": "@vS26/60/TODA_0000.",
 		"TextJPN": "「……本部どうぞ。本部どうぞ。……全車配置完了…」",
 		"NamesENG": "Voice",
-		"TextENG": "``......Headquarters, answer. Headquarters, answer. ......End the deployment of all cars...``"
+		"TextENG": "``......HQ, over. HQ, over. ......All cars now in position...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155832,
 		"TextJPN": "落雷の音。@k@r徐々に舞台明るくなる。@k@rどしゃぶりの音、遠くなっていく。",
-		"TextENG": "The sound of lightning.@k@rThe stage gradually becomes brighter.@k@rThe sound of the downpour has now distanced itself."
+		"TextENG": "Thunder echoes.@k@rThe stage steadily lights up.@k@rThe sound of heavy rain fades into the distance."
 	},
 	{
 		"type": "MSGSET",
@@ -2196,7 +2196,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0180.",
 		"TextJPN": "「…いやー、雷雨とはまた！　…ひっどい天気になっちゃったねぇ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...No, another thunderstorm! ...This weather is getting really bad.``"
+		"TextENG": "``...Man, to think it's a thunderstorm too! ...This is some awful weather we're having.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2205,7 +2205,7 @@
 		"PreTextTags": "@vS26/56/TTON_0340.",
 		"TextJPN": "「でも向こうの空が少々明るくなった気がしませんか」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``However, I do feel the sky over there has become a little brighter.``"
+		"TextENG": "``But I think I see the sky getting a little brighter in the distance.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2214,7 +2214,7 @@
 		"PreTextTags": "@vS26/55/TARA_0260.",
 		"TextJPN": "「案外、バスがくる頃にはからっと晴れちゃうかも知れませんね」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Suddenly, maybe it'll be miraculously sunny when the bus arrives.``"
+		"TextENG": "``Maybe it'll all clear up by the time the bus gets here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2223,7 +2223,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0790.",
 		"TextJPN": "「……吉村さんは取材で来たんですか？　…やっぱり雛見沢ダムの？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Yoshimura-san, did you come here to collect data? ...About the Hinamizawa dam, I'd guess?``"
+		"TextENG": "``......Are you out here gathering information, Yoshimura-san? ...On the Hinamizawa dam, I suppose?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2232,7 +2232,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0190.",
 		"TextJPN": "「…うん。ダムの件とは一応関係があるけどね。…僕が取材に来たのはダムの事じゃあないんだよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Yeah. For the time being, it's connected to the dam. ...Although the dam isn't the main thing I came here to report on.``"
+		"TextENG": "``...Yeah. The dam is at least a part of it. ...But I'm gathering information generally.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2241,7 +2241,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0620.",
 		"TextJPN": "「…ダム計画を巡る住民の反対運動？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Is it the opposition movement of the inhabitants against the dam project?``"
+		"TextENG": "``...Then on the villager's protest movements against the dam project?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2250,7 +2250,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0200.",
 		"TextJPN": "「違うよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``No.``"
+		"TextENG": "``Not that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2259,7 +2259,7 @@
 		"PreTextTags": "@vS26/56/TTON_0350.",
 		"TextJPN": "「ダム建設が及ぼす環境への影響」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``The dam constructions impact on the environment.``"
+		"TextENG": "``The effect building the dam will have on the environment?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2268,7 +2268,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0210.",
 		"TextJPN": "「違いますよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``It's something different.``"
+		"TextENG": "``No, not that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2277,7 +2277,7 @@
 		"PreTextTags": "@vS26/55/TARA_0270.",
 		"TextJPN": "「ダムによる地域への貢献」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Contribution of the dam to the area.``"
+		"TextENG": "``The contributions a dam will provide to the region?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2286,7 +2286,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0220.",
 		"TextJPN": "「はっはっは！　違いますよ違いますよ。そんな真面目なものではありません」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Ah ha ha ha! You've got it all wrong. It's not something that serious.``"
+		"TextENG": "``Hahaha! No, not that, not that. It's nothing nearly that serious.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2295,7 +2295,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0800.",
 		"TextJPN": "「美少女突撃リポート東北編！　雛見沢に国民的美少女を見たッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Bishojo assault report northeast edition! I watched the national bishojo in Hinamizawa!``"
+		"TextENG": "``A surprise report on pretty young girls from Northern Honshu! National beauties discovered in Hinamizawa!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2304,13 +2304,13 @@
 		"PreTextTags": "@vS26/54/TYOS_0230.",
 		"TextJPN": "「…僕が…、取材に来たのはですね…。…………………」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...I... I came here to collect data on... .....................``"
+		"TextENG": "``...What I... came to gather information on is... .....................``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155846,
 		"TextJPN": "もったいぶる吉村。@k@r魅音はいつまでも固まっている。@k@r呆れた梨花、仕方なしに魅音に握手する。@k@r再び、無言で大喜びする魅音。",
-		"TextENG": "Yoshimura is being pretentious.@k@rMion solidifies herself as ever.@k@rAmazed, Rika shakes Mion's hand.@k@rAnd once again, Mion is overjoyed in silence."
+		"TextENG": "Yoshimura pauses to build tension.@k@rMion remains frozen in her pose.@k@rRika, exasperated, relents and shakes Mion's hand.@k@rMion is once more silently overjoyed."
 	},
 	{
 		"type": "MSGSET",
@@ -2319,7 +2319,7 @@
 		"PreTextTags": "@vS26/55/TARA_0280.",
 		"TextJPN": "「……何です？　…もったいぶらないで下さいよ」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......What is it? ...Please don't be pretentious.``"
+		"TextENG": "``...What is it? ...Please don't keep holding out on us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2328,7 +2328,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0240.",
 		"TextJPN": "「…オヤシロさま、…って知ってますか」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Oyashiro-sama ...do you know about it?``"
+		"TextENG": "``...Are you familiar... with Oyashiro-sama?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2337,7 +2337,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0810.",
 		"TextJPN": "「………オヤシロさまって…、」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........Oyashiro-sama...``"
+		"TextENG": "``.........By Oyashiro-sama, you mean...``"
 	},
 	{
 		"type": "MSGSET",
@@ -2346,6 +2346,6 @@
 		"PreTextTags": "@vS26/52/TRIK_0630.",
 		"TextJPN": "「…そう。……オヤシロさま」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Yes. Oyashiro-sama.``"
+		"TextENG": "``...Yes. ......that Oyashiro-sama.``"
 	}
 ]

--- a/bus_stop_2.json
+++ b/bus_stop_2.json
@@ -12,7 +12,7 @@
 		"PreTextTags": "@vS26/56/TTON_0360.",
 		"TextJPN": "「…って、何です？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Hey, what is it?``"
+		"TextENG": "``...Huh? Who's that?``"
 	},
 	{
 		"type": "MSGSET",
@@ -21,7 +21,7 @@
 		"PreTextTags": "@vS26/55/TARA_0290.",
 		"TextJPN": "「馬鹿馬鹿しいッ！　下らない迷信ですよ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It's nonsense! Nothing but worthless superstition!``"
+		"TextENG": "``That's ridiculous! It's just some stupid superstition!``"
 	},
 	{
 		"type": "MSGSET",
@@ -30,7 +30,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0250.",
 		"TextJPN": "「もちろん迷信ですよ。単なるお伽話です」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Of course it's superstition. It's only a fairy tale.``"
+		"TextENG": "``Of course it's a superstition. It's just a simple fairy tale.``"
 	},
 	{
 		"type": "MSGSET",
@@ -39,7 +39,7 @@
 		"PreTextTags": "@vS26/55/TARA_0300.",
 		"TextJPN": "「下らないッ！　…あなたはそんな下らないもののためにわざわざ取材にやって来たんですか！？」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It's stupid! ...Did you really bother to come all the way just to cover such a worthless story!?``"
+		"TextENG": "``It's stupid! ...You've come all the way out here just to gather information on something as stupid as that?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -48,7 +48,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0260.",
 		"TextJPN": "「…下らない下らない、ってわりには気にしておられるようですね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...You say it's stupid and worthless, but you seem to be concerned about it.``"
+		"TextENG": "``...You keep calling it stupid, but you seem to be pretty concerned about it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -57,7 +57,7 @@
 		"PreTextTags": "@vS26/56/TTON_0370.",
 		"TextJPN": "「荒川君、落ち着いて落ち着いて。何だか知らないがお伽話なんだろう？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Arakawa-kun, calm down, calm down. Although I don't know what it is, isn't it just a fairy tale?``"
+		"TextENG": "``Arakawa-kun, calm down, calm down. I don't get what's going on, but it's a fairy tale, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -66,7 +66,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0640.",
 		"TextJPN": "「………そうよ。…単なるお伽話」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........Yes. ...A simple fairy tale.``"
+		"TextENG": "``.........Yes. ...It's a simple fairy tale.``"
 	},
 	{
 		"type": "MSGSET",
@@ -75,7 +75,7 @@
 		"PreTextTags": "@vS26/56/TTON_0380.",
 		"TextJPN": "「…一体何の話だい？　…園崎さんは知ってますか？　…そのナントカ様の話」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...What are you talking about? ...Sonozaki-san, do you know? ...I'm clueless here.``"
+		"TextENG": "``...What on earth is he talking about? ...Sonozaki-san, do you know? ...Who's this Whatever-sama?``"
 	},
 	{
 		"type": "MSGSET",
@@ -84,7 +84,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0820.",
 		"TextJPN": "「いちおー小学校で習いましたからねぇ…。…ま、とりあえずは」",
 		"NamesENG": "Mion",
-		"TextENG": "``I first learned about it in elementary school... ...Well, first of all.``"
+		"TextENG": "``We learned about him in elementary school, by the way... ...So I know some things.``"
 	},
 	{
 		"type": "MSGSET",
@@ -93,7 +93,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0270.",
 		"TextJPN": "「オヤシロさまはこの雛見沢の守り神さまの名前なんですよ。地元の人間なら誰でも知っています」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Oyashiro-sama is the name of the guardian deity of Hinamizawa. Every local here must know about it.``"
+		"TextENG": "``Oyashiro-sama is the name of Hinamizawa's guardian deity. Everyone that's local knows about him.``"
 	},
 	{
 		"type": "MSGSET",
@@ -102,7 +102,7 @@
 		"PreTextTags": "@vS26/55/TARA_0310.",
 		"TextJPN": "「もうオヤシロさまの話は聞き飽きましたよ！　まだ聞かせる気ですかッ！　あの下らない話をッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I'm tired of hearing this story about Oyashiro-sama! Are you still going to tell it? That stupid story!``"
+		"TextENG": "``I've heard enough about Oyashiro-sama already! And you're planning on making me hear more?! More of those stupid stories?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -111,7 +111,7 @@
 		"PreTextTags": "@vS26/56/TTON_0390.",
 		"TextJPN": "「…話？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Story?``"
+		"TextENG": "``...Stories?``"
 	},
 	{
 		"type": "MSGSET",
@@ -120,7 +120,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0650.",
 		"TextJPN": "「…オヤシロさまのお伽話よ。…雛見沢を汚そうとするとね…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...The fairy tale of Oyashiro-sama. ...That if you try to pollute Hinamizawa...``"
+		"TextENG": "``...Oyashiro-sama's fairy tales. ...They say that if you try to defile Hinamizawa...``"
 	},
 	{
 		"type": "LOGSET",
@@ -134,7 +134,7 @@
 		"type": "MSGSET",
 		"MessageID": 155864,
 		"TextJPN": "遠雷。@k@r雨の音が少し強くなる。@k@rしばしの沈黙。",
-		"TextENG": "Distant thunder.@k@rThe sound of the rain becomes strong.@k@rA brief silence."
+		"TextENG": "Distant thunder.@k@rThe sound of rain grows a little stronger.@k@rThere's silence for a moment."
 	},
 	{
 		"type": "MSGSET",
@@ -143,7 +143,7 @@
 		"PreTextTags": "@vS26/55/TARA_0320.",
 		"TextJPN": "「馬鹿な話ですよッ！　…どこの郷里にだってその手の話のひとつやふたつあるもんです！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``That's just a stupid story! ...There's always a story or two like that in anyone's hometown!``"
+		"TextENG": "``It's a stupid story! ...Every rural village has a tale or two like that!``"
 	},
 	{
 		"type": "MSGSET",
@@ -152,7 +152,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0280.",
 		"TextJPN": "「そうです。祟る神様の伝承は日本各地、数え出したらきりがない。…でもこのオヤシロさまの祟りは他のそれとはまったく異なっています」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``You're right about that. There are folklore's about gods' curses all over Japan, the number is infinite. ...But, the curse of Oyashiro-sama is completely different from the rest of them.``"
+		"TextENG": "``That's right. There's no end to the number of legends about gods cursing people throughout all the regions of Japan. ...But the tales of this Oyashiro-sama's curse are completely different from the rest.``"
 	},
 	{
 		"type": "MSGSET",
@@ -161,7 +161,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0670.",
 		"TextJPN": "「………本当に祟るのよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........You really can be cursed.``"
+		"TextENG": "``.........He really does curse people.``"
 	},
 	{
 		"type": "MSGSET",
@@ -170,7 +170,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0840.",
 		"TextJPN": "「……ははは、はははははは！　…まっさかー！　今時、祟りなんて流行んないですよー！　梨花さんも脅し過ぎですってばー」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Ha ha ha, ha ha ha ha ha ha! ...No way! These days curses aren't the most trendy of things! You're scaring us too much, Rika!``"
+		"TextENG": "``......Hahaha, hahahahahaha! ...No way! Curses aren't even a thing anymore! You're scaring them, Rika-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -179,7 +179,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0290.",
 		"TextJPN": "「……魅音ちゃんは知らないみたいだね。…いや。…無理もないよ。その全てが新聞で取り上げられたわけじゃないから」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Mion-chan, it doesn't seem like you know much. ...No. ...That's understandable. Since it hasn't been addressed in the newspapers.``"
+		"TextENG": "``......Looks like you don't know, Mion-chan. ...Well. ...I don't blame you for that. It wasn't like everything got published in the news, after all.``"
 	},
 	{
 		"type": "MSGSET",
@@ -188,7 +188,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0300.",
 		"TextJPN": "「……具体的数字を挙げよう。…４人だ。………すでに建設省の職員が４人、………亡くなってるんだよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......I'll give a concrete number. ...Four people. .........Four employees from the Ministry of Construction......... have already died.``"
+		"TextENG": "``......We can put an exact number on it. ...Four. .........Four people working for the Ministry of Construction......... have already passed away.``"
 	},
 	{
 		"type": "MSGSET",
@@ -197,7 +197,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0680.",
 		"TextJPN": "「尋常じゃない死に方でね」",
 		"NamesENG": "Rika",
-		"TextENG": "``Their deaths were not ordinary.``"
+		"TextENG": "``Their deaths were unnatural.``"
 	},
 	{
 		"type": "MSGSET",
@@ -206,7 +206,7 @@
 		"PreTextTags": "@vS26/55/TARA_0330.",
 		"TextJPN": "「馬鹿馬鹿しいッ！　偶然にも不幸が重なる事はあります！　…いいですか！？　我々は常にどこかしらのダム計画に関係しています」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``That's ridiculous! It was just was a coincidence of misfortunes that happened one after another! ...Listen me, okay!? We are always connected to the dam project no matter where we are.``"
+		"TextENG": "``This is ridiculous! It's just a series of simple accidents! ...So listen here! We're always working on the dam project one way or another.``"
 	},
 	{
 		"type": "MSGSET",
@@ -215,7 +215,7 @@
 		"PreTextTags": "@vS26/55/TARA_0340.",
 		"TextJPN": "「公務中に倒れる度にどこぞの祟りだなんて言われてたらたまったもんじゃないんですよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``So if someone dies on duty, you just say it was some curse every time. We don't need this!``"
+		"TextENG": "``So I'm not going to stand for people claiming it's a curse whenever someone collapses on the job!``"
 	},
 	{
 		"type": "MSGSET",
@@ -224,7 +224,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0310.",
 		"TextJPN": "「常識的な死に方だったら私も妙なことは言い出しません。…ですが、彼らは普通じゃなかった」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``If they died in a common way, I wouldn't be saying such strange things. ...But, they didn't die normally.``"
+		"TextENG": "``I wouldn't be saying these things either if they had died ordinary deaths. ...However, theirs weren't even remotely normal.``"
 	},
 	{
 		"type": "MSGSET",
@@ -233,7 +233,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0850.",
 		"TextJPN": "「…普通じゃない…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Not normally...?``"
+		"TextENG": "``...They weren't normal...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -242,7 +242,7 @@
 		"PreTextTags": "@vS26/56/TTON_0400.",
 		"TextJPN": "「……去年の暮れの……近藤さんの事かい…？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``......On the evening of last year...... wasn't it Kondo-san...?``"
+		"TextENG": "``......Are you referring to Kondou-san...... at the end of last year...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -251,7 +251,7 @@
 		"PreTextTags": "@vS26/55/TARA_0350.",
 		"TextJPN": "「……あれは派手に新聞に載りましたからね」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......That made quite a flashy fuss in the newspapers.``"
+		"TextENG": "``......That one was highlighted in the newspapers.``"
 	},
 	{
 		"type": "MSGSET",
@@ -260,7 +260,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0320.",
 		"TextJPN": "「昨年の１１月２０日。……寝ていた家族を次々と襲い、自らも喉を掻き切って死ぬという凄惨な事件が発生しました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Last year on November 20th. ......A man stabbed his family to death one after another using a kitchen knife while they were sleeping. As for himself, he slit his own throat and died, what a tragic incident.``"
+		"TextENG": "``It happened on November 20th of last year. ......It was a gruesome incident, one where he stabbed his sleeping family members one after another before slitting his own throat.``"
 	},
 	{
 		"type": "MSGSET",
@@ -269,7 +269,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0330.",
 		"TextJPN": "「…男の名は@bこんどうよしゆき.@<近藤義幸@>。…建設省河川局開発課の職員です」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...The man's name was Kondo Yoshiyuki. ...He was an employee of the Ministry of Construction River Bureau Development Division.``"
+		"TextENG": "``...The man's name was Kondou Yoshiyuki. ...He was a member of the Ministry of Construction's River Bureau, Development Division.``"
 	},
 	{
 		"type": "MSGSET",
@@ -278,7 +278,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0690.",
 		"TextJPN": "「彼は雛見沢ダム計画の初期のスタッフで、雛見沢には何度も訪れていた」",
 		"NamesENG": "Rika",
-		"TextENG": "``Since he was part of the initial staff of the Hinamizawa dam project, he visited Hinamizawa many times.``"
+		"TextENG": "``He was one of the initial staff on the Hinamizawa dam project, and he visited Hinamizawa several times.``"
 	},
 	{
 		"type": "MSGSET",
@@ -287,7 +287,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0860.",
 		"TextJPN": "「……無理心中ってヤツですか…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Is that what you call a forced suicide?``"
+		"TextENG": "``......So it was some kind of murder/suicide thing...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -296,7 +296,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0340.",
 		"TextJPN": "「最終的にはね。そういう事で落ち着いたよ。…でもね、警察がいくら調べても心中しなくてはならない理由を見つける事はできなかったんだ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Maybe. All these thing began to settle down. ...But you know, no matter how much the police looked into it, they couldn't find any reason why they had to commit suicide.``"
+		"TextENG": "``Ultimately, yes. At least, that's how it was settled. ...But no matter how hard the police investigated him, they couldn't find any reason he would commit suicide.``"
 	},
 	{
 		"type": "MSGSET",
@@ -305,7 +305,7 @@
 		"PreTextTags": "@vS26/56/TTON_0410.",
 		"TextJPN": "「…クスリの類に手を出したんじゃないか、なんて噂が流れたのを覚えてる」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Could he have used some kind of drug, I remember that was one of the rumors.``"
+		"TextENG": "``...I remember hearing rumors that he might gotten his hands on some kind of drug.``"
 	},
 	{
 		"type": "MSGSET",
@@ -314,7 +314,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0350.",
 		"TextJPN": "「検死の結果、薬物の反応は一切検出されなかったそうです。事件当時の彼のスケジュールは過密で、警察では過労による発作的な凶行と断定しました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``As for the result of the autopsy, it was reported that they couldn't detect any trace of drugs. His schedule at the time of the incident was overcrowded, so the police concluded that this sporadic act of violence was due to overworking.``"
+		"TextENG": "``When they conducted the autopsy, they found absolutely no trace of any drugs in his system. At the time of the incident, he was pretty overworked, and the police decided that he had snapped because of it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -323,7 +323,7 @@
 		"PreTextTags": "@vS26/55/TARA_0360.",
 		"TextJPN": "「…悲惨な出来事だったとは思うよ。確かに普通じゃない！　…だからと言ってすぐにオヤシロさまの祟りと結びつけるのはあまりに短絡的だッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...I do think that this was a tragic incident. Surely it wasn't normal! However, it's too simplistic to immediately relate it to the curse of Oyashiro-sama!``"
+		"TextENG": "``...I think what happened to him is tragic. And sure, it wasn't normal! ...But it's far too hasty to go claiming it was Oyashiro-sama's curse!``"
 	},
 	{
 		"type": "MSGSET",
@@ -332,7 +332,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0360.",
 		"TextJPN": "「…まったくです。…この事件ひとつだけなら、私も短絡的に祟りなんかと結びつけたりはしない」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...You're right about that. ...If the incident only happened once that is, then I wouldn't simplistically relate it to things like curses.``"
+		"TextENG": "``...You're absolutely right. ...If it were an isolated incident, I wouldn't jump straight to blaming the curse either.``"
 	},
 	{
 		"type": "MSGSET",
@@ -341,7 +341,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0870.",
 		"TextJPN": "「…他にもあるんですか。…そーいうの…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...So there were others. ...If I understand correctly...``"
+		"TextENG": "``...There were others? ...Who were they...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -350,7 +350,7 @@
 		"PreTextTags": "@vS26/56/TTON_0420.",
 		"TextJPN": "「そう言えば吉村さん、職員が４人死んだと言いましたよね。…でも、私は近藤さんのこと以外は一切聞いていませんよ」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Yoshimura-san, that reminds me, you said there were four employees who died. ...But, I haven't heard of anyone else other than Kondo-san.``"
+		"TextENG": "``You said four staff members died, didn't you, Yoshimura-san? ...But I haven't heard a thing about anyone other than Kondou-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -359,7 +359,7 @@
 		"PreTextTags": "@vS26/56/TTON_0430.",
 		"TextJPN": "「職員が亡くなったら絶対に回書が回るはずだ。…なぁ荒川君！」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``If any other personnel died, we would have definitely received reports about it. ...Right, Arakawa-kun?``"
+		"TextENG": "``If a member of staff passed away, then you'd think we would have gotten some notice about it. ...Right, Arakawa-kun?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -368,7 +368,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0370.",
 		"TextJPN": "「…失礼ですが、利根川さんはこの４月の異動ですか？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Excuse me, but didn't you transfer in this April, Tonegawa-san?``"
+		"TextENG": "``...Pardon me, but you moved into the department in April, right, Tonegawa-san?``"
 	},
 	{
 		"type": "MSGSET",
@@ -377,7 +377,7 @@
 		"PreTextTags": "@vS26/56/TTON_0440.",
 		"TextJPN": "「え…えぇ！　４月までは砂防部の傾斜地保全課におりました」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Eh... yeah! Until April, I was in the Slope Conservation Division of Erosion Control Department.``"
+		"TextENG": "``Y...Yes! Up until April, I was with the Land Conservation Division of the Erosion and Sediment Control Department.``"
 	},
 	{
 		"type": "MSGSET",
@@ -386,7 +386,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0700.",
 		"TextJPN": "「……隠されてるのよ。……もっと死んでるわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......They're covering it up. ......There's more dead.``"
+		"TextENG": "``......They've kept it hidden. ......Even more have died.``"
 	},
 	{
 		"type": "MSGSET",
@@ -395,13 +395,13 @@
 		"PreTextTags": "@vS26/56/TTON_0450.",
 		"TextJPN": "「あ、荒川君！？　本当かい！？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``A-Arakawa-Kun!? Is that true!?``"
+		"TextENG": "``A-Arakawa-kun?! Is that true?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155894,
 		"TextJPN": "苦い顔をして俯く荒川。@k@r利根川は何が何やらわからない。",
-		"TextENG": "Arakawa looks down with a bitter face.@k@rTonegawa cannot tell what is going on."
+		"TextENG": "Arakawa bitterly hangs his head.@k@rTonegawa is left confused."
 	},
 	{
 		"type": "MSGSET",
@@ -410,7 +410,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0380.",
 		"TextJPN": "「彼の事件直後から雛見沢ダムの担当者の間にある噂が流れ始めました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Immediately after that incident, a rumor surrounding the person in charge of the Hinamizawa dam started to rise.``"
+		"TextENG": "``After that incident with him, certain rumors began to spread among those in charge of the Hinamizawa dam.``"
 	},
 	{
 		"type": "MSGSET",
@@ -419,7 +419,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0390.",
 		"TextJPN": "「その噂は事件の前から囁かれていましたが、少なくとも事件が起きるまではただのお伽話に過ぎませんでした」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Although this rumor was spread before the incident even happened, but until the incident occurred, it was just a fairy tale.``"
+		"TextENG": "``The rumors were whispered well before that incident, but at the very least, they were treated as just fairy tales up until it occurred.``"
 	},
 	{
 		"type": "MSGSET",
@@ -428,7 +428,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0880.",
 		"TextJPN": "「…お伽話って、…ひょっとして」",
 		"NamesENG": "Mion",
-		"TextENG": "``...That fairy tale... could it be.``"
+		"TextENG": "``...By fairy tales... you mean?``"
 	},
 	{
 		"type": "MSGSET",
@@ -437,7 +437,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0710.",
 		"TextJPN": "「そう。……オヤシロさまの…祟り」",
 		"NamesENG": "Rika",
-		"TextENG": "``Yes. ...... Oyashiro-sama's... curse.``"
+		"TextENG": "``Yes. ......Oyashiro-sama's... curse.``"
 	},
 	{
 		"type": "MSGSET",
@@ -446,7 +446,7 @@
 		"PreTextTags": "@vS26/55/TARA_0370.",
 		"TextJPN": "「やめて下さいよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Please stop it!``"
+		"TextENG": "``Stop this already!``"
 	},
 	{
 		"type": "MSGSET",
@@ -455,7 +455,7 @@
 		"PreTextTags": "@vS26/56/TTON_0460.",
 		"TextJPN": "「…どんな話なんですか。その、…オヤシロさまのお伽話と言うのは」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...What does the story say... I mean... Oyashiro-sama's fairy tale.``"
+		"TextENG": "``...What kind of stories are they? These... well, fairy tales about Oyashiro-sama.``"
 	},
 	{
 		"type": "MSGSET",
@@ -464,7 +464,7 @@
 		"PreTextTags": "@vS26/55/TARA_0380.",
 		"TextJPN": "「つまらない話ですよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It's just a boring story!``"
+		"TextENG": "``They're just stories, nothing more!``"
 	},
 	{
 		"type": "MSGSET",
@@ -473,7 +473,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0720.",
 		"TextJPN": "「…昔々、…貧しい老夫婦と３人の息子たちが住んでたわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Once upon a time... there lived a poor elderly couple and their three sons.``"
+		"TextENG": "``...Long, long ago... there lived a poor elderly couple with three sons.``"
 	},
 	{
 		"type": "MSGSET",
@@ -482,7 +482,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0730.",
 		"TextJPN": "「…畑仕事が嫌いで贅沢な暮らしに憧れる３人の息子はね、ある日、両親も先祖代々の畑も捨てて都へ旅立ってしまうの」",
 		"NamesENG": "Rika",
-		"TextENG": "``...The three sons hated life on the fields, and yearned for a luxurious life. Then one day, they left their parents and the fields of their ancestors, and left for the capital.``"
+		"TextENG": "``...The three sons hated working the fields, and longed for a life of luxury. So one day, they abandoned the fields their parents and ancestors had worked to travel to the capital.``"
 	},
 	{
 		"type": "MSGSET",
@@ -491,7 +491,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0890.",
 		"TextJPN": "「一度に３人も逃げられたんだからねぇ。…ま、そんなわけでお爺さんもお婆さんも頑張って２人だけでご先祖さまの土地を守っていくんだけどー、…駄目なんだよね」",
 		"NamesENG": "Mion",
-		"TextENG": "``All three men ran away at once. ...Well, because of that, the old man and woman decided to work hard and do their best to protect their ancestors land with only two people.``"
+		"TextENG": "``All three of them had ran away at once. ...So well, their parents worked hard all by themselves to protect their ancestors' land. ...But it wasn't enough.``"
 	},
 	{
 		"type": "MSGSET",
@@ -500,7 +500,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0900.",
 		"TextJPN": "「…結局ある日、倒れて２人とも寝込んでしまう」",
 		"NamesENG": "Mion",
-		"TextENG": "``...However, it was no use. ...Because eventually one day, both of them collapsed and were forced to stay in bed from there on.``"
+		"TextENG": "``...In the end, both of them collapsed and fell sick one day.``"
 	},
 	{
 		"type": "MSGSET",
@@ -509,7 +509,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0740.",
 		"TextJPN": "「先祖の畑を守る為にはどうしても息子たちの力がいる。…老夫婦はオヤシロさまに祈ったの。…どうか息子たちに帰ってくるようにお伝え下さい。…ってね」",
 		"NamesENG": "Rika",
-		"TextENG": "``In order to protect their ancestors fields, they surely needed help from their sons. ...So the elderly couple prayed to Oyashiro-sama. ...'Please tell our sons to come home'.``"
+		"TextENG": "``They couldn't protect their ancestors' fields without the strength of their sons. ...So the elderly couple prayed to Oyashiro-sama. ...'Please tell our sons to come home,' they asked.``"
 	},
 	{
 		"type": "MSGSET",
@@ -518,7 +518,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0400.",
 		"TextJPN": "「…オヤシロさまはまず長男のもとへ行った。…そして夢枕に立ってね。故郷に帰るように諭したんだ。…だが都の華やかな暮らしに染まった長男は頑として拒んだ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Oyashiro-sama visited the eldest son first. ...Appeared in his dream. And Admonished him to return home. ...However, the eldest son was already stained with the glamorous life of the capital and stubbornly refused.``"
+		"TextENG": "``...First, Oyashiro-sama visited the eldest son. ...He stood at the son's bedside, and admonished him to return to his homeland. ...But after coming to know the gaudy life of the city, the oldest son stubbornly refused.``"
 	},
 	{
 		"type": "MSGSET",
@@ -527,7 +527,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0750.",
 		"TextJPN": "「オヤシロさまは七日七晩、長男の夢枕に立ったわ。…でも長男は雛見沢に帰ろうとはしなかった」",
 		"NamesENG": "Rika",
-		"TextENG": "``Then, Oyashiro-sama for seven nights appeared to the eldest son in his dreams. ...But, the eldest son still had no intention of returning home to Hinamizawa.``"
+		"TextENG": "``So Oyashiro-sama stood at his bedside for seven days and seven nights. ...But the eldest son would not return to Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -536,7 +536,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0910.",
 		"TextJPN": "「毎晩、枕元立たれるのはキツいですよねー。…単なる嫌がらせの領域ですよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Every night, just standing beside his bed must have been tough. ...That kind of behaviour is just harassment.``"
+		"TextENG": "``Having him by his bedside every night must have been pretty rough. ...That sounds more like harassment.``"
 	},
 	{
 		"type": "MSGSET",
@@ -545,7 +545,7 @@
 		"PreTextTags": "@vS26/56/TTON_0470.",
 		"TextJPN": "「……それで？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``......And then what happened?``"
+		"TextENG": "``......So then?``"
 	},
 	{
 		"type": "MSGSET",
@@ -554,7 +554,7 @@
 		"PreTextTags": "@vS26/55/TARA_0390.",
 		"TextJPN": "「結局、長男は祟りで死んでしまうんですよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``In the end, the eldest son was killed by the curse!``"
+		"TextENG": "``In the end, the eldest son is cursed to death!``"
 	},
 	{
 		"type": "MSGSET",
@@ -563,7 +563,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0760.",
 		"TextJPN": "「次にオヤシロさまは次男の夢枕に立ったわ。…でも次男も帰ろうとはしなかった」",
 		"NamesENG": "Rika",
-		"TextENG": "``Next, Oyashiro-sama appeared in the second son's dreams. ...But the second son didn't plan on returning home either.``"
+		"TextENG": "``Next, Oyashiro-sama visited the second son's bedside. ...But the second son wouldn't return either.``"
 	},
 	{
 		"type": "MSGSET",
@@ -572,7 +572,7 @@
 		"PreTextTags": "@vS26/55/TARA_0400.",
 		"TextJPN": "「次男も同様ッ！　七日目におかしくなって死んでしまうんですッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``The second son was the same! He became strange and died on the seventh day!``"
+		"TextENG": "``So the same happens to him! He goes crazy on the seventh day and dies!``"
 	},
 	{
 		"type": "MSGSET",
@@ -581,7 +581,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0410.",
 		"TextJPN": "「兄たちの変死に怖くなってね。三男は逃げるように帰るんだよ。…そして３人で力を合わせて畑を守っていったんだとさ。…おしまい」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Then, becoming scared about the unnatural deaths of his older brothers, the third son choose to escape and return home. And then the three people united their strength to protect their fields. ...The end.``"
+		"TextENG": "``The third grew frightened by his brothers' untimely deaths. So he fled back home. ...And then the three of them worked together to protect their fields. ...The end.``"
 	},
 	{
 		"type": "MSGSET",
@@ -590,7 +590,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0420.",
 		"TextJPN": "「郷に生まれた者は郷に生き、郷に死ぬことを良しとする風習を伝えたお伽話だと考えられています。…そういう風習自体はそんなに珍しいものじゃない」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``The people born in the village should live in the village, so it's thought this fairy tale is told to tell us a custom that people born in the village... should live and die in the village. ...That custom itself isn't so rare.``"
+		"TextENG": "``Some consider it a fairy tale meant to promote the custom of those who are born here remaining until they die. ...And such a custom isn't all that unusual.``"
 	},
 	{
 		"type": "MSGSET",
@@ -599,7 +599,7 @@
 		"PreTextTags": "@vS26/56/TTON_0480.",
 		"TextJPN": "「…別に…近藤さんはここの出身だったわけじゃないでしょう？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Apart from that... Kondo-san wasn't from this place, am I right?``"
+		"TextENG": "``...It's not like... Kondou-san was from here though, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -608,7 +608,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0430.",
 		"TextJPN": "「えぇ違いますよ。…要するにオヤシロさまって神様は、雛見沢から出て行こうとする人、よそから雛見沢に入って来ようとする人に厳しいんですよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Yeah, but it's not just that. ...In short, the god Oyashiro-sama told the people they are not to leave Hinamizawa... And is said to be severe on anyone going against that, and anyone trying to enter Hinamizawa from the outside.``"
+		"TextENG": "``No, he wasn't. ...In other words, this god, this Oyashiro-sama, is strict towards both those who try to leave Hinamizawa, and those outsiders who come to Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -617,7 +617,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0440.",
 		"TextJPN": "「…守り神さまですからね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...He is also considered a guardian deity.``"
+		"TextENG": "``...He is a guardian deity, after all.``"
 	},
 	{
 		"type": "MSGSET",
@@ -626,7 +626,7 @@
 		"PreTextTags": "@vS26/55/TARA_0410.",
 		"TextJPN": "「ダム反対派の老人たちが揃いも揃ってこの話をするもんなんで！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Do you know why every elderly person and the dam opposition talk about this thing?!``"
+		"TextENG": "``The old folks opposed to the dam all keep talking about this!``"
 	},
 	{
 		"type": "MSGSET",
@@ -635,7 +635,7 @@
 		"PreTextTags": "@vS26/55/TARA_0420.",
 		"TextJPN": "「…みんな面白がっていましたよ。…この近代社会で、まだこんなお伽話を聞けるとは思いませんでしたから！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...At first, everyone was just amused. ...Because we live in a modern society, they didn't think they would hear such a fairy tale!``"
+		"TextENG": "``...They've all been getting a kick out of it. ...Because they didn't think they'd get to hear such fairy tales again in modern times!``"
 	},
 	{
 		"type": "MSGSET",
@@ -644,13 +644,13 @@
 		"PreTextTags": "@vS26/54/TYOS_0450.",
 		"TextJPN": "「そう。お伽話だったんです。…事件が起きるまではね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Yes. It was just a fairy tale. ...Until that incident happened.``"
+		"TextENG": "``Yes. It was a fairy tale. ...Until that incident happened.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155922,
 		"TextJPN": "遠くで雷鳴。@k@r相変わらず土砂降りの雨。@k@rしばらくの沈黙。",
-		"TextENG": "The sound of thunder in the distance.@k@rThe usual downpour of the rain.@k@rA brief silence."
+		"TextENG": "Thunder rings in the distance.@k@rThe rain continues pouring down hard.@k@rA moment of silence passes."
 	},
 	{
 		"type": "MSGSET",
@@ -659,7 +659,7 @@
 		"PreTextTags": "@vS26/55/TARA_0430.",
 		"TextJPN": "「最初に言ったのは誰か忘れました。…ここんところ眠れなくて辛いって言うんですよ。…寝ようとすると落ち着かなくなって起きてしまうって！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I forgot to tell you this. ...He had always said it's been difficult to sleep recently. ...And that he always became restless if he tried to go asleep!``"
+		"TextENG": "``I forget who was the first to say it. ...They said they've been having trouble because they can't get any sleep lately. ...They said that whenever they try to sleep, they get restless and wake up!``"
 	},
 	{
 		"type": "MSGSET",
@@ -668,7 +668,7 @@
 		"PreTextTags": "@vS26/56/TTON_0490.",
 		"TextJPN": "「…過労だよ」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...It must have been from overworking.``"
+		"TextENG": "``...They're overworked.``"
 	},
 	{
 		"type": "MSGSET",
@@ -677,7 +677,7 @@
 		"PreTextTags": "@vS26/55/TARA_0440.",
 		"TextJPN": "「その内、誰かが言い出したんです。寝ようとすると何かの気配を感じる。灯りを付けて探すんだが誰もいない。…でも再び灯りを消すと確かに気配を感じるんだってッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``One day, people started to talk. That he felt the presence of someone when he tried to sleep. He switched the light on and looked around, but found nobody. ...However, he sensed its presence again when he turned off the lights!``"
+		"TextENG": "``Then one of them started saying this. 'When I try to sleep, I feel some kind of presence nearby.' 'I turned the light on to look for them, but no one was there.' '...Yet once I turned the light off again, I felt that same presence!'``"
 	},
 	{
 		"type": "MSGSET",
@@ -686,7 +686,7 @@
 		"PreTextTags": "@vS26/55/TARA_0450.",
 		"TextJPN": "「…みんなは面白がってそれをオヤシロさまの祟りだと囃し立てました。オヤシロさまが夢枕に立ってるんだ、って言って！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...Everyone jeered in amusement when he said it was the curse of Oyashiro-sama. Oyashiro-sama appears in his dreams, they said!``"
+		"TextENG": "``...They all thought it was amusing to play it up as Oyashiro-sama's curse. They say that Oyashiro-sama's standing by their bedsides!``"
 	},
 	{
 		"type": "MSGSET",
@@ -695,7 +695,7 @@
 		"PreTextTags": "@vS26/55/TARA_0460.",
 		"TextJPN": "「…今思うと、最初に不眠の事を訴えたのは近藤さんだったように思います。…近藤さんは……事件の直前には笑い事じゃない状況になってました」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...When I think about it, Kondo-san was the first one to complain about insomnia. ...Kondo-san's situation was not a laughing matter just before the incident.``"
+		"TextENG": "``...Thinking back on it now, I believe Kondou-san was the first to complain about his lack of sleep. ...Kondou-san...... The way he was acting before the incident was no laughing matter.``"
 	},
 	{
 		"type": "MSGSET",
@@ -704,7 +704,7 @@
 		"PreTextTags": "@vS26/55/TARA_0470.",
 		"TextJPN": "「…………“いる”って言うんですよ」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``............'It exists' he said.``"
+		"TextENG": "``.........He swore something was there.``"
 	},
 	{
 		"type": "MSGSET",
@@ -713,7 +713,7 @@
 		"PreTextTags": "@vS26/55/TARA_0480.",
 		"TextJPN": "「…毎晩、寝ようとすると…“いる”ってッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...Every night, when he tried to sleep... 'It's there' he said!``"
+		"TextENG": "``...He swore that every night when he tried to sleep... that he was there!``"
 	},
 	{
 		"type": "MSGSET",
@@ -722,7 +722,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0920.",
 		"TextJPN": "「…“いる”って……、……はは……ヤダなぁ……」",
 		"NamesENG": "Mion",
-		"TextENG": "``...'It's there' he said...... ......ha ha...... no way......``"
+		"TextENG": "``...He was there......? ......Haha...... No way......``"
 	},
 	{
 		"type": "MSGSET",
@@ -731,7 +731,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0460.",
 		"TextJPN": "「そして事件が起こった。…その時、お伽話はもはや単なる笑い話ではありませんでした」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``And then that incident happened. ...At that time, the fairy tale was no longer just a funny story.``"
+		"TextENG": "``Then the incident happened. ...At that point, it was no simple laughing matter anymore.``"
 	},
 	{
 		"type": "MSGSET",
@@ -740,7 +740,7 @@
 		"PreTextTags": "@vS26/55/TARA_0490.",
 		"TextJPN": "「その後しばらく、職場はオバケ屋敷状態でしたよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Then for some time, our workplace became a haunted house!``"
+		"TextENG": "``Our workplace was like a haunted mansion for a while after that!``"
 	},
 	{
 		"type": "MSGSET",
@@ -749,7 +749,7 @@
 		"PreTextTags": "@vS26/55/TARA_0500.",
 		"TextJPN": "「…仮眠室で怪しい気配を感じた！　深夜まで残業をしていたら背後に“誰か”が立った！　電車の中まで“何か”が付いて来たッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...Anyone could feel a suspicious breeze in the nap room! And whenever one of us worked overtime until midnight, 'someone' was standing behind them! Even on a train, 'something' was following them!``"
+		"TextENG": "``...'I sensed an eerie presence in the nap room!' 'When I was up pulling overtime late at night, there was someone standing behind me!' 'There was something following me in the train!'``"
 	},
 	{
 		"type": "MSGSET",
@@ -758,7 +758,7 @@
 		"PreTextTags": "@vS26/55/TARA_0510.",
 		"TextJPN": "「…馬鹿馬鹿しいにも程があるッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...It's beyond ridiculous!``"
+		"TextENG": "``...It couldn't have gotten more ridiculous than that!``"
 	},
 	{
 		"type": "MSGSET",
@@ -767,6 +767,6 @@
 		"PreTextTags": "@vS26/52/TRIK_0770.",
 		"TextJPN": "「馬鹿馬鹿しくなんかない。…“いる”んだもの。…オヤシロさまは」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's not ridiculous. ...Because, 'it exists'. Oyashiro-sama exists.``"
+		"TextENG": "``It isn't ridiculous. ...He does exist. ...That Oyashiro-sama.``"
 	}
 ]

--- a/bus_stop_3.json
+++ b/bus_stop_3.json
@@ -12,7 +12,7 @@
 		"PreTextTags": "@vS26/55/TARA_0520.",
 		"TextJPN": "「…いつしか、その“何か”は！　…オヤシロさまと呼ばれるようになりました」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...Yeah, at some point that 'something'! ...Began to be called Oyashiro-sama.``"
+		"TextENG": "``...Yeah, at some point that 'something'... began to be called Oyashiro-sama.``"
 	},
 	{
 		"type": "MSGSET",
@@ -528,7 +528,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0590.",
 		"TextJPN": "「加藤さんは電車に飛び込み亡くなられました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Katou-san leapt in front of a train at Nishi-Funabashi Station in Chiba Prefecture, and died.``"
+		"TextENG": "``Katou-san leapt in front of a train, and died.``"
 	},
 	{
 		"type": "MSGSET",

--- a/bus_stop_3.json
+++ b/bus_stop_3.json
@@ -12,7 +12,7 @@
 		"PreTextTags": "@vS26/55/TARA_0520.",
 		"TextJPN": "「…いつしか、その“何か”は！　…オヤシロさまと呼ばれるようになりました」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...We're unaware what that 'something' really was! It just came to be called Oyashiro-sama.``"
+		"TextENG": "``...Yeah, at some point that 'something'! ...Began to be called Oyashiro-sama.``"
 	},
 	{
 		"type": "MSGSET",
@@ -21,7 +21,7 @@
 		"PreTextTags": "@vS26/56/TTON_0500.",
 		"TextJPN": "「…そんな噂はまったく聞いた事がないよ！」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...I've never heard of such rumors before!``"
+		"TextENG": "``...I've never heard anything about these rumors!``"
 	},
 	{
 		"type": "MSGSET",
@@ -30,7 +30,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0470.",
 		"TextJPN": "「日本人の気質としてね、忌みとするものには口を閉ざしてしまうんですよ。…口に出さない事によってなかった事にしようとする」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``It's the nature of the Japanese, to shut their mouths on the topic of taboos. ...By keeping their mouths closed, they tried to forget it ever happened.``"
+		"TextENG": "``One thing about us Japanese people, is that we all go quiet about anything taboo. ...The workers are hoping that not speaking about it will make it go away.``"
 	},
 	{
 		"type": "MSGSET",
@@ -39,7 +39,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0480.",
 		"TextJPN": "「…でも起こってしまうんですよ。…第２第３の事件が。……奇怪な事件が起こる度にオヤシロさまの祟りに怯え、ますます口を閉ざしていく」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...But it happened again. ...There was a second and third incident. ......Every time a mysterious incident occurred, they were frightened of Oyashiro-sama's curse, and became increasingly tight-lipped.``"
+		"TextENG": "``...But then it happened. ...There was a second, and a third incident. ......And with every new incident that happened, they went even quieter in fear of Oyashiro-sama's curse.``"
 	},
 	{
 		"type": "MSGSET",
@@ -48,7 +48,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0490.",
 		"TextJPN": "「…管理職は事態を憂い、極力事実を隠蔽しようと図ったようです」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...The management became worried about the situation, so they tried as much as possible to conceal the facts.``"
+		"TextENG": "``...The management was distressed by the situation, and so they did everything in their power to try and cover it up.``"
 	},
 	{
 		"type": "MSGSET",
@@ -57,7 +57,7 @@
 		"PreTextTags": "@vS26/56/TTON_0510.",
 		"TextJPN": "「そんな馬鹿な…！　…職員が死んだと言うのに、隠蔽だなんて！　考えられない！」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``That's ridiculous...! ...To say staff members died, and they hid it! It's unthinkable!``"
+		"TextENG": "``There's no way...! ...Cover it up? When staff are dying?! That's unthinkable!``"
 	},
 	{
 		"type": "MSGSET",
@@ -66,7 +66,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0500.",
 		"TextJPN": "「別に死体を隠したとか、そういう事じゃありません。徹底的な情報管制で、無関係な人間の耳に入らないように配慮した、…という事です」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``It's not that they hid the bodies or anything. Just thoroughly controlling the information, to make sure nothing irrelevant entered the people's ears... that was it.``"
+		"TextENG": "``It's not like they were hiding the corpses or anything. They just... made an effort to keep control over the information and keep it from reaching anyone not involved.``"
 	},
 	{
 		"type": "MSGSET",
@@ -75,7 +75,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0510.",
 		"TextJPN": "「これ以上、職場の士気を下げないためにね。……でも知っている人は知っているんですよ。…ねぇ、荒川さん」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Nothing more, in order to prevent the morale of the workplace dropping any further. But still there are people there who knows something. ......Right, Arakawa-san?``"
+		"TextENG": "``They didn't want morale to go down any further at the workplace. ......But those who knew, know. ...Right, Arakawa-san?``"
 	},
 	{
 		"type": "MSGSET",
@@ -84,7 +84,7 @@
 		"PreTextTags": "@vS26/55/TARA_0530.",
 		"TextJPN": "「……あれは……事故だッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......It was...... an accident!``"
+		"TextENG": "``......That...... was an accident!``"
 	},
 	{
 		"type": "MSGSET",
@@ -93,7 +93,7 @@
 		"PreTextTags": "@vS26/56/TTON_0520.",
 		"TextJPN": "「…荒川…君…！」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Arakawa... kun...?``"
+		"TextENG": "``...Arakawa...kun...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -102,7 +102,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0930.",
 		"TextJPN": "「…はははは！　…もー勘弁して下さいよー！　…あははははは！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Ha ha ha ha! ...Please give a break! ...Ah ha ha ha ha ha!``"
+		"TextENG": "``...Hahahaha! ...Cut us a break already! ...Ahahahahaha!``"
 	},
 	{
 		"type": "MSGSET",
@@ -120,7 +120,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0940.",
 		"TextJPN": "「だ、だって…笑うなって方が無理ですよ。…はははは！　…ねぇ！　この現代にさー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``B-Because... it's impossible not to laugh. ...Ha ha ha ha! ...Right! Something like that in this modern age!``"
+		"TextENG": "``I-I mean... it's impossible not to laugh, right? ...Hahahaha! ...Right?! In this modern age?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -129,7 +129,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0950.",
 		"TextJPN": "「あーっはっはっはっは！　笑っちゃえ笑っちゃえ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah ha ha ha ha ha! Come on, laugh!``"
+		"TextENG": "``Ahhahahaha! Laugh, laugh!``"
 	},
 	{
 		"type": "MSGSET",
@@ -138,7 +138,7 @@
 		"PreTextTags": "@vS26/55/TARA_0540.",
 		"TextJPN": "「笑いましたよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I laughed!``"
+		"TextENG": "``We did laugh!``"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@vS26/55/TARA_0550.",
 		"TextJPN": "「こんな馬鹿な事があってたまるかって、笑いましたよッ！　僕も！　仲間も！　みんな！　みんなッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I doubted the possibility wherever such stupid things could exist, and laughed! I did! My colleagues did! Everyone! Everyone did!``"
+		"TextENG": "``We laughed and said, 'How could such a ridiculous thing be real?!' I did! My friends did! We all did! We all did!``"
 	},
 	{
 		"type": "MSGSET",
@@ -156,7 +156,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0520.",
 		"TextJPN": "「そして再び起こった。次の犠牲者は都市河川室の柿沼さんという方でした」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``And then it happened again. The next victim was someone called Kakinuma-san from the Urban River Office.``"
+		"TextENG": "``Then it happened again. The next victim was Kakinuma-san from the Urban River Office.``"
 	},
 	{
 		"type": "MSGSET",
@@ -165,7 +165,7 @@
 		"PreTextTags": "@vS26/55/TARA_0560.",
 		"TextJPN": "「沼さんのは事故だよッ！　…祟りなんかじゃないッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Numa-san's case was an accident! ...It wasn't the curse!``"
+		"TextENG": "``Numa-san's death was an accident! ...That was no curse!``"
 	},
 	{
 		"type": "MSGSET",
@@ -183,7 +183,7 @@
 		"PreTextTags": "@vS26/56/TTON_0530.",
 		"TextJPN": "「…い、いや。…知らない職員だ」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...N-No. ...Most of the employees didn't know him.``"
+		"TextENG": "``...N-No. ...He was a worker I didn't know.``"
 	},
 	{
 		"type": "MSGSET",
@@ -192,7 +192,7 @@
 		"PreTextTags": "@vS26/55/TARA_0570.",
 		"TextJPN": "「酒と博打の好きなよく笑う人だった。…僕の直接の仕事の前任者で、歳は離れていたけどよく飲みに行きましたよ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``He was a big joke who liked sake and gambling. ...He was my predecessor in work, we were years apart in age but always went drinking!``"
+		"TextENG": "``He was man who loved his liquor and gambling, and he smiled often. ...He was my direct predecessor at the job I have now, and while there was an age gap between us, I often went drinking with him!``"
 	},
 	{
 		"type": "MSGSET",
@@ -201,7 +201,7 @@
 		"PreTextTags": "@vS26/55/TARA_0580.",
 		"TextJPN": "「１０は若く見える美人の奥さんがいるくせに毎晩毎晩飲み明かしてるんですよ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``And although he had beautiful wife who looked ten years younger than him, he still drunk the night away, every single night!``"
+		"TextENG": "``He was a guy who'd drink the night away every night, even though he had a beautiful wife who looked a decade younger!``"
 	},
 	{
 		"type": "MSGSET",
@@ -210,7 +210,7 @@
 		"PreTextTags": "@vS26/55/TARA_0590.",
 		"TextJPN": "「…たまには早い時間に帰ってあげた方がいいんじゃないですか」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...Occasionally I would say to him, 'Don't you think you should go home early?', and he would say...``"
+		"TextENG": "``...He could've gone home early for her every now and then.``"
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0000.",
 		"TextJPN": "「いいかい荒ちゃん。結婚なんてするもんじゃねえぞ～？　自由な時間がいくらでも持てる独身の内がハナなんだぞ！」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``Listen, Ara-chan. Do you actually think being married is a good thing? Being single with alot of free time is the best!``"
+		"TextENG": "``Listen now, Ara-chan. Don't ever get married, you hear? You only have free time to yourself while you're single!``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,7 +228,7 @@
 		"PreTextTags": "@vS26/55/TARA_0600.",
 		"TextJPN": "「…どうも疲れてるみたいでした。連日の激務でしたからね。無理もない事だと思ってました」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...He always seemed to be tired for some reason. It could have been from working hard day every day. But it didn't matter what I thought.``"
+		"TextENG": "``...I figured he must have been tired. He had been working very hard for several days in a row. So it made sense to me.``"
 	},
 	{
 		"type": "MSGSET",
@@ -237,7 +237,7 @@
 		"PreTextTags": "@vS26/55/TARA_0610.",
 		"TextJPN": "「終電はとっくになくなってましたからね。…いつものように沼さんの車で送ってもらってる時でした。…僕、言ったんですよ。…沼さん、だいぶ疲れてるみたいですねって」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Then one day, the last train I could catch was long gone. ...So Numa-san offered to drive me home in his car, like he always did. ...Then... I said to him... ...'Numa-san, you look very tired'.``"
+		"TextENG": "``The last train had long since left. ...So Numa-san was taking me home in his car like usual. ...That's when I said to him, ...'Numa-san, you look pretty tired.'``"
 	},
 	{
 		"type": "MSGSET",
@@ -246,7 +246,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0010.",
 		"TextJPN": "「…ここんトコ、寝苦しくてなぁ…。なかなか眠れないんだよ」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``...You're right about that, I haven't slept well lately... It's been difficult to get any sleep.``"
+		"TextENG": "``...I've been having trouble sleeping lately... So I haven't gotten much sleep.``"
 	},
 	{
 		"type": "MSGSET",
@@ -255,7 +255,7 @@
 		"PreTextTags": "@vS26/55/TARA_0620.",
 		"TextJPN": "「は！　…はははは！　…沼さん、やめて下さいよ！　…沼さんの所にまで現れるんですかー！？　例のアレ」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Ha! ...Ha ha ha ha! ...Numa-san, please stop that! ...Numa-san, does it even appear at your place!? This thing.``"
+		"TextENG": "``Ha! ...Hahahaha! ...Numa-san, please stop that! ...Is it showing up at your place too?! The you know what.``"
 	},
 	{
 		"type": "MSGSET",
@@ -264,7 +264,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0020.",
 		"TextJPN": "「……………荒ちゃんは何も感じないかい。…夜とか」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``...............Ara-chan, don't you feel anything... ...at night...?``"
+		"TextENG": "``...............You don't sense anything, Ara-chan? ...At night?``"
 	},
 	{
 		"type": "MSGSET",
@@ -273,7 +273,7 @@
 		"PreTextTags": "@vS26/55/TARA_0630.",
 		"TextJPN": "「夜に感じるって、…ははは！　何かやらしー話ですねー！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Feel anything at night...? Ha ha ha! Now you're talking dirty!``"
+		"TextENG": "``Sense something at night? ...Hahaha! Sounds like something naughty!``"
 	},
 	{
 		"type": "MSGSET",
@@ -282,7 +282,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0030.",
 		"TextJPN": "「…………確かに“いる”んだよ。………“いる”」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``............Definitely, 'it exists'. .........'It exists'.``"
+		"TextENG": "``............I'm positive that they're there. .........Positive.``"
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0040.",
 		"TextJPN": "「………気になって灯を点けるんだ。…だけど部屋には女房と子供しかいない。当たり前だよな。…………でもやっぱり“いる”んだよ」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``.........I felt uneasy and turned on the light. ...But there was only my wife and child in the room. That was ordinary to see. .........But still, I know 'it exists'.``"
+		"TextENG": "``......When it bugs me, I turn on the lights. ...But there's only ever my wife and child in the room. Of course, right? .........But still, they're really there.``"
 	},
 	{
 		"type": "MSGSET",
@@ -300,7 +300,7 @@
 		"PreTextTags": "@vS26/55/TARA_0640.",
 		"TextJPN": "「…沼さん勘弁して下さいよ…。…いるいるいるいるって、…何がいるって言うんです？」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...Numa-san, please give me a break... ...You say, it exists, it exists, it exists, it exists... but what is this it you're talking about?``"
+		"TextENG": "``...Numa-san, please give me a break... ...They're there, they're there... What are you even saying is there?``"
 	},
 	{
 		"type": "MSGSET",
@@ -309,7 +309,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0050.",
 		"TextJPN": "「………近藤さんもさ。…ひと月くらい前から、そんなこと言ってたよな…」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``.........Kondo-san. ...About one month ago, he also said those words...``"
+		"TextENG": "``.........Kondou-san also... said things like that, about a month before now, right...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -318,7 +318,7 @@
 		"PreTextTags": "@vS26/55/TARA_0650.",
 		"TextJPN": "「近藤さんは、ほらちょっと！　…なんていうのか…そういう所がありましたし…」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Kondo-san... you know, he was a bit off! ...I don't know how to put this... That's how it was...``"
+		"TextENG": "``Kondou-san was... Come on, you know! ...It was kind of... well, there were similar aspects...``"
 	},
 	{
 		"type": "MSGSET",
@@ -327,7 +327,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0060.",
 		"TextJPN": "「……近藤さんの所にもさ、……俺の所と同じヤツが……“いた”のかもな」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``......At Kondo-san's place...... perhaps the same guy at his...... is the same 'thing' at mine.``"
+		"TextENG": "``......Maybe the same one... that's showing up at my place ......was there at Kondou-san's place too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -336,7 +336,7 @@
 		"PreTextTags": "@vS26/55/TARA_0660.",
 		"TextJPN": "「……やめましょうよ。近藤さんの話は！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......Let's stop this. This story about Kondo-san!``"
+		"TextENG": "``......Let's stop this. All this talk about Kondou-san!``"
 	},
 	{
 		"type": "MSGSET",
@@ -345,7 +345,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0070.",
 		"TextJPN": "「…わかるよ。……多分、近藤さんが“いる”って言ってたヤツが…あいつなんだよ」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``...I understand. ......But maybe, the same thing Kondo-san said 'exists'... is that thing.``"
+		"TextENG": "``...I know. ......When Kondou-san said 'they were there'... it was probably him.``"
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0080.",
 		"TextJPN": "「…あいつは間違いなく“いる”んだ。…日が経つごとに、強く感じられるようになる」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``...No doubt about it, that 'thing' definitely exists. ...Whenever a day goes by, the feeling becomes stronger.``"
+		"TextENG": "``...He definitely exists. ...With every passing day, I feel him even more strongly.``"
 	},
 	{
 		"type": "MSGSET",
@@ -363,7 +363,7 @@
 		"PreTextTags": "@vS26/55/TARA_0670.",
 		"TextJPN": "「もうやめませんか。この話。…面白くないですよ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Will you stop it?! This story. ...is not funny!``"
+		"TextENG": "``Can we stop this already? Stop talking about this stuff. ...It's not any fun!``"
 	},
 	{
 		"type": "MSGSET",
@@ -372,7 +372,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0090.",
 		"TextJPN": "「…あぁ！　…やめようか。……でもな、…日増しに気配を強く感じるようになるんだよ。本当だぜ？」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``...Oh! ...I will stop. ......But... I can feel its presence around me growing stronger day by day. I'm talking the truth!``"
+		"TextENG": "``...Yeah! ...Let's stop. ......But you know ...I do sense his presence more strongly with every day that goes by. That's true.``"
 	},
 	{
 		"type": "MSGSET",
@@ -381,13 +381,13 @@
 		"PreTextTags": "@vS26/00/TKAK_0100.",
 		"TextJPN": "「………瞼をふっと開ければ、…そこに立ってるんじゃないか、ってくらいに」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``.........And whenever I suddenly open my eyelids... it's like it's standing there, watching me.``"
+		"TextENG": "``.........I feel him so strongly ...it feels like I'll find him standing there when I open my eyes.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155978,
 		"TextJPN": "ライト消え、舞台真っ暗になる。",
-		"TextENG": "Light disappears,@rand the stage becomes pitch black."
+		"TextENG": "The light goes out and the stage goes dark."
 	},
 	{
 		"type": "MSGSET",
@@ -396,7 +396,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0110.",
 		"TextJPN": "「…俺さ。…もうすぐ“会える”と思うんだよ。………オヤシロさまに」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``...I think. ...I'll 'meet' it soon. .........Oyashiro-sama.``"
+		"TextENG": "``...Listen. ...I think I'm about to meet him soon. .........To meet Oyashiro-sama.``"
 	},
 	{
 		"type": "MSGSET",
@@ -405,7 +405,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0540.",
 		"TextJPN": "「…その日の深夜ですよね。……対向車線のダンプに突っ込み、亡くなられました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Then, in the middle of the night that day. ......His car plunged into a dump truck on the opposite lane, and he died.``"
+		"TextENG": "``...It happened late at night that day. ......He ran into a dump truck while driving in the opposite lane, and passed away.``"
 	},
 	{
 		"type": "MSGSET",
@@ -414,7 +414,7 @@
 		"PreTextTags": "@vS26/55/TARA_0680.",
 		"TextJPN": "「事故ですよッ！　…あんな話のあった直後とは言え！　…事故なんですよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It was an accident! ...That said, this happened immediately after we talked! ...It was an accident!``"
+		"TextENG": "``That was an accident! ...Even if it did happen right after that conversation! ...It was an accident!``"
 	},
 	{
 		"type": "MSGSET",
@@ -423,7 +423,7 @@
 		"PreTextTags": "@vS26/55/TARA_0690.",
 		"TextJPN": "「……でも奥さんには…そんな話はとてもできなかった！　…こんな馬鹿げた話、…出来るわけがないッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......But I couldn't tell his wife... there was no way I could tell her such a thing! ...Such an absurd story... I couldn't do it!``"
+		"TextENG": "``......But I couldn't very well ...tell his wife about that! ...There's no way I could... No way I could tell her such a ridiculous story!``"
 	},
 	{
 		"type": "MSGSET",
@@ -432,7 +432,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0550.",
 		"TextJPN": "「当初は居眠り運転かと考えられました。でも実際は違った。…柿沼さんの遺体は喉が掻きむしられていました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``At first, I thought he had fell asleep while driving. But in reality, it was much different. ...Kakinuma-san, his corpse was found with its throat scratched.``"
+		"TextENG": "``At the time, they thought he had fallen asleep behind the wheel. But the truth was different. ...Kakinuma-san's corpse was found with its throat scratched out.``"
 	},
 	{
 		"type": "MSGSET",
@@ -441,7 +441,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0560.",
 		"TextJPN": "「両の手は血だらけで、爪の剥がれている指もありました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Both of his hands were full of blood, and all of his finger nails were peeled off.``"
+		"TextENG": "``Both of his hands were covered in blood, and several of the nails were peeled off his fingers.``"
 	},
 	{
 		"type": "MSGSET",
@@ -450,7 +450,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0980.",
 		"TextJPN": "「…ちょっとよく飲み込めないんですけど…、」",
 		"NamesENG": "Mion",
-		"TextENG": "``...I can't really swallow this well...``"
+		"TextENG": "``...I'm having trouble taking all of this in here...``"
 	},
 	{
 		"type": "MSGSET",
@@ -459,7 +459,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0790.",
 		"TextJPN": "「…つまりね。…彼は死の直前、何を思ったのか自分の喉を掻きむしり始めたのよ。…生爪が剥がれるくらいの…恐ろしい力でね」",
 		"NamesENG": "Rika",
-		"TextENG": "``...In other words. ...Just before his death, he thought of something and began scratching at his own throat. ...If even his fingernails were peeled off... he must have used a terrible amount of force.``"
+		"TextENG": "``...In other words... whatever may have been running through his mind, he began to scratch out his throat right before he died. ...With such horrifying force ...that it peeled his nails off.``"
 	},
 	{
 		"type": "MSGSET",
@@ -468,7 +468,7 @@
 		"PreTextTags": "@vS26/55/TARA_0700.",
 		"TextJPN": "「なんであんた、そんな事まで知ってるんだ！？　…その事は、」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Do you... know anything about this!? ...This thing.``"
+		"TextENG": "``How do you know about that too?! ...Could you be...``"
 	},
 	{
 		"type": "MSGSET",
@@ -477,7 +477,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0570.",
 		"TextJPN": "「調べたんですよ。…一応ライターの端くれですからね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Because I examined it. ...And because I'm a writer, albeit a minor one.``"
+		"TextENG": "``I investigated it. ...I am something of a reporter, you know.``"
 	},
 	{
 		"type": "MSGSET",
@@ -486,7 +486,7 @@
 		"PreTextTags": "@vS26/56/TTON_0540.",
 		"TextJPN": "「……どうしてそんな事を…」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``......Why did such a thing happen...?``"
+		"TextENG": "``......But how did you...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -495,13 +495,13 @@
 		"PreTextTags": "@vS26/52/TRIK_0800.",
 		"TextJPN": "「…彼は“会って”しまったのよ。………………オヤシロさまに」",
 		"NamesENG": "Rika",
-		"TextENG": "``...That man, he 'met' it. ..................Oyashiro-sama.``"
+		"TextENG": "``...He did meet him. ..................Oyashiro-sama, that is.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155991,
 		"TextJPN": "遠雷。@k@r雨の音。@k@r重苦しい沈黙。",
-		"TextENG": "Distant thunder.@k@rThe sound of rain.@k@rHeavy silence."
+		"TextENG": "Distant thunder.@k@rThe sound of rain.@k@rA heavy silence."
 	},
 	{
 		"type": "MSGSET",
@@ -510,7 +510,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0580.",
 		"TextJPN": "「森さんと加藤さんのことはご存知ですか？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Do you know Mori-san and Kato-san?``"
+		"TextENG": "``Did you know about Mori-san and Katou-san?``"
 	},
 	{
 		"type": "MSGSET",
@@ -519,7 +519,7 @@
 		"PreTextTags": "@vS26/55/TARA_0710.",
 		"TextJPN": "「知らないッ！　その二人の事は本当に知らない！　…加藤さんの事は本当に…聞いただけで……よくは知らないんですッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I don't know! I really don't know about those two! I truly only heard about Kato-san...... but I don't know much about it!``"
+		"TextENG": "``I don't! I really don't know about those two! ...I only just heard about... Katou-san...... so I really don't know!``"
 	},
 	{
 		"type": "MSGSET",
@@ -528,7 +528,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0590.",
 		"TextJPN": "「加藤さんは電車に飛び込み亡くなられました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Kato-san jumped into a train and died.``"
+		"TextENG": "``Katou-san leapt in front of a train at Nishi-Funabashi Station in Chiba Prefecture, and died.``"
 	},
 	{
 		"type": "MSGSET",
@@ -537,7 +537,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0600.",
 		"TextJPN": "「…飛び込む直前の彼の奇怪な行動を駅員が目撃していますが詳細はわかりません」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Just before his jump, a station attendant had witnessed his strange behavior, however I don't know the details.``"
+		"TextENG": "``...The station employees witnessed him demonstrating bizarre behavior right before jumping, but the details are unclear.``"
 	},
 	{
 		"type": "MSGSET",
@@ -555,7 +555,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0610.",
 		"TextJPN": "「森さんはどうです？　彼は職場でしたよね。あなたも出勤していたはずです」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``How about Mori-san? He was at your workplace. So you should have been there at work.``"
+		"TextENG": "``How about Mori-san? His was on site, wasn't it? You should have been working there too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -564,7 +564,7 @@
 		"PreTextTags": "@vS26/56/TTON_0550.",
 		"TextJPN": "「職場！？　…知らないぞ！　何の事だい！？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``The workplace!? ...I didn't know that! What happened!?``"
+		"TextENG": "``On site?! ...I didn't know about this! What happened?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -573,7 +573,7 @@
 		"PreTextTags": "@vS26/55/TARA_0730.",
 		"TextJPN": "「…知らないですッ！　私は食事に出掛けてた！　…帰って来たら…騒がしくなっていて……終わってたんですよ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...I don't know! I went out for a meal! ...And when I came back... it was noisy...... it was already over!``"
+		"TextENG": "``...I don't know! I had left to go eat! ...When I came back... there was a huge commotion...... but it was all over!``"
 	},
 	{
 		"type": "MSGSET",
@@ -582,7 +582,7 @@
 		"PreTextTags": "@vS26/55/TARA_0740.",
 		"TextJPN": "「私が帰って来た時にはもうッ！　…だから知らないッ！　何も知らないんですッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It was already over when I came back! Therefore I don't know! I don't know anything!``"
+		"TextENG": "``It was over by the time I got back! ...So I don't know! I don't know anything!``"
 	},
 	{
 		"type": "MSGSET",
@@ -591,7 +591,7 @@
 		"PreTextTags": "@vS26/56/TTON_0560.",
 		"TextJPN": "「初耳だよ！　…職場でそんな事があったら耳に入らないわけがない！」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``This is the first time I've heard of this! ...I should have heard if such a thing happened in our workplace!``"
+		"TextENG": "``This is my first time hearing about that! ...How could I not hear about this when it happened on site?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -600,7 +600,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0620.",
 		"TextJPN": "「…さすがに、森さんの時は４人目でしたからね。“特殊”な事情について事前に警察の上層部と話がついていたようで、現場検証等も全て秘密で行われました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...As I expected, Mori-san was the fourth person. I heard they talked with the highest ranks of the police in advance about 'special' circumstances. So all the on site investigations were probably performed in secret.``"
+		"TextENG": "``...Because by then, Mori-san was the fourth. Apparently, the upper management and the police had already come to an agreement beforehand regarding 'special circumstances', so everything, even inspection of the scene, was carried out in secret.``"
 	},
 	{
 		"type": "MSGSET",
@@ -609,7 +609,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0630.",
 		"TextJPN": "「……覚えていますか？　…ガス弁の交換中に事故があって騒ぎになった日があったのを」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Do you remember it? ...The day when there was an accident during the replacement of a gas value, it made such an uproar.``"
+		"TextENG": "``......Do you remember? ...There was a day where there was some commotion about an accident that happened while replacing gas valves.``"
 	},
 	{
 		"type": "MSGSET",
@@ -618,7 +618,7 @@
 		"PreTextTags": "@vS26/56/TTON_0570.",
 		"TextJPN": "「……そんな事もあったかな…。…工事業者と立ち会った職員がケガをして運び出されたって話で…。…騒然とした日があったような……」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``......Now that you mention it... ...Some employees got injured while observing the contractors and were carried out... ...That was such a turbulent day......``"
+		"TextENG": "``......I think I remember something like that... ...They said the construction worker and staff member that were there got injured and were carried off in an ambulance... ...That was a crazy day......``"
 	},
 	{
 		"type": "MSGSET",
@@ -627,7 +627,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0640.",
 		"TextJPN": "「無論、カバーストーリーです。事実は大きく異なります」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Of course, that was the cover story. The truth was very different.``"
+		"TextENG": "``Of course, that was just a cover story. The truth is vastly different.``"
 	},
 	{
 		"type": "MSGSET",
@@ -636,7 +636,7 @@
 		"PreTextTags": "@vS26/53/TMIO_0990.",
 		"TextJPN": "「…カバーストーリー？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Cover story?``"
+		"TextENG": "``...What do you mean?``"
 	},
 	{
 		"type": "MSGSET",
@@ -645,7 +645,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0810.",
 		"TextJPN": "「…嘘の話のことよ。…事実を隠す為の偽りの話」",
 		"NamesENG": "Rika",
-		"TextENG": "``...It was a false story. ...A false story created in order to hide the truth.``"
+		"TextENG": "``...They were lying. ...They used their authority to cover up the truth.``"
 	},
 	{
 		"type": "MSGSET",
@@ -654,7 +654,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0650.",
 		"TextJPN": "「…関係者の口が大変硬く、あまり詳しいことはよくわかりませんが、以下の事は確実です」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Getting anything from the mouth of those involved was extremely difficult, so I'm not sure about many of the details. However, the following can be confirmed.``"
+		"TextENG": "``...Those who were involved kept their lips very tight, so I don't know too many details myself, but this is the truth.``"
 	},
 	{
 		"type": "MSGSET",
@@ -663,7 +663,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0660.",
 		"TextJPN": "「…昼休みの終わり頃、席で寝ていた森さんは突然起き出し、千枚通しで隣の席の職員を襲いました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Towards the end of the lunch break, Mr. Mori, who had been asleep in his seat, suddenly woke up and attacked the staff members sitting next to him with an awl.``"
+		"TextENG": "``...Mori-san had been sleeping, and just as their lunch break was ending, he suddenly shot up and stabbed the staff member sitting next to him with an awl.``"
 	},
 	{
 		"type": "MSGSET",
@@ -672,7 +672,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0670.",
 		"TextJPN": "「そのまま３人の職員に襲いかかり…取り押さえられる前に、自分の喉を突き刺し、絶命しました。わずか１～２分間の事です」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``He attacked three members of staff... but before he was able to be subdued, he pierced his own throat, killing himself. It all happened in the time span of 1-2 minutes.``"
+		"TextENG": "``Then he continued to assault three other staff members... and before they managed to pin him down, he stabbed his own throat, ending his life. It all happened within a mere one or two minutes.``"
 	},
 	{
 		"type": "MSGSET",
@@ -681,13 +681,13 @@
 		"PreTextTags": "@vS26/55/TARA_0750.",
 		"TextJPN": "「だから僕は食事に出てたんだよッ！知らないんだよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I said I went out for a meal! So I don't know!``"
+		"TextENG": "``I told you, I had gone out to eat! So I don't know!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156012,
 		"TextJPN": "舞台、暗くなる。@k@r荒川にライトが当たる。@k@r荒川は千枚通しを持った森に追い詰められる所を回想している。",
-		"TextENG": "The stage becomes dark.@k@rLight shines on Arakawa.@k@rAs Arakawa recollects the time when@rhe was cornered with an awl."
+		"TextENG": "The stage goes dark.@k@rThe light centers on Arakawa.@k@rArakawa recalls the moment when he was cornered by Mori wielding an awl."
 	},
 	{
 		"type": "MSGSET",
@@ -696,7 +696,7 @@
 		"PreTextTags": "@vS26/55/TARA_0760.",
 		"TextJPN": "「やめて下さいよ森さんッ！　“い”ませんよッ！　誰も“い”ませんよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Mori-san, please stop! It doesn't 'exist'! Nothing 'exists'!``"
+		"TextENG": "``Please stop this, Mori-san! They're not there! No one is there!``"
 	},
 	{
 		"type": "MSGSET",
@@ -705,7 +705,7 @@
 		"PreTextTags": "@vS26/55/TARA_0770.",
 		"TextJPN": "「“いる”わけないじゃないですかッ！　“い”ないんですよッ！　落ち着いて下さいッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It can't 'exist'! It doesn't 'exist'! So please calm down!``"
+		"TextENG": "``There's no way they could be there! They don't exist! Please calm down!``"
 	},
 	{
 		"type": "MSGSET",
@@ -714,7 +714,7 @@
 		"PreTextTags": "@vS26/55/TARA_0780.",
 		"TextJPN": "「お伽話ですよ！　…“い”ないんだッ！　オヤシロさまなんて！　“い”ないんだぁあああぁッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It's just a fairy tale! ...It doesn't 'exist'... Oyashiro-sama doesn't exist! It doesn't 'exist'!!!``"
+		"TextENG": "``It's a fairy tale! ...They don't exist! Oyashiro-sama! Isn't reaaaaaaal!``"
 	},
 	{
 		"type": "MSGSET",
@@ -723,13 +723,13 @@
 		"PreTextTags": "@vS26/55/TARA_0790.",
 		"TextJPN": "「……お手洗い。……すみません。…もう一度、失礼します」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......I need the restroom. ......I'm sorry. ...Once again, excuse me.``"
+		"TextENG": "``......I'm using the bathroom. ......I'm sorry. ...Please excuse me again.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156017,
 		"TextJPN": "荒川、辛そうに退場する。@k@r…再び雨の音。",
-		"TextENG": "Arakawa leaves in a painful way.@k@r...And once again, the sound of the rain can be heard."
+		"TextENG": "Arakawa bitterly leaves the stage.@k@r...The sound of rain resumes."
 	},
 	{
 		"type": "MSGSET",
@@ -738,7 +738,7 @@
 		"PreTextTags": "@vS26/56/TTON_0580.",
 		"TextJPN": "「……知らなかった。……そんな事が…」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``......I didn't know. ......About such a thing...``"
+		"TextENG": "``......I never knew. ......That such things had...``"
 	},
 	{
 		"type": "MSGSET",
@@ -747,7 +747,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0680.",
 		"TextJPN": "「オヤシロさまの祟りの正体は判りません。…しかし間違いなくそれは実在します。そしてその謎を解く鍵はここ、雛見沢にあるはずなんです」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``We don't know the real identity of the curse of Oyashiro-sama. ...However, it definitely exists. And the key to solving those mysteries should be somewhere in Hinamizawa.``"
+		"TextENG": "``No one knows the true identity of Oyashiro-sama's curse. ...But it definitely exists somehow. And the key to unravelling that mystery... should be here in Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -756,7 +756,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0690.",
 		"TextJPN": "「……僕はね。…その何かを…調べに来たんですよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......So I... came to investigate this something.``"
+		"TextENG": "``......That's why. That's why I've come here. To find out what it is.``"
 	},
 	{
 		"type": "MSGSET",
@@ -774,7 +774,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0700.",
 		"TextJPN": "「え？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Eh?``"
+		"TextENG": "``Huh?``"
 	},
 	{
 		"type": "MSGSET",
@@ -783,7 +783,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0830.",
 		"TextJPN": "「………あなたも死ぬわ。……オヤシロさまの正体を探るなんて事そのものがオヤシロさまへの冒涜だもの」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........You will die as well. ......Exploring its identity is something considered a desecration to Oyashiro-sama.``"
+		"TextENG": "``.........You'll die too. ......The very act of trying to uncover Oyashiro-sama's true identity is blasphemy toward Oyashiro-sama.``"
 	},
 	{
 		"type": "MSGSET",
@@ -792,13 +792,13 @@
 		"PreTextTags": "@vS26/52/TRIK_0840.",
 		"TextJPN": "「……もしそれが雛見沢を訪れた理由なら、…………あなたも死ぬわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......If that's your reason for visiting Hinamizawa............ you too will die.``"
+		"TextENG": "``......If that's really why you've come to Hinamizawa............ then you'll die too.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156025,
 		"TextJPN": "重苦しい沈黙。吉村は答えない。",
-		"TextENG": "Heavy silence. Yoshimura doesn't answer."
+		"TextENG": "A heavy silence hangs between them. Yoshimura doesn't respond."
 	},
 	{
 		"type": "MSGSET",
@@ -807,7 +807,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0710.",
 		"TextJPN": "「…遅いねぇ。バス。……そろそろ来てもいい時間じゃないのかい？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Bus is late. ......This should be the time it arrives, shouldn't it?``"
+		"TextENG": "``...It's late. The bus. ......Isn't it about time for it to show up?``"
 	},
 	{
 		"type": "MSGSET",
@@ -816,13 +816,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1000.",
 		"TextJPN": "「…はは、…遅れてんじゃないすか？　………雨ですからー」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Ha ha... you honestly don't know why it's late? .........Because of the rain.``"
+		"TextENG": "``...Haha... it's probably delayed, right? .........Since it's raining.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156028,
 		"TextJPN": "雨の音と共に舞台、徐々に暗転。@k@rしばらくの沈黙。@k@r舞台は真っ暗のまま。無線の声が聞こえる。",
-		"TextENG": "The stage along with the sound of the rain@rgradually becomes dark.@k@rThere is now silence.@k@rThe stage remains completely dark.@rVoice from the radio can be heard."
+		"TextENG": "The sound of rain gradually fades out along with the lights.@k@rA moment of silence passes.@k@rThe stage remains pitch black. A voice plays over a radio."
 	},
 	{
 		"type": "MSGSET",
@@ -831,7 +831,7 @@
 		"PreTextTags": "@vS26/60/TODA_0010.",
 		"TextJPN": "「……偵察班より報告。…部外者が混じっています」",
 		"NamesENG": "Voice",
-		"TextENG": "``......According to the reconnaissance teams report. ...Some outsiders have mingled in.``"
+		"TextENG": "``......Recon team, reporting in. ...There's outsiders with them.``"
 	},
 	{
 		"type": "MSGSET",
@@ -840,6 +840,6 @@
 		"PreTextTags": "@vS26/61/THOT_0010.",
 		"TextJPN": "「……予定外です。…中止しますか？」",
 		"NamesENG": "Voice",
-		"TextENG": "``......This is unexpected. ...Should we cancel it?``"
+		"TextENG": "``......That's unexpected. ...Do we call it off?``"
 	}
 ]

--- a/bus_stop_4.json
+++ b/bus_stop_4.json
@@ -9,7 +9,7 @@
 		"type": "MSGSET",
 		"MessageID": 156031,
 		"TextJPN": "落雷の音。@k@r徐々に舞台明るくなる。@k@rどしゃぶりの音、遠くなっていく。@k@r荒川だけ依然トイレから戻らない。",
-		"TextENG": "The sound of lightning.@k@rThe stage gradually becomes brighter.@k@rThe sound of the downpour has now distanced itself.@k@rArakawa has still not returned from the restroom."
+		"TextENG": "The sound of thunder strikes.@k@rThe stage gradually grows brighter.@k@rThe sound of heavy rain fades into the distance.@k@rArakawa still hasn't returned from the bathroom yet."
 	},
 	{
 		"type": "MSGSET",
@@ -18,7 +18,7 @@
 		"PreTextTags": "@vS26/56/TTON_0590.",
 		"TextJPN": "「…遅いな。荒川君。………また調子でも悪くなったのかな…？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Arakawa-kun is late. .........I wonder if his condition has worsened...?``"
+		"TextENG": "``...He's taking a while. That Arakawa-kun. .........Maybe he's feeling sick again...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -27,7 +27,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0850.",
 		"TextJPN": "「……荒川さん、体調悪いの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Is Arakawa'san's condition bad?``"
+		"TextENG": "``......Arakawa-san's sick?``"
 	},
 	{
 		"type": "MSGSET",
@@ -36,7 +36,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1010.",
 		"TextJPN": "「あー、梨花さんいなかったんですよね。…さっき梨花さんがお手洗に行ってる時、頭ガンガンするって、のたうち回ってたんですよー」",
 		"NamesENG": "Mion",
-		"TextENG": "``Oh, you didn't see him before, Rika-san. ...A little while ago, when you were in the bathroom, Rika-san, his head was pounding, he writhed and was in a great deal of pain.``"
+		"TextENG": "``Ohh, you weren't there, were you? ...Earlier, while you were in the bathroom, he was squirming around, saying his head was throbbing.``"
 	},
 	{
 		"type": "MSGSET",
@@ -45,7 +45,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1020.",
 		"TextJPN": "「発作とか言ってましたけど。えーとえーと……@k@|@y@vS26/53/TMIO_1021.モウカリマッカ出血！」",
 		"NamesENG": "Mion",
-		"TextENG": "``He said it was a spasm attack. Well, umm......@k@|@y@vS26/53/TMIO_1021. It was a subarachnoid hemorrhage!``"
+		"TextENG": "``They said it was a sign of something. Uhh, uhh......@k@|@y@vS26/53/TMIO_1021. Supearninggud hemorrhaging'!``"
 	},
 	{
 		"type": "MSGSET",
@@ -54,7 +54,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0860.",
 		"TextJPN": "「クモ膜下出血…」",
 		"NamesENG": "Rika",
-		"TextENG": "``A subarachnoid hemorrhage...``"
+		"TextENG": "``Subarachnoid hemorrhaging...``"
 	},
 	{
 		"type": "MSGSET",
@@ -63,13 +63,13 @@
 		"PreTextTags": "@vS26/56/TTON_0600.",
 		"TextJPN": "「………ちょっと様子を見て来ます」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``.........I'll go check up on him.``"
+		"TextENG": "``.........I'm going to go check on him.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156038,
 		"TextJPN": "利根川退場。@k@rしばらくしてから梨花も立ち上がる。",
-		"TextENG": "Tonegawa leaves.@k@rRika stands up after a while."
+		"TextENG": "Tonegawa exits.@k@rRika also stands up after a moment."
 	},
 	{
 		"type": "MSGSET",
@@ -78,7 +78,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0870.",
 		"TextJPN": "「…頭痛に効く薬、持ってるのよ。……ちょっと私も行ってくるわね。…すぐ戻るから」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I have medicine effective against headaches with me, he can use it. ......I'll go after him. But I'll come back right away.``"
+		"TextENG": "``...I have some medicine that's good for headaches. ......So I'll go see him too. ...I'll be right back.``"
 	},
 	{
 		"type": "MSGSET",
@@ -87,13 +87,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1030.",
 		"TextJPN": "「あ、はい。…行ってらっしゃーい…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Oh, yes. ...See you soon...``"
+		"TextENG": "``Oh, sure. ...Take care...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156041,
 		"TextJPN": "取り残される魅音と吉村。@k@r雨の音と沈黙。@k@r魅音は軽い頭痛を終始気にしている。",
-		"TextENG": "Now only Mion and Yoshimura are left behind.@k@rTogether with silence and the sound of the rain.@k@rMion begins to caress her mild headache."
+		"TextENG": "Mion and Yoshimura are left behind.@k@rThere is silence and the sound of rain.@k@rMion is concerned with her light headache the entire time."
 	},
 	{
 		"type": "MSGSET",
@@ -102,7 +102,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1040.",
 		"TextJPN": "「……ふぁぁあ～…。……なんか眠くなって来ちゃったし…。何となく頭も痛いし。…私も風邪かなー…」",
 		"NamesENG": "Mion",
-		"TextENG": "``......*Yawn*... ......Somehow, I'm getting sleepy... And for some reason, my head hurts too. ...I wonder if I got cold...``"
+		"TextENG": "``......Faaaah~... ......I'm starting to feel kind of sleepy... My head kind of hurts too. ...Maybe I have a cold...``"
 	},
 	{
 		"type": "MSGSET",
@@ -111,7 +111,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0720.",
 		"TextJPN": "「…先日、東京観光に行ってね。…もっとも観光っていってもねずみーランドに遊びに行っただけなんだけど」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...The other day, I went sightseeing in Tokyo. ...And even though I was meant to sight-see, I only went to play in Mouse Land.``"
+		"TextENG": "``...I was sightseeing in Tokyo the other day. ...Though it was less sightseeing, and more like I went there to enjoy Mouse Land.``"
 	},
 	{
 		"type": "MSGSET",
@@ -120,7 +120,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1050.",
 		"TextJPN": "「え！？　…あ、そーなんですかぁ！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Eh!? ...Oh, is that so!?``"
+		"TextENG": "``Huh?! ...Oh, you did?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -129,7 +129,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1060.",
 		"TextJPN": "「…私も行ったんですよ東京観光ッ！　ねずみーランドに行きましたハイ！　…って言っても私もそこしか行ってないんですけどねぇ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...I've been to Tokyo for sightseeing, too! And I even went to Mouse Land! ...Although, that's the only place I went to play, too!``"
+		"TextENG": "``...I've been sightseeing in Tokyo too! I went to Mouse Land too, yeah! ...Though that's really the only place I went as well!``"
 	},
 	{
 		"type": "MSGSET",
@@ -138,7 +138,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0730.",
 		"TextJPN": "「ホテルシーサイド江戸海って所に泊まったんだよ。ランドの近くにある@bしょうしゃ.@<瀟洒@>なホテルでねぇ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``I stayed at a seaside hotel called Edo Umi. A simple and elegant hotel located in Kasai Coastal Park.``"
+		"TextENG": "``We stayed in a place called Hotel Seaside Edokai. It's an elegant hotel in Kasai Rinkai Park.``"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1070.",
 		"TextJPN": "「え！？　え！？　えーッ！？　ウチもですよ！　ウチもそこに泊まったんですよーッ！　すっごい偶然ーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Eh!? Eh!? Ehh!? Me too! My family stayed there as well! What a coincidence!``"
+		"TextENG": "``Huh?! Huh?! Huuh?! Me too! That's where I stayed too! What a coincidence!``"
 	},
 	{
 		"type": "MSGSET",
@@ -156,7 +156,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0740.",
 		"TextJPN": "「夜、公園の周りを散歩したんだが、すごいね。アベックの聖域だよ。独り者には肩身が狭いね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``At night, I took a walk around the park, and saw something amazing. It was a sanctuary for couples. It made me feel ashamed being single.``"
+		"TextENG": "``I took a walk around the park at night, and it was incredible. That place was a sacred ground for couples. I felt ashamed being there while single.``"
 	},
 	{
 		"type": "MSGSET",
@@ -165,7 +165,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1080.",
 		"TextJPN": "「あっはははははは！　同感同感ー！　私も思いましたー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah ha ha ha ha ha ha! I agree, I agree! I thought so, too!``"
+		"TextENG": "``Ahahahahahaha! Same, same! I thought so too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -174,7 +174,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0750.",
 		"TextJPN": "「食事も想像してたよりずっと素晴らしかった」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``The meal was also much greater than I had imagined.``"
+		"TextENG": "``The food was far more magnificent than I imagined it would be.``"
 	},
 	{
 		"type": "MSGSET",
@@ -183,7 +183,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0760.",
 		"TextJPN": "「でも両親に合わせて和食を選んだのは失敗だったね。…結局煮魚は口に合わず丸ごと残してしまった」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``But I made the mistake of choosing Japanese food to suit my parents. ...In the end, the boiled fish was not to my taste and I left the whole thing behind.``"
+		"TextENG": "``But I lost out, ordering the Japanese meal like my parents did. ...I didn't like the boiled fish at all, so I left the whole thing.``"
 	},
 	{
 		"type": "MSGSET",
@@ -192,7 +192,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1090.",
 		"TextJPN": "「あはははは！　吉村さんもですかー？　私もなんですよー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah ha ha ha ha ha! Yoshimura-san, too? It was the same for me!``"
+		"TextENG": "``Ahahahahaha! You too, Yoshimura-san? I did that too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -201,7 +201,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0770.",
 		"TextJPN": "「それで夜中、どうしてもお腹が空いて眠れないんだ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Then, in the middle of the night, I couldn't sleep at all since my stomach was empty.``"
+		"TextENG": "``That night I couldn't sleep because I was so hungry.``"
 	},
 	{
 		"type": "MSGSET",
@@ -210,7 +210,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0780.",
 		"TextJPN": "「仕方なくホテルを抜け出して、交番の近くにあったカップめんの自販機までやって来た。…ところが困った事に小銭がないんだよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``So I had no choice but to leave the hotel, and then I came to a vending machine of cup noodles that was near a koban. ...However, it unfortunately wouldn't accept small change.``"
+		"TextENG": "``I had no choice but to slip out of the hotel to buy some cup noodles from the vending machine near the police box. ...But to my chagrin, I didn't have any change.``"
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0790.",
 		"TextJPN": "「…あの時はひもじかったねぇ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...I was so hungry at that time.``"
+		"TextENG": "``...So, I was starving that night.``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,7 +228,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1100.",
 		"TextJPN": "「あっははははは！　吉村さんもですかー？　私もなんですよー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah ha ha ha ha ha! Yoshimura-san, too? It was the same for me!``"
+		"TextENG": "``Ahahahahaha! You too, Yoshimura-san? I did that too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -237,7 +237,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0800.",
 		"TextJPN": "「翌朝。お父さんに借りた携帯をポケットに入れたままトイレで用を足そうとしたら、うっかり便器に落としてしまって大変だ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``The following morning. I borrowed my dad's cellphone, put it in my pocket and went to the toilet, then I accidentally dropped it in the toilet.``"
+		"TextENG": "``The next morning I had the cell phone I borrowed from my father with me in my pocket when I went to do my business, and, well, I accidentally dropped it in the toilet.``"
 	},
 	{
 		"type": "MSGSET",
@@ -246,7 +246,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0810.",
 		"TextJPN": "「汚いのも構わず慌てて拾って、ドライヤーで乾かしたんだよな」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``I grabbed it in a hurry without minding it was dirty, and dried it with the dryer.``"
+		"TextENG": "``I panicked and pulled it out without regard for how filthy it was, and then I tried drying it off with the hair dryer.``"
 	},
 	{
 		"type": "MSGSET",
@@ -255,7 +255,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0820.",
 		"TextJPN": "「…お父さんには電池が切れたみたいだよって言って誤魔化したけど。駄目だったんだよね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...I lied to my dad and said the battery seemed to have run out. But it was useless.``"
+		"TextENG": "``...I tried to fool my father by saying the battery had died, but that didn't work.``"
 	},
 	{
 		"type": "MSGSET",
@@ -264,7 +264,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1110.",
 		"TextJPN": "「あはははは！　吉村さんもですかー？　私もなん、」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah ha ha ha ha! Yoshimura-san, too? It was the...``"
+		"TextENG": "``Ahahahahaha! You too, Yoshimura-san? I did that t--!``"
 	},
 	{
 		"type": "MSGSET",
@@ -273,7 +273,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0830.",
 		"TextJPN": "「ねずみーランドではとにかく色々なものに乗ったね。大はしゃぎだったよ。笑えるのはエリカは海賊ってヤツだ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``I got on a variety of rides in Mouse Land. What a romp. That Caliph of Pirates guy was hilarious.``"
+		"TextENG": "``I rode all kinds of rides at Mouse Land. I had a great time. I laughed the most on the pirate one.``"
 	},
 	{
 		"type": "MSGSET",
@@ -282,7 +282,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0840.",
 		"TextJPN": "「宝の山があったんでゴンドラから身を乗りだして触ろうとしたら放送で怒られただろ。ランドの人ってちゃんと見てるもんなんだよなぁ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Then there was a mountain of treasure, but I got shouted at by the broadcaster when I leaned out from the gondola and tried to touch it. The people in that amusement park watch you very strictly.``"
+		"TextENG": "``There was a mountain of treasure along the ride, so I leaned out of the gondola to try and touch it, but they yelled at me through the loudspeaker. The people working those theme parks sure watch carefully, don't they?``"
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1120.",
 		"TextJPN": "「あはははは！　吉村さんも…、」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah ha ha ha ha! Yoshimura-san...``"
+		"TextENG": "``Ahahahahaha! You too, Yoshimu--``"
 	},
 	{
 		"type": "MSGSET",
@@ -300,7 +300,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0850.",
 		"TextJPN": "「閉園時間ぎりぎりまで遊び倒したよね。閉園時間ぎりぎりで、アイスクリーム屋さんに飛び込んで、お母さんにラムレーズンをねだったんだ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``I used all of energy to play until very last moment before closing time. But just before closing time, I jumped into an ice cream shop in the nick of time and begged my mom for a rum raisin.``"
+		"TextENG": "``You played as much as you could all the way up to the park's closing time, didn't you? Then right before the park closed, you stormed into an ice cream shop and begged your mother to buy you rum raisin.``"
 	},
 	{
 		"type": "MSGSET",
@@ -309,7 +309,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0860.",
 		"TextJPN": "「ボタボタ垂らしながら食べてるとそれをじっと見ている清掃のお兄さんがいたよね。手を振ったらプイと横を向かれたんでムッとしたっけ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Then I saw a young man who was cleaning, stare at me while I ate as it started dripping. You waved your hand at him but he turned away, I guess he was annoyed.``"
+		"TextENG": "``There was this one man cleaning the park who was looking on as it kept dripping while you ate it. You waved at him, so he turned away from you, and I think you got upset.``"
 	},
 	{
 		"type": "MSGSET",
@@ -318,7 +318,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0870.",
 		"TextJPN": "「…それで目線を戻したら、自分のスカートに垂らし放題。…これじゃ電車にも乗れないって大泣きしたんだっけ…？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Then when you looked back, it was all over your skirt. Because of that, you cried very much and assumed you couldn't get on the train, right...?``"
+		"TextENG": "``...Then when you looked back, it was dripping all over your skirt. ...You cried real hard, saying that you couldn't get on the train like that, right...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -327,7 +327,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1130.",
 		"TextJPN": "「はは、ははは……、」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ha ha, ha ha ha......``"
+		"TextENG": "``Haha, hahaha......``"
 	},
 	{
 		"type": "MSGSET",
@@ -336,7 +336,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0880.",
 		"TextJPN": "「大はしゃぎが祟ったのか、翌朝はものすごい頭痛に悩まされた。頭痛薬を飲んだがその場凌ぎにしかならない」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``However, it seems that romp had severe consequences, because the next morning, you were plagued by a terrible headache. You took painkillers, but that only patched things up for the moment.``"
+		"TextENG": "``Maybe carrying on so much came back to bite you, but you suffered a really bad headache the next morning. You took some medicine, but that was only a temporary relief.``"
 	},
 	{
 		"type": "MSGSET",
@@ -345,7 +345,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0890.",
 		"TextJPN": "「…お父さんとお母さんは考えた挙げ句、予定を繰り上げて帰ることにしたんだよな」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...So after thinking it over, your mom and dad decided to return home ahead of schedule.``"
+		"TextENG": "``...After your father and mother thought it over, they decided to move their plans forward and go home after that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0900.",
 		"TextJPN": "「頭痛でふらふらなのに君、泣きながら訴えたんだ。こんな頭痛すぐ治るからって。でも我が子が可愛い両親は帰る事に決めてしまった」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``And even though you were lightheaded from your headache, you still made an appeal while crying. But your parents who loved their cute child decided to go home.``"
+		"TextENG": "``You were unsteady on your feet from the headache, but you cried and pleaded with them. You said the headache would go away soon. But your parents decided to go home, because they treasured their daughter.``"
 	},
 	{
 		"type": "MSGSET",
@@ -363,7 +363,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0910.",
 		"TextJPN": "「…今でも心残りだろ。東京観光は」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Even now, you still regret it. Sightseeing in Tokyo.``"
+		"TextENG": "``...You still regret that, don't you? From the time you went sightseeing in Tokyo.``"
 	},
 	{
 		"type": "MSGSET",
@@ -372,13 +372,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1140.",
 		"TextJPN": "「…え……えぇ………そりゃあ………………………」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Eh...... Ehh......... Yeah...........................``"
+		"TextENG": "``...Huh? ......Yeah. .........Sure.............................``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156073,
 		"TextJPN": "遠雷。雨の音。長い沈黙。魅音の顔は笑顔を装いながらも青白い。カタカタ震える肩。",
-		"TextENG": "Distant thunder.@rThe sound of the rain.@rA long silence.@rMion's face is pale, she pretends to smile.@rHer shoulder rattles trembly."
+		"TextENG": "Thunder rings in the distance. The sound of rain continues. A long silence passes between them. Mion is pretending to smile, but her face is pale. Her shoulders are shuddering."
 	},
 	{
 		"type": "MSGSET",
@@ -387,7 +387,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0920.",
 		"TextJPN": "「……君、ダムは賛成派だよな。立ち退き料で東京へ引っ越してくれないかと期待してる」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......You agree with the dam. So you're expecting the compensation for eviction so you can move to Tokyo.``"
+		"TextENG": "``......You're in favor of the dam, right? You're hoping that you'll be able to move to Tokyo with the compensation money.``"
 	},
 	{
 		"type": "MSGSET",
@@ -396,7 +396,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0930.",
 		"TextJPN": "「…でも両親の仕事の関係で引っ越し先は市内になりそうだ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...But moving to a new address in the city concerns your parents and their jobs.``"
+		"TextENG": "``...But due to your parents' work, you're likely to move to the local city.``"
 	},
 	{
 		"type": "MSGSET",
@@ -405,7 +405,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0940.",
 		"TextJPN": "「…でも妥協点だよな。少なくとも雛見沢よりはよっぽど都会だ。…“消防団”より高い建物なんかいくらでもある」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...But it is a compromise. As life in the city will be much better than Hinamizawa. ...And there are plenty of tall buildings there than just one 'volunteer fire department'.``"
+		"TextENG": "``...But you can make that compromise. Because it's still far more metropolitan than Hinamizawa, at the very least. ...There's plenty of buildings taller than the fire department there.``"
 	},
 	{
 		"type": "MSGSET",
@@ -414,7 +414,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1150.",
 		"TextJPN": "「…………なん…で…………そんなこと…まで…知ってんですか…………」",
 		"NamesENG": "Mion",
-		"TextENG": "``............Wh-Why............ do you... know... that much............``"
+		"TextENG": "``............How... do you know... all... of that............?``"
 	},
 	{
 		"type": "MSGSET",
@@ -423,7 +423,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0950.",
 		"TextJPN": "「君は魂を東京に置いて来てしまったんだよ。…もう心は雛見沢にない。………まずいんじゃあないかな。…そういうのって」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``You've put your soul into Tokyo already. ...Your heart's no longer in Hinamizawa. .........I wonder... if that's a bad thing.``"
+		"TextENG": "``You left your soul back in Tokyo. ...Your heart's not here in Hinamizawa anymore. ............That's bad for you, isn't it? ...Being like that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -432,7 +432,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1160.",
 		"TextJPN": "「…ま、……まずいって、………、」",
 		"NamesENG": "Mion",
-		"TextENG": "``...B-Bad.........?``"
+		"TextENG": "``...Bad...... bad how............?``"
 	},
 	{
 		"type": "MSGSET",
@@ -441,7 +441,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0960.",
 		"TextJPN": "「……オヤシロさまだよ。……オヤシロさまは雛見沢を捨てて出て行こうとする人を祟るんだぜ？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......It's Oyashiro-sama. ......Oyashiro-sama will curse anyone who intends to leave and abandon Hinamizawa, right?``"
+		"TextENG": "``......Because of Oyashiro-sama. ......Oyashiro-sama curses those who try to abandon Hinamizawa, you know.``"
 	},
 	{
 		"type": "MSGSET",
@@ -450,13 +450,13 @@
 		"PreTextTags": "@vS26/54/TYOS_0970.",
 		"TextJPN": "「……俺がもしそのオヤシロさまだったら、……君はアウトだと思うけどねぇ…。……どう思う？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Suppose, I were Oyashiro-sama. ......I'd think you were one of them... ......What you think?``"
+		"TextENG": "``......If I were this Oyashiro-sama...... then you'd be out, in my mind... ......What do you think?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156082,
 		"TextJPN": "魅音、カタカタと小さく震えながら後退る。",
-		"TextENG": "Mion edges back and begins to tremble."
+		"TextENG": "Mion steps back, shuddering a little."
 	},
 	{
 		"type": "MSGSET",
@@ -465,7 +465,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0980.",
 		"TextJPN": "「…小さい頃から、信じちゃうタチなんだよね。……童話でもお伽話でも、怪談でもそう」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Since you were small, you've been the type to believe in them. ......Whether it be a fairy tale, nursery tale, or even a ghost story.``"
+		"TextENG": "``...I've always been the type who believes in them, ever since I was little. ......I believe in fairy tales, nursery rhymes, and even ghost stories.``"
 	},
 	{
 		"type": "MSGSET",
@@ -474,7 +474,7 @@
 		"PreTextTags": "@vS26/54/TYOS_0990.",
 		"TextJPN": "「…作り話だと判っちゃいるのに…信じちゃうんだよなぁ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Even though you know they're made up... you believe in them anyway.``"
+		"TextENG": "``...I know they're all made up... but I still believe in them.``"
 	},
 	{
 		"type": "MSGSET",
@@ -483,7 +483,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1000.",
 		"TextJPN": "「…東京で頭痛を患って以来。……オヤシロさまの話、……聞き流せないんだよねぇ…」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Ever since you had a headache in Tokyo....... You can't listen to Oyashiro-sama..... His story...``"
+		"TextENG": "``...Ever since you suffered that headache in Tokyo... you haven't been able to brush off your worries about Oyashiro-sama, have you...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -492,7 +492,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1010.",
 		"TextJPN": "「……作り話と判っちゃいるのに、…ねぇ…」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Even though you know they're just made up stories... right...``"
+		"TextENG": "``......Even though you know they're made-up stories... right...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -501,7 +501,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1170.",
 		"TextJPN": "「…あ………あ、……あんた…………誰…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Wh-Wh-Who are............ you...``"
+		"TextENG": "``...Wh......... Wh...... Who............ are you...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -510,7 +510,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1020.",
 		"TextJPN": "「僕？　…僕かい？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Me? ...Me you ask?``"
+		"TextENG": "``Me? ...Who am I?``"
 	},
 	{
 		"type": "MSGSET",
@@ -519,13 +519,13 @@
 		"PreTextTags": "@vS26/54/TYOS_1030.",
 		"TextJPN": "「………くっくっく、はっはっは！　あーっはっはっはっはッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``.........Hee hee hee hee, ha ha ha ha! Ahh ha ha ha ha ha!``"
+		"TextENG": "``............Kukuku, hahaha! Ahahahaha!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156090,
 		"TextJPN": "狂ったように笑い転げる吉村。異様な状況に魅音、立ち尽くす。",
-		"TextENG": "Yoshimura stumbles about laughing madly. Mion in this strange situation remains still."
+		"TextENG": "Yoshimura begins to laugh like crazy. Mion stands there dumbstruck by his bizarre state."
 	},
 	{
 		"type": "MSGSET",
@@ -534,19 +534,19 @@
 		"PreTextTags": "@vS26/54/TYOS_1040.",
 		"TextJPN": "「……さっきも言ったろ？　吉村さ。…フリーライターの吉村だよ。……フリーターの親戚じゃあないんだぜ？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Didn't I already say a while ago? I’m Yoshimura. Yoshimura the freelance writer. ......It's relative to part-time worker, right?``"
+		"TextENG": "``......I told you earlier, didn't I? I'm Yoshimura. ...Yoshimura, the freelance writer. ......And not just some freeloader.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156092,
 		"TextJPN": "大きな雷鳴。土砂降りの雨の音と共に暗転。@rしばらくの沈黙。",
-		"TextENG": "A large thunder.@rThe surroundings turns dark alongside@rthe growing sound of the pouring rain.@rSilence."
+		"TextENG": "Thunder violently roars. The scene goes dark with the sound of a heavy downpour.@rA moment of silence passes."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156093,
 		"TextJPN": "舞台は真っ暗のまま。無線の声が聞こえる。",
-		"TextENG": "The stage remains dark.@rThe voice from a radio is heard."
+		"TextENG": "The stage remains dark. A voice plays over the radio."
 	},
 	{
 		"type": "MSGSET",
@@ -555,13 +555,13 @@
 		"PreTextTags": "@vS26/57/TNIT_0000.",
 		"TextJPN": "「…本部より全車へ。……部外者混入につき作戦開始時刻を延期。全車は即応態勢で待機。…油断するな。どう出てくるかわからんぞ」",
 		"NamesENG": "Voice",
-		"TextENG": "``...Headquarters calling all cars. ......On the account of outsider mingling, we are postponing the starting time of all operations. All cars are to wait on standby, prepare for any situation. ...Don't be careless. We don't know what will come out.``"
+		"TextENG": "``...HQ to all cars. ......Due to the involvement of outsiders, commencement of the operation is postponed. All cars go to standby. Be ready to move immediately. ...Remain vigilant. We do not know how this will go.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156095,
 		"TextJPN": "落雷の音。徐々に舞台明るくなる。@rどしゃぶりの音、遠くなっていく。@r５人全員ベンチに座っている。",
-		"TextENG": "The sound of lightning.@rThe stage gradually becomes brighter.@rThe sound of the downpour has now distanced itself.@rAll five people are sitting on the bench."
+		"TextENG": "Thunder booms out again. The stage steadily grows lighter. The sound of pouring rain fades into the distance. All five people are sitting on the bench."
 	},
 	{
 		"type": "MSGSET",
@@ -570,7 +570,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0880.",
 		"TextJPN": "「……どう？　…薬、効いてきた？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......How about it? ...Did the medicine work?``"
+		"TextENG": "``......Well? ...Is the medicine working?``"
 	},
 	{
 		"type": "MSGSET",
@@ -579,7 +579,7 @@
 		"PreTextTags": "@vS26/55/TARA_0800.",
 		"TextJPN": "「…すみません。……もうだいぶ楽になりました。ありがとうございます」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...I'm sorry. ......I feel alot better. Thank you.``"
+		"TextENG": "``...I'm sorry. ......I feel much better now. Thank you very much.``"
 	},
 	{
 		"type": "MSGSET",
@@ -588,7 +588,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0890.",
 		"TextJPN": "「……効いた？　……そう」",
 		"NamesENG": "Rika",
-		"TextENG": "``......It worked? ......Good.``"
+		"TextENG": "``......It worked? ......Okay.``"
 	},
 	{
 		"type": "MSGSET",
@@ -597,7 +597,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1180.",
 		"TextJPN": "「梨花さん、私にももらえませんか。頭痛の薬。…私もちょっと…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Rika-san, can I have some, too? Medicine for my headache I mean. ...I just feel a little...``"
+		"TextENG": "``Rika-san, could I have some too? Of that headache medicine, I mean. ...Mine's a bit...``"
 	},
 	{
 		"type": "MSGSET",
@@ -606,7 +606,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0900.",
 		"TextJPN": "「……痛むの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Does your head ache, too?``"
+		"TextENG": "``......Your head is hurting too?``"
 	},
 	{
 		"type": "MSGSET",
@@ -615,7 +615,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1190.",
 		"TextJPN": "「いえ、今はいいんですけどね。さっきものすごーく痛かったんですよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``No, I'm fine now. But it hurt alot a little while ago.``"
+		"TextENG": "``No, it's fine right now. Though it really hurt earlier.``"
 	},
 	{
 		"type": "MSGSET",
@@ -624,7 +624,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1050.",
 		"TextJPN": "「俺もってるぜ。やろうか」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``I have one. If you want.``"
+		"TextENG": "``I have some medicine. Want it?``"
 	},
 	{
 		"type": "MSGSET",
@@ -633,13 +633,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1200.",
 		"TextJPN": "「け、結構ですッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``N-No thanks!``"
+		"TextENG": "``I-I'm fine!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156104,
 		"TextJPN": "過剰な反応を示して拒否する魅音。吉村と利根川・荒川、異様な反応にちょっと驚く。",
-		"TextENG": "Mion shows an excessive reaction and refuses.@rTonegawa and Arakawa are surprised@rat her strange reaction to Yoshimura."
+		"TextENG": "Mion refuses with an excessive response. Yoshimura, Tonegawa, and Arakawa are all a bit surprised by her odd reaction."
 	},
 	{
 		"type": "MSGSET",
@@ -648,7 +648,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1060.",
 		"TextJPN": "「……そ、…そうかい。……ならいいんだ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......I-Is that so. ......Well then, that's okay.``"
+		"TextENG": "``......I ...I see. ......Alright then.``"
 	},
 	{
 		"type": "MSGSET",
@@ -657,7 +657,7 @@
 		"PreTextTags": "@vS26/56/TTON_0610.",
 		"TextJPN": "「それにしても、…バスが来ないですね。もう来る時間だと思うんですけど」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Still... the bus hasn't come yet. And I think it's past its arrival time already.``"
+		"TextENG": "``Still... that bus sure isn't coming, is it? It should be here by now, though.``"
 	},
 	{
 		"type": "MSGSET",
@@ -666,13 +666,13 @@
 		"PreTextTags": "@vS26/52/TRIK_0910.",
 		"TextJPN": "「…雨だからね…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Because of the rain...``"
+		"TextENG": "``...It is raining out, after all...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156108,
 		"TextJPN": "しばらくの沈黙と雨の音。そこへ刑事２人（@bほしの.@<星野@>・@bおかの.@<岡野@>）登場。",
-		"TextENG": "While everyone sits in silence with the sound@rof the rain. Two detectives (Hoshino@rand Okano) appear."
+		"TextENG": "There's a moment of silence accompanied by the sound of rain. Then two detectives (Hoshino and Okano) enter."
 	},
 	{
 		"type": "MSGSET",
@@ -681,7 +681,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1210.",
 		"TextJPN": "「…また来ましたよ。人。………なんで今日はこんなにいっぱい来るんですかね。……いつもは誰もいないのに」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Someone's coming. It's some people. .........Why would they come now. ......There's been nobody else so far.``"
+		"TextENG": "``...There's more again. More people. .........Why are there so many people coming here today, of all days? ......There's usually no one here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -690,7 +690,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0920.",
 		"TextJPN": "「…雨だからね…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Because of the rain...``"
+		"TextENG": "``...Because it's raining out...``"
 	},
 	{
 		"type": "MSGSET",
@@ -699,7 +699,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0000.",
 		"TextJPN": "「こんにちは。…皆さんはバスをお待ちですか？」",
 		"NamesENG": "Okano",
-		"TextENG": "``Hi there. ...Is everybody waiting for the bus?``"
+		"TextENG": "``Good afternoon. ...Are all of you waiting for the bus?``"
 	},
 	{
 		"type": "MSGSET",
@@ -708,7 +708,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1070.",
 		"TextJPN": "「…えぇ。そろそろ来ると思うんですがね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Yeah. I think it'll come soon.``"
+		"TextENG": "``...Yes. It should be here soon, though.``"
 	},
 	{
 		"type": "MSGSET",
@@ -717,7 +717,7 @@
 		"PreTextTags": "@vS26/58/THOS_0000.",
 		"TextJPN": "「バスは来ません」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``The bus won't come.``"
+		"TextENG": "``The bus isn't coming.``"
 	},
 	{
 		"type": "MSGSET",
@@ -726,7 +726,7 @@
 		"PreTextTags": "@vS26/56/TTON_0620.",
 		"TextJPN": "「え、…それはどういう、」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Eh... what does that mean?``"
+		"TextENG": "``Huh?! ...What do you mean by that?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -735,7 +735,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0010.",
 		"TextJPN": "「どうか冷静にお願いします。…私どもは警察です。ある事件により近辺を捜査中です。皆さんのご協力をお願いします」",
 		"NamesENG": "Okano",
-		"TextENG": "``I would like you all to act calmly. ...We're the police. There was an incident, so we are currently investigating this neighborhood. I would like you all to co-operate.``"
+		"TextENG": "``Please listen calmly. ...We're with the police. We're currently investigating the area around here in regards to a case. We'd like it if you all would cooperate with us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -744,7 +744,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1220.",
 		"TextJPN": "「事件って、」",
 		"NamesENG": "Mion",
-		"TextENG": "``An incident?``"
+		"TextENG": "``A case?``"
 	},
 	{
 		"type": "MSGSET",
@@ -753,7 +753,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1080.",
 		"TextJPN": "「何ですか。何かあったんですか！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``What is it? Did something happen!?``"
+		"TextENG": "``What is it? What's happened?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -762,7 +762,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0020.",
 		"TextJPN": "「ですからどうぞ冷静にお願いします。……昼前に市内で起こった通り魔殺人の犯人がこの近辺に潜伏していると思われます」",
 		"NamesENG": "Okano",
-		"TextENG": "``Please calm down. ......It happened in town before noon, so it is thought that the criminal who committed the street murder is hiding somewhere in this vicinity.``"
+		"TextENG": "``Like we said, please remain calm. ......We believe the culprit behind a slashing that took place in the city this afternoon is hiding out in this location.``"
 	},
 	{
 		"type": "MSGSET",
@@ -771,7 +771,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0030.",
 		"TextJPN": "「…現在この地域は非常線で封鎖されています。ですからバスは来ません」",
 		"NamesENG": "Okano",
-		"TextENG": "``At present, the area has been sealed off with a cordon. Therefore, the bus can't come here.``"
+		"TextENG": "``...So at present, this area is being cordoned off. That's why the bus won't be coming.``"
 	},
 	{
 		"type": "MSGSET",
@@ -780,7 +780,7 @@
 		"PreTextTags": "@vS26/55/TARA_0810.",
 		"TextJPN": "「通り魔殺人！？」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``A street murder!?``"
+		"TextENG": "``A slasher?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -789,7 +789,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1230.",
 		"TextJPN": "「変質者！？　麻薬中毒者！？　…もー…勘弁して下さいよぅ…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Degenerate!? A drug addict!? ...Oh please... give me a break...``"
+		"TextENG": "``Some degenerate?! A drug addict?! ...Please... cut us a break already...``"
 	},
 	{
 		"type": "MSGSET",
@@ -798,7 +798,7 @@
 		"PreTextTags": "@vS26/56/TTON_0630.",
 		"TextJPN": "「な、何人も殺されてるんですか？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``H-How many people have been killed?``"
+		"TextENG": "``H-How many people were killed?``"
 	},
 	{
 		"type": "MSGSET",
@@ -807,7 +807,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0040.",
 		"TextJPN": "「…詳しい事は申し上げられませんが、すでに何人かが犠牲になっています」",
 		"NamesENG": "Okano",
-		"TextENG": "``...We can't talk about the details, but there have already been several victims.``"
+		"TextENG": "``...I cannot provide any details, but there have already been several victims.``"
 	},
 	{
 		"type": "MSGSET",
@@ -816,7 +816,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1090.",
 		"TextJPN": "「犯人は？　…性別は？　年齢は？　…どんなヤツなんです？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Who is the criminal? ...The gender? The age? ...What kind of person did it?``"
+		"TextENG": "``And the culprit? ...Their gender? Their age? ...What are they like?``"
 	},
 	{
 		"type": "MSGSET",
@@ -825,7 +825,7 @@
 		"PreTextTags": "@vS26/58/THOS_0010.",
 		"TextJPN": "「…ご職業は推理作家ですか？　…身分証を拝見します」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...Is your occupation a mystery writer? ...May I see your ID card?``"
+		"TextENG": "``...Do you write mysteries for a living, or something? ...I'd like to see your ID.``"
 	},
 	{
 		"type": "MSGSET",
@@ -834,7 +834,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1100.",
 		"TextJPN": "「…あー、…名刺じゃ駄目ですか？　…吉村って言います。職業はフリーライターです」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Oh... is a business card okay? ...My name's Yoshimura. My occupation's a freelance writer.``"
+		"TextENG": "``...Uhh... does my business card work? ...I'm Yoshimura. I'm a freelance writer.``"
 	},
 	{
 		"type": "MSGSET",
@@ -843,7 +843,7 @@
 		"PreTextTags": "@vS26/58/THOS_0020.",
 		"TextJPN": "「…顔写真の付いたものはありませんか？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...Don't you have anything with a photograph of your face?``"
+		"TextENG": "``...Do you have anything with your photo on it?``"
 	},
 	{
 		"type": "MSGSET",
@@ -852,7 +852,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1110.",
 		"TextJPN": "「あー……生憎…」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Oh...... unfortunately not...``"
+		"TextENG": "``Ohh...... unfortunately not...``"
 	},
 	{
 		"type": "MSGSET",
@@ -861,7 +861,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0050.",
 		"TextJPN": "「そちらのお二人は」",
 		"NamesENG": "Okano",
-		"TextENG": "``Now, onto you two.``"
+		"TextENG": "``What about you two?``"
 	},
 	{
 		"type": "MSGSET",
@@ -870,7 +870,7 @@
 		"PreTextTags": "@vS26/56/TTON_0640.",
 		"TextJPN": "「建設省の者です。職員証も免許証もあります」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``We're from the Ministry of Construction. We both have our staff identification and driver's licenses.``"
+		"TextENG": "``We're with the Ministry of Construction. Here's our licenses and employee IDs.``"
 	},
 	{
 		"type": "MSGSET",
@@ -879,7 +879,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0060.",
 		"TextJPN": "「どうも。お仕事ご苦労さまです」",
 		"NamesENG": "Okano",
-		"TextENG": "``Thank you. I appreciate your hard work.``"
+		"TextENG": "``Thank you. We appreciate all your hard work.``"
 	},
 	{
 		"type": "MSGSET",
@@ -888,7 +888,7 @@
 		"PreTextTags": "@vS26/58/THOS_0030.",
 		"TextJPN": "「そっちの二人は？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``Who are you two?``"
+		"TextENG": "``And what about you two?``"
 	},
 	{
 		"type": "MSGSET",
@@ -897,7 +897,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1240.",
 		"TextJPN": "「え？　…へへぇー……！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Eh? ...Heh heh......!``"
+		"TextENG": "``Huh? ...Hehee......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -906,7 +906,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1120.",
 		"TextJPN": "「犯人はどんなヤツなんですか！　ひょっとすると誰か見ているかも知れない」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``What kind of person is the criminal! Possibly someone may have saw him.``"
+		"TextENG": "``So what was the culprit like?! Maybe one of us has seen him.``"
 	},
 	{
 		"type": "MSGSET",
@@ -915,7 +915,7 @@
 		"PreTextTags": "@vS26/55/TARA_0820.",
 		"TextJPN": "「え、えぇ！　…そうですよ！　教えて下さい！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``E-Eh! ...He's right! Please tell us!``"
+		"TextENG": "``Y-Yes! ...That's right! Please tell us!``"
 	},
 	{
 		"type": "MSGSET",
@@ -924,13 +924,13 @@
 		"PreTextTags": "@vS26/59/TOKA_0070.",
 		"TextJPN": "「…情報が不足していますので確実ではありませんが。…犯人は二人組の可能性が高い！」",
 		"NamesENG": "Okano",
-		"TextENG": "``...I'm not certain, since we're short on information. ...But the criminal is most likely one of the duo's here!``"
+		"TextENG": "``...There's not enough information right now, so we can't be certain. ...However, there's a high chance it was done by two people!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156137,
 		"TextJPN": "吉村、立ち上がって建設省の２人と魅音・梨花を見比べる。",
-		"TextENG": "Yoshimura stands up and compares Mion and Rika@rwith the two men from the Ministry of Construction."
+		"TextENG": "Yoshimura stands up and looks over the two Ministry men and then Mion and Rika."
 	},
 	{
 		"type": "MSGSET",
@@ -939,13 +939,13 @@
 		"PreTextTags": "@vS26/59/TOKA_0080.",
 		"TextJPN": "「…もちろん誤解で単独犯の可能性もあります。……性別は…男性である可能性が高い！」",
 		"NamesENG": "Okano",
-		"TextENG": "``...Of course, it's also possible this is a misunderstanding and the criminal is working alone. ......And the gender... is more likely to be male!``"
+		"TextENG": "``...Of course we could be mistaken. There's also a chance they were acting alone. ...As for gender... there's a high chance they were male.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156139,
 		"TextJPN": "魅音、立ち上がって建設省の２人と吉村を見比べる。吉村は建設省の２人を疑う。たじろぐ２人。",
-		"TextENG": "Mion stands up and compares Yoshimura@rwith the two men from the Ministry of Construction.@rYoshimura doubts the two men from@rthe Ministry of Construction. The two men shiver."
+		"TextENG": "Mion stands up and looks over the two Ministry men, and then at Yoshimura. Yoshimura eyes the two Ministry men suspiciously. They both wince."
 	},
 	{
 		"type": "MSGSET",
@@ -954,7 +954,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0090.",
 		"TextJPN": "「…目撃が曖昧なので女性の可能性も否定できません。…ま、…建設省のお二人は身元が確かなので問題ないでしょう。アリバイも調べやすい」",
 		"NamesENG": "Okano",
-		"TextENG": "``...But, since the witness was very vague, I cannot deny the possibility that it is a woman. ...Well... since we can identify them, it seems the two men from the Ministry of Construction won't be a problem. It's easy to check out their alibis.``"
+		"TextENG": "``...Witness accounts were vague, so we can't rule out the possibility it was done by a woman. ...Well... these two from the Ministry certainly are who they say they are, so there's no problems there. It'll be easy to confirm their alibis too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -963,7 +963,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1130.",
 		"TextJPN": "「つまり、犯人はどんなヤツなのかまったく見当がつかない、って事ですか？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``In other words, you have no idea what kind of person the criminal is, or even if it's one of us, right?``"
+		"TextENG": "``In other words, you have absolutely no idea who the culprit might be, is that right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -972,6 +972,6 @@
 		"PreTextTags": "@vS26/58/THOS_0040.",
 		"TextJPN": "「詳しく申し上げられないだけです。…皆さんの中に被疑者がいるかも知れませんから」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``It wasn't expressed in detail. ...So it seems we'll have to suspect everyone here.``"
+		"TextENG": "``We simply can't offer any specific details. ...After all, the suspect might be one of you all.``"
 	}
 ]

--- a/bus_stop_5.json
+++ b/bus_stop_5.json
@@ -12,7 +12,7 @@
 		"PreTextTags": "@vS26/58/THOS_0050.",
 		"TextJPN": "「…で？　…君たちの身分証は？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...So? ...Where are your IDs?``"
+		"TextENG": "``...So? ...What about your IDs?``"
 	},
 	{
 		"type": "MSGSET",
@@ -21,7 +21,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1250.",
 		"TextJPN": "「はは、は！　…郵便局のカードじゃーだめですかねぇ…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ha ha, ha! ...I'm guessing my post office card won't be of any use, right...?``"
+		"TextENG": "``Haha, ha! ...Does a post office card work...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -30,7 +30,7 @@
 		"PreTextTags": "@vS26/58/THOS_0060.",
 		"TextJPN": "「…君たち学生ね？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...Are you students?``"
+		"TextENG": "``...You two are students, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -39,7 +39,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1260.",
 		"TextJPN": "「刑事さん、私ゃ思うに、あの吉村ってオッサンが怪しいと思うんですよ…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ms. detective, I think that old man Yoshimura is suspicious...``"
+		"TextENG": "``Detective, I think that man Yoshimura there is suspicious...``"
 	},
 	{
 		"type": "MSGSET",
@@ -48,7 +48,7 @@
 		"PreTextTags": "@vS26/58/THOS_0070.",
 		"TextJPN": "「…今日は平日だけど学校はどうしたの？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...It's a weekday today. What happened to school?``"
+		"TextENG": "``...Today's a weekday, right? Why aren't you in school? Hmm?``"
 	},
 	{
 		"type": "MSGSET",
@@ -57,7 +57,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1270.",
 		"TextJPN": "「いやー、えへへへ！　…そのー…開校記念日でー…！」",
 		"NamesENG": "Mion",
-		"TextENG": "``No, eh heh heh heh! ...Umm... it's the school's opening anniversary...!``"
+		"TextENG": "``Well, ehehehe! ...Umm... today's the anniversary of our school's founding...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -66,7 +66,7 @@
 		"PreTextTags": "@vS26/58/THOS_0080.",
 		"TextJPN": "「…ちょっと向こうで話を聞かせてもらっていい？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...May I hear a little more of your story?``"
+		"TextENG": "``...Do you mind if we talk to them for a bit?``"
 	},
 	{
 		"type": "MSGSET",
@@ -75,7 +75,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1280.",
 		"TextJPN": "「じゃなくてほらッ！　学級閉鎖ー！　みんなインフルエンザでぶっ倒れてー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``I mean...! Class was closed! Everyone's down with the flu!``"
+		"TextENG": "``Wait, I mean! School was closed! Everyone's come down with the flu!``"
 	},
 	{
 		"type": "MSGSET",
@@ -84,7 +84,7 @@
 		"PreTextTags": "@vS26/58/THOS_0090.",
 		"TextJPN": "「…開校記念日で学級閉鎖で？　…次は何…？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...Class closed on a school's opening anniversary? ...What's next...?``"
+		"TextENG": "``...First it's the founding day, now the school's closed? ...What'll it be next...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -93,13 +93,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1290.",
 		"TextJPN": "「あ、あ、あ、…雨ですからー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Oh, oh, oh... Because of the rain!``"
+		"TextENG": "``Uh, uh, uh... Because it's raining!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156153,
 		"TextJPN": "魅音と梨花を伴って星野退場。",
-		"TextENG": "Hoshino leaves accompanied by Mion and Rika."
+		"TextENG": "Mion and Rika leave the scene with Hoshino."
 	},
 	{
 		"type": "MSGSET",
@@ -108,7 +108,7 @@
 		"PreTextTags": "@vS26/56/TTON_0650.",
 		"TextJPN": "「……あの、……トイレに行っちゃまずいですか…？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...Oh...... it's kinda bad, can I use the toilet over there...?``"
+		"TextENG": "``...Oh...... is it alright if I go use the bathroom?``"
 	},
 	{
 		"type": "MSGSET",
@@ -126,13 +126,13 @@
 		"PreTextTags": "@vS26/56/TTON_0660.",
 		"TextJPN": "「…ちょっと行ってくる」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``...I'll be back in a bit.``"
+		"TextENG": "``...I'll be right back, then.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156157,
 		"TextJPN": "利根川退場。しばらくして岡野に電話が入る。",
-		"TextENG": "Tonegawa leaves. A phone call arrives for Okano a few minutes later."
+		"TextENG": "Tonegawa leaves the scene. After a moment, Okano gets a call."
 	},
 	{
 		"type": "MSGSET",
@@ -141,25 +141,25 @@
 		"PreTextTags": "@vS26/59/TOKA_0110.",
 		"TextJPN": "「はい岡野です。………………はい。…………………はい」",
 		"NamesENG": "Okano",
-		"TextENG": "``Yes, this is Okano. ..................Yes. .....................Yes.``"
+		"TextENG": "``Yes, Okano here. ..................Yes. .....................Yes.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156159,
 		"TextJPN": "岡野は携帯で話をしながら退場する。",
-		"TextENG": "Okano leaves while talking on the phone."
+		"TextENG": "Okano exits the stage talking on his phone."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156160,
 		"TextJPN": "ぽかんとして見送る吉村。",
-		"TextENG": "Yoshimura seems to be dumbfounded, and watches him leave."
+		"TextENG": "Yoshimura watches agape as they leave."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156161,
 		"TextJPN": "荒川はまた頭痛が始まったようで頭を押さえている。",
-		"TextENG": "Arakawa begins to hold his head, his head seems to ache again."
+		"TextENG": "Arakawa holds his head like his headache has returned."
 	},
 	{
 		"type": "MSGSET",
@@ -168,7 +168,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1140.",
 		"TextJPN": "「どうしました？　…また頭痛ですか？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``What happened? ...Is it your head?``"
+		"TextENG": "``What's the matter? ...Another headache?``"
 	},
 	{
 		"type": "MSGSET",
@@ -177,7 +177,7 @@
 		"PreTextTags": "@vS26/55/TARA_0830.",
 		"TextJPN": "「…え…えぇ…。…また……痛くなってきた…」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...Y-Yeah... ...The pain's coming back again...``"
+		"TextENG": "``...Yes... Yes... ...It's...... hurting again...``"
 	},
 	{
 		"type": "MSGSET",
@@ -186,7 +186,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1150.",
 		"TextJPN": "「お辛そうですねぇ。……代われるものなら代わってあげたいですよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``It looks really painful. ......You should seriously get some help when you can.``"
+		"TextENG": "``They really seem painful. ......If I could take them on for you, I would.``"
 	},
 	{
 		"type": "MSGSET",
@@ -195,7 +195,7 @@
 		"PreTextTags": "@vS26/55/TARA_0840.",
 		"TextJPN": "「……くそ……。……参ったな…。……く………」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......Damn it...... ......I'm tired of this... ......Uh.........``"
+		"TextENG": "``......Dammit...... ......This sucks... ......Kh.........``"
 	},
 	{
 		"type": "MSGSET",
@@ -204,7 +204,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1160.",
 		"TextJPN": "「頭痛の原因はたくさんあるんだそうです。風邪、眼精疲労が主なところですが他にもたくさんあります」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``There are also alot of causes for a headache. A cold and asthenopia are the main ones, but there are more.``"
+		"TextENG": "``They say there are lots of different causes for headaches. Colds and eyestrain are the leading causes, but there are a lot of other ones too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -213,7 +213,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1170.",
 		"TextJPN": "「面白い事にですね、脳自身は傷つけられても痛みを感じないんだそうですよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``The funny thing is, the brain itself doesn't feel pain when it hurts.``"
+		"TextENG": "``It's funny, but apparently you don't feel any pain when the brain itself is damaged.``"
 	},
 	{
 		"type": "MSGSET",
@@ -222,7 +222,7 @@
 		"PreTextTags": "@vS26/55/TARA_0850.",
 		"TextJPN": "「……こんなに痛いのに…？」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......Even though it hurts so much...?``"
+		"TextENG": "``......Even though it hurts this bad...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -231,7 +231,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1180.",
 		"TextJPN": "「自殺する時、ピストルで頭を撃つでしょう。…あれって、一番痛みを感じない死に方らしいですね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``When you commit suicide, you shoot yourself in the head with a pistol. ...That seems to be the least painful way to die.``"
+		"TextENG": "``When people commit suicide, they sometimes shoot their heads with a pistol, right? ...Apparently you actually experience the least pain when dying that way.``"
 	},
 	{
 		"type": "MSGSET",
@@ -240,7 +240,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1190.",
 		"TextJPN": "「…反面、意外にも辛いのが切腹なんですよ。脳と違って痛みをまともに感じますからね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...On the other hand, it would be surprisingly painful if you commit seppuku. Unlike the brain, we feel pain of other parts in a very real way..``"
+		"TextENG": "``...In contrast, committing seppuku is surprisingly painful. Because unlike when you damage the brain, you feel all the pain in your stomach.``"
 	},
 	{
 		"type": "MSGSET",
@@ -249,7 +249,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1200.",
 		"TextJPN": "「だからほら、介錯ってあるでしょう。…痛みに苦しむ前に首をはねてくれる人。…ははは！　面白くない話でしたかねぇ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Therefore, you will need an assistant. Someone to behead you before you suffer from any more pain. ...Ha ha ha! Don't you think that is interesting?``"
+		"TextENG": "``That's why there was always a second, you know. ...That person's job was to behead the man before they suffered too much. ...Hahaha! I guess that wasn't a very funny tidbit, was it?``"
 	},
 	{
 		"type": "MSGSET",
@@ -258,7 +258,7 @@
 		"PreTextTags": "@vS26/55/TARA_0860.",
 		"TextJPN": "「………はは、………くぅ……！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``.........Ha ha......... Gh......!``"
+		"TextENG": "``.........Haha......... Khh......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -267,7 +267,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1210.",
 		"TextJPN": "「辛そうですねぇ。…いっその事、介錯してあげられればいいんですけど」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``You look like you're in extreme pain. ...Preferably, I would like to be your assistant.``"
+		"TextENG": "``That looks so painful. ...I almost wish I could be your second at this point.``"
 	},
 	{
 		"type": "MSGSET",
@@ -276,7 +276,7 @@
 		"PreTextTags": "@vS26/55/TARA_0870.",
 		"TextJPN": "「………冗談じゃない…。………ううッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``.........This isn't funny... .........Uuu!``"
+		"TextENG": "``.........That's not funny... .........Nnngh!``"
 	},
 	{
 		"type": "MSGSET",
@@ -285,7 +285,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1220.",
 		"TextJPN": "「あなたの場合、頭痛の原因は睡眠不足にあるように思いますが、いかがです？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``In your case, I think the cause of a headache is lack of sleep. Don't you think so?``"
+		"TextENG": "``In your case, I imagine the cause of the headache is lack of sleep. Does that sound right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -294,7 +294,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1230.",
 		"TextJPN": "「…ちゃんと６時間眠ってますか？　昨夜は何時に床に就きましたか？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Are you sleeping properly for six hours? What time did you go to bed at last night?``"
+		"TextENG": "``...Are you getting at least six hours sleep at night? What time do you usually turn in for bed?``"
 	},
 	{
 		"type": "MSGSET",
@@ -303,7 +303,7 @@
 		"PreTextTags": "@vS26/55/TARA_0880.",
 		"TextJPN": "「……１２時前には消灯したよ。…７時間は眠ってる…！　……うぅ…ッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......I turned off the light before midnight. ...And I slept for seven hours...! ......Uuu...!``"
+		"TextENG": "``......I turn the lights out just before midnight. ...I get a full seven hours sleep...! ......Nngh...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -312,13 +312,13 @@
 		"PreTextTags": "@vS26/54/TYOS_1240.",
 		"TextJPN": "「本当にですか？　…本当にそれだけ眠れていれば、そんなに辛くはならないはずなんですがねぇ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Really? ...Did you really sleep that long? Because if you did, it wouldn't be that painful.``"
+		"TextENG": "``Really? ...If you're really getting that much sleep, then you shouldn't be in so much pain.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156179,
 		"TextJPN": "悶え苦しむ荒川。吉村は得意そうに話すだけ。",
-		"TextENG": "Arakawa writhes in agony.@rYoshimura speaks proudly."
+		"TextENG": "Arakawa continues writhing in pain. Yoshimura continues speaking like he knows what's going on."
 	},
 	{
 		"type": "MSGSET",
@@ -327,7 +327,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1250.",
 		"TextJPN": "「…本当に眠れていましたか？　…本当に」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Were you really able to sleep? ...Really?``"
+		"TextENG": "``...Were you really able to sleep? ...Truly?``"
 	},
 	{
 		"type": "MSGSET",
@@ -336,7 +336,7 @@
 		"PreTextTags": "@vS26/55/TARA_0890.",
 		"TextJPN": "「…寝たさ！　…寝てますよ」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...I slept! ...I went to sleep.``"
+		"TextENG": "``...I slept! ...I am sleeping.``"
 	},
 	{
 		"type": "MSGSET",
@@ -345,7 +345,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1260.",
 		"TextJPN": "「灯をちゃんと消して？　…灯を点けっぱなしだと深くは眠れませんよ？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Did you remember to turn off the lights properly? ...Because you can't sleep deeply if you leave them on.``"
+		"TextENG": "``You're making sure to turn the lights out? ...If you leave the lights on, you can't get decent sleep, you know.``"
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS26/55/TARA_0900.",
 		"TextJPN": "「……ちょっと……消し忘れただけです…！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......Just one...... I only forgot to turn one off...!``"
+		"TextENG": "``......I just...... forgot to turn them off a bit...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -363,7 +363,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1270.",
 		"TextJPN": "「本当に瞼を閉じてましたか？　…横になっているだけでは睡眠とは言えませんよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Did you really close your eyelids? ...Because just lying in bed isn't sleeping.``"
+		"TextENG": "``Did you really close your eyes? ...You can't call it sleep if you're just lying down.``"
 	},
 	{
 		"type": "MSGSET",
@@ -372,7 +372,7 @@
 		"PreTextTags": "@vS26/55/TARA_0910.",
 		"TextJPN": "「閉じてた！　…ちゃんと瞼を閉じて寝ようとしましたよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I closed them! ...I properly closed my eyelids and went to sleep!``"
+		"TextENG": "``I closed them! ...I closed my eyes and tried to sleep!``"
 	},
 	{
 		"type": "MSGSET",
@@ -381,7 +381,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1280.",
 		"TextJPN": "「…でも眠れなかった…？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...But you were not able to sleep...``"
+		"TextENG": "``...But you couldn't sleep...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -390,7 +390,7 @@
 		"PreTextTags": "@vS26/55/TARA_0920.",
 		"TextJPN": "「……寝ようとしましたよ！　寝ようとッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......I went to sleep! I went to sleep!``"
+		"TextENG": "``......I tried to sleep! I tried to!``"
 	},
 	{
 		"type": "MSGSET",
@@ -399,7 +399,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1290.",
 		"TextJPN": "「………どうして瞼を閉じられなかったんです？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``.........Then why were your eyelids not closed?``"
+		"TextENG": "``.........Why couldn't you close your eyes?``"
 	},
 	{
 		"type": "MSGSET",
@@ -408,7 +408,7 @@
 		"PreTextTags": "@vS26/55/TARA_0930.",
 		"TextJPN": "「……うるさいなぁッ！　…そんな事、どうでもいいじゃないですか！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......You're being annoying! ...It doesn't matter!``"
+		"TextENG": "``......Shut up! ...Why does any of that even matter?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -417,7 +417,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1300.",
 		"TextJPN": "「…不眠で毎晩、辛いんでしょう？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Every night with insomnia must be painful, right?``"
+		"TextENG": "``...It must be tough going every night without sleep, huh?``"
 	},
 	{
 		"type": "MSGSET",
@@ -426,7 +426,7 @@
 		"PreTextTags": "@vS26/55/TARA_0940.",
 		"TextJPN": "「僕は、……不眠なんかじゃ…ないッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I...... I don't have insomnia...!``"
+		"TextENG": "``I'm not...... going without... sleep!``"
 	},
 	{
 		"type": "MSGSET",
@@ -435,7 +435,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1310.",
 		"TextJPN": "「…近藤さんも言ってましたよ。……不眠で辛いって」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Kondo-san said the same thing, too. ......Insomnia is painful.``"
+		"TextENG": "``...Kondou-san said so too. ......That it was tough missing sleep.``"
 	},
 	{
 		"type": "MSGSET",
@@ -444,7 +444,7 @@
 		"PreTextTags": "@vS26/55/TARA_0950.",
 		"TextJPN": "「近藤さんなんか知らない！　…僕は不眠なんかじゃないんだッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I don't know about Kondo-san! ...And I don't have insomnia!``"
+		"TextENG": "``I don't care about Kondou-san! ...I'm not going without sleep!``"
 	},
 	{
 		"type": "MSGSET",
@@ -453,7 +453,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1320.",
 		"TextJPN": "「…寝ようとすると、…落ち着かなくなって起きてしまう。…そうでしょう」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...But every time you try to sleep... it occurs and you become restless. ...Isn't that the case?``"
+		"TextENG": "``...You try to sleep, sure... but you feel restless and end up waking up. ...Isn't that right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -462,7 +462,7 @@
 		"PreTextTags": "@vS26/55/TARA_0960.",
 		"TextJPN": "「そんなことはないッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It's nothing like that!``"
+		"TextENG": "``That's not true!``"
 	},
 	{
 		"type": "MSGSET",
@@ -471,7 +471,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1330.",
 		"TextJPN": "「…でもその内、感じるようになったんですよね？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...But, among other things, haven't you begun to feel *it*?``"
+		"TextENG": "``...But at some point you began to feel it, didn't you?``"
 	},
 	{
 		"type": "MSGSET",
@@ -480,13 +480,13 @@
 		"PreTextTags": "@vS26/55/TARA_0970.",
 		"TextJPN": "「感じるッ！？　…何も感じないですよ！　何もッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Feel!? ...I feel nothing! Nothing!``"
+		"TextENG": "``Feel it?! ...I'm not feeling anything! Anything at all!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156198,
 		"TextJPN": "舞台は真っ赤なライトで照らし出される。",
-		"TextENG": "The stage is illuminated by a gloomy bright red light.@rThe light shines on Arakawa."
+		"TextENG": "A dim, pure red light shines down on the stage."
 	},
 	{
 		"type": "MSGSET",
@@ -495,7 +495,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0120.",
 		"TextJPN": "「……………荒ちゃんは何も感じないかい。…夜とか」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``...............Ara-chan, don't you feel anything... ...at night...?``"
+		"TextENG": "``...............You don't sense anything, Ara-chan? ...At night?``"
 	},
 	{
 		"type": "MSGSET",
@@ -504,7 +504,7 @@
 		"PreTextTags": "@vS26/55/TARA_0980.",
 		"TextJPN": "「感じないですッ！　何にもッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I don't feel it! Nothing!``"
+		"TextENG": "``I don't sense anything! Nothing!``"
 	},
 	{
 		"type": "MSGSET",
@@ -513,7 +513,7 @@
 		"PreTextTags": "@vS26/00/TKAK_0130.",
 		"TextJPN": "「…………確かに“いる”んだよ。………“いる”」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``............Definitely, 'it exists'. .........'It exists'.``"
+		"TextENG": "``............I'm positive they're there. .........Positive.``"
 	},
 	{
 		"type": "MSGSET",
@@ -522,7 +522,7 @@
 		"PreTextTags": "@vS26/55/TARA_0990.",
 		"TextJPN": "「“い”ないッ！　…何にも“い”ないッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It doesn't 'exist'! ...It can't 'exist'!``"
+		"TextENG": "``They're not there! ...There's nothing there!``"
 	},
 	{
 		"type": "MSGSET",
@@ -531,13 +531,13 @@
 		"PreTextTags": "@vS26/00/TKAK_0140.",
 		"TextJPN": "「………近藤さんもさ。…ひと月くらい前から、そんなこと言ってたよな…」",
 		"NamesENG": "Kakinuma's voice",
-		"TextENG": "``.........Kondo-san. ...About one month ago, he also said those words...``"
+		"TextENG": "``.........Kondou-san also... said things like that, about a month before now, right...?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156204,
 		"TextJPN": "真っ赤なライトが今度は青いライトに変わる。",
-		"TextENG": "Now the bright red light turns into a blue light."
+		"TextENG": "The red light changes into a blue one."
 	},
 	{
 		"type": "MSGSET",
@@ -546,7 +546,7 @@
 		"PreTextTags": "@vS26/00/TKON_0000.",
 		"TextJPN": "「…はは。…もちろん笑ってくれていいよ。……だがな…。…あいつは………“いる”んだよ…！」",
 		"NamesENG": "Kondo's voice",
-		"TextENG": "``...Ha ha. ...Of course you may laugh. ......But... that thing......... it definitely 'exists'...!``"
+		"TextENG": "``...Haha. ...Of course you can laugh at that. ......However... ...They......... are really there...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -555,7 +555,7 @@
 		"PreTextTags": "@vS26/55/TARA_1000.",
 		"TextJPN": "「“い”ないッ！　…嘘っぱちだッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It doesn't 'exist'! ...It's an arrant lie!``"
+		"TextENG": "``They're not there! ...It's all!``"
 	},
 	{
 		"type": "MSGSET",
@@ -564,7 +564,7 @@
 		"PreTextTags": "@vS26/00/TKON_0010.",
 		"TextJPN": "「……いいや、“いる”。……そりゃあ目に見えないものを疑うのは簡単さ」",
 		"NamesENG": "Kondo's voice",
-		"TextENG": "``......No, 'it exists'. ......It's easy to simply doubt something you can't see.``"
+		"TextENG": "``......No, they are there. ......Sure, it's easy to doubt something you can't see with your own eyes.``"
 	},
 	{
 		"type": "MSGSET",
@@ -573,7 +573,7 @@
 		"PreTextTags": "@vS26/00/TKON_0020.",
 		"TextJPN": "「……だけど例え見えなかったとしてもやっぱり、……“いる”んだよ！」",
 		"NamesENG": "Kondo's voice",
-		"TextENG": "``......But even if you can't see it...... it still 'exists'!``"
+		"TextENG": "``......But even if you can't see them there, they're still...... they're still there!``"
 	},
 	{
 		"type": "MSGSET",
@@ -582,13 +582,13 @@
 		"PreTextTags": "@vS26/55/TARA_1010.",
 		"TextJPN": "「わぁあああぁあぁぁああああぁあッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Ahhhhhhhhhhhhhhhhh!``"
+		"TextENG": "``Waaaaaaaaaaaaaahhh!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156210,
 		"TextJPN": "青いライトが再び真っ赤なライトに変わる。",
-		"TextENG": "The blue light turns back into a bright red light."
+		"TextENG": "The blue light changes back to red once more."
 	},
 	{
 		"type": "MSGSET",
@@ -597,7 +597,7 @@
 		"PreTextTags": "@vS26/00/TKAT_0000.",
 		"TextJPN": "「…ぁああぁあぁあッ！　…触るんじゃねえ！　触るんじゃねぇッ！」",
 		"NamesENG": "Kato's voice",
-		"TextENG": "``...Ahhhhhhhhh! ...Don't touch me! Don't even try!``"
+		"TextENG": "``...Aaaaaaaaah! ...Don't touch me! Don't you touch me!``"
 	},
 	{
 		"type": "MSGSET",
@@ -606,7 +606,7 @@
 		"PreTextTags": "@vS26/55/TARA_1020.",
 		"TextJPN": "「加藤さんッ！　…落ち着いて下さいよ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Kato-san! ...Please calm down!``"
+		"TextENG": "``Katou-san! ...Please calm down!``"
 	},
 	{
 		"type": "MSGSET",
@@ -615,7 +615,7 @@
 		"PreTextTags": "@vS26/00/TKAT_0010.",
 		"TextJPN": "「…なめやがって！　…どいつもこいつも俺の事を馬鹿にしてやがるッ！　…ぁああぁぁあああッ！」",
 		"NamesENG": "Kato's voice",
-		"TextENG": "``...Are you kidding me?! ...You're all just making fun of me! ...Ahhhhhhhhh!``"
+		"TextENG": "``...You're looking down on me! ...Every damn one of you keeps making fun of me! ...Aaaaaaaaaah!``"
 	},
 	{
 		"type": "MSGSET",
@@ -624,7 +624,7 @@
 		"PreTextTags": "@vS26/00/TKAT_0020.",
 		"TextJPN": "「……上等だぜ。…そのケンカ、買ってやろうじゃねえか。…てめえなんざ怖くも何ともねえんだぞ…！」",
 		"NamesENG": "Kato's voice",
-		"TextENG": "``......This is great. ...I'll fight you all. ...Dying isn't that scary at all...!``"
+		"TextENG": "``......Fine by me, then. ...I'll accept that fight of yours. ...You're nothing to be afraid of at all...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -633,7 +633,7 @@
 		"PreTextTags": "@vS26/55/TARA_1030.",
 		"TextJPN": "「誰もケンカなんか売ってないです！　だから落ち着いて下さい！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Nobody's wanna fight! So please calm down!``"
+		"TextENG": "``I'm not picking a fight with you! So please calm down!``"
 	},
 	{
 		"type": "MSGSET",
@@ -642,7 +642,7 @@
 		"PreTextTags": "@vS26/00/TKAT_0030.",
 		"TextJPN": "「…くらぁッ！　…殺してやるッ！　…俺を馬鹿にするヤツはみんな殺してやる！」",
 		"NamesENG": "Kato's voice",
-		"TextENG": "``...Kura! ...I'll kill you! ...I'll kill everyone making fun of me!``"
+		"TextENG": "``...Come on! ...I'll kill you! ...I'll kill everyone who makes fun of me!``"
 	},
 	{
 		"type": "MSGSET",
@@ -651,7 +651,7 @@
 		"PreTextTags": "@vS26/00/TKAT_0040.",
 		"TextJPN": "「……何がオヤシロさまだ。…祟りが怖くてケンカができるかぁッ！」",
 		"NamesENG": "Kato's voice",
-		"TextENG": "``......What is Oyashiro-sama? ...Are you that afraid of fighting a curse?!``"
+		"TextENG": "``......Screw Oyashiro-sama! ...You think I'm too scared of the curse to fight?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -660,13 +660,13 @@
 		"PreTextTags": "@vS26/55/TARA_1040.",
 		"TextJPN": "「かか、加藤さんッ！　…で、電車、来ますって…ッ！　…ぁ、ぁあ…ああぁあぁああああぁああッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Ka-Ka-Kato-san! ...Th-The train, it's coming...! ...A-ah... ahhhhhhhhhhhh!``"
+		"TextENG": "``K-K-Katou-san! ...T-The train is pulling in...! ...Ah, aah... aaaaaaaaaaaaaaah!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156219,
 		"TextJPN": "電車の入ってくる音。",
-		"TextENG": "Incoming sound of the train."
+		"TextENG": "The sound of an oncoming train is heard."
 	},
 	{
 		"type": "MSGSET",
@@ -675,7 +675,7 @@
 		"PreTextTags": "@vS26/55/TARA_1050.",
 		"TextJPN": "「…ぁあぁああぁあッ！　…“い”ないんだ！　…オヤシロさまなんて…！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``...Ahhhhhhhh! ...It doesn't 'exist'! ...Oyashiro-sama doesn't exist...!``"
+		"TextENG": "``...Aaaaaaah! ...They don't exist! ...Oyashiro-sama doesn't exist...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -684,7 +684,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1340.",
 		"TextJPN": "「…嫌でしょう。…“いる”のに会えないなんて。…悔しいですよねぇ。……“いる”のに」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``,,,You must hate it. ...It 'exists' and you aren't able to see it. ...It's frustrating, isn't it? ...Even though it 'exists'.``"
+		"TextENG": "``...You hate it, don't you? ...Not being able to meet them when they're there. ...It's frustrating, isn't it? ......When they're right there next to you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -693,7 +693,7 @@
 		"PreTextTags": "@vS26/55/TARA_1060.",
 		"TextJPN": "「“い”ない！　“い”ない！　“い”ないーッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``It doesn't 'exist'... It doesn't 'exist'! It doesn't 'exist'!!!``"
+		"TextENG": "``They're not there! They're not there! They're not theeere!``"
 	},
 	{
 		"type": "MSGSET",
@@ -702,7 +702,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1350.",
 		"TextJPN": "「…近藤さんは会いましたよ。…柿沼さんもね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Kondo-san met it. ...Kakinuma-san, too.``"
+		"TextENG": "``...Kondou-san got to meet them. ...Kakinuma-san did too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -720,7 +720,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1360.",
 		"TextJPN": "「森さんも会った。加藤さんも会った」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Mori-san met it. Kato-san met it.``"
+		"TextENG": "``Mori-san met them too. Katou-san, he met them also.``"
 	},
 	{
 		"type": "MSGSET",
@@ -729,7 +729,7 @@
 		"PreTextTags": "@vS26/55/TARA_1080.",
 		"TextJPN": "「もうやめてくれ！　…たくさんだ！　たくさんだッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Stop it already! ...It's too much! It's too much!``"
+		"TextENG": "``Stop it already! ...That's enough! That's enough!``"
 	},
 	{
 		"type": "MSGSET",
@@ -738,7 +738,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1370.",
 		"TextJPN": "「…会いたいでしょう？　…会いたいはずだ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Do you want to meet it? ...I think you should meet it.``"
+		"TextENG": "``...You want to meet them, right? ...You should want to meet them.``"
 	},
 	{
 		"type": "MSGSET",
@@ -747,13 +747,13 @@
 		"PreTextTags": "@vS26/55/TARA_1090.",
 		"TextJPN": "「嫌だッ！　嫌だッ！　…助けてッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I don't want to! I don't want to! Help!``"
+		"TextENG": "``No! No! ...Help!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156229,
 		"TextJPN": "地べたを這いつくばりながら、どこかへ逃げようとする荒川。頭痛がひどく、それもままならない。",
-		"TextENG": "Arakawa tries to escape to somewhere, but falls onto the ground and begins crawling. His headache is severe, it stops him from doing what he wants."
+		"TextENG": "Arakawa crawls along the ground, trying to escape to anywhere else. Yet his headache is terrible, and he doesn't get very far."
 	},
 	{
 		"type": "MSGSET",
@@ -762,7 +762,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1380.",
 		"TextJPN": "「…なぜ拒むんです？　……会えば救われるのに」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Why do you refuse? ......You will be saved if you meet it.``"
+		"TextENG": "``...Why do you refuse him? ......If you met him, you'd be saved, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -771,7 +771,7 @@
 		"PreTextTags": "@vS26/55/TARA_1100.",
 		"TextJPN": "「ぁああぁぁああッ！　……やだ！　…やだ…ッ…！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Ahhhhhhh! ......No! ...No......!``"
+		"TextENG": "``Aaaaaaah! ......No! ...No...! ...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -780,13 +780,13 @@
 		"PreTextTags": "@vS26/54/TYOS_1390.",
 		"TextJPN": "「……いい歳した大人が、そんなに怖がる事はないじゃあないですか…。…みっともない」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......An adult at your age shouldn't be afraid of something like this... ...Disgraceful.``"
+		"TextENG": "``......You shouldn't be so frightened when you're an adult... ...It's rather pathetic.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156233,
 		"TextJPN": "荒川は舞台中央で腰をぬかし、がたがた震えるだけ。",
-		"TextENG": "Arakawa is unable to stand up at the stage center,@rhe trembles."
+		"TextENG": "Arakawa's legs give out at center stage, and he just keeps shuddering."
 	},
 	{
 		"type": "MSGSET",
@@ -795,6 +795,6 @@
 		"PreTextTags": "@vS26/54/TYOS_1400.",
 		"TextJPN": "「……あれ、…ひょっとして失禁しました…？　……恥ずかしいなぁ…」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Or perhaps... maybe it's incontinence...? ......How embarrassing...``"
+		"TextENG": "``......Huh? ...Did you wet yourself, by chance...? ......How embarrassing...``"
 	}
 ]

--- a/bus_stop_6.json
+++ b/bus_stop_6.json
@@ -9,7 +9,7 @@
 		"type": "MSGSET",
 		"MessageID": 156235,
 		"TextJPN": "ライトに照らされる荒川。@r無表情な魅音・梨花・利根川・星野・岡野登場。@rゆっくりと遠巻きに荒川を囲む。",
-		"TextENG": "The stage has now become dark.@rArakawa is illuminated by the light.@rAs an expressionless Mion, Rika,@rTonegawa, Hoshino and Okano appear.@rThey enclose on Arakawa slowly from afar."
+		"TextENG": "The light shines on Arakawa. An expressionless Mion, Rika, Tonegawa, Hoshino, and Okano enter the scene. They slowly surround Arakawa at a distance."
 	},
 	{
 		"type": "MSGSET",
@@ -18,7 +18,7 @@
 		"PreTextTags": "@vS26/55/TARA_1110.",
 		"TextJPN": "「……、な…何だよお前ら…！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``......Wh-What do you people want...!``"
+		"TextENG": "``......Wha... What's up with all of you...?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -27,7 +27,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1410.",
 		"TextJPN": "「市立柳川小学校に通われましたね。…３年生の時でしたか？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``You were haunted at Yanagawa City elementary school. ...Wasn't it around the time of third grade?``"
+		"TextENG": "``You used to go to Yanagawa Municipal Elementary, didn't you? ...It happened in third grade, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -36,7 +36,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1420.",
 		"TextJPN": "「…運悪く帰宅の途中で便意をもよおしてしまったあなたは、茂みでこっそりと用を足してしまう事にしました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Unfortunately, you were on your way home and tried to hold your bowel movement, but couldn't and decided to do it secretly in the bushes.``"
+		"TextENG": "``...You were unfortunate enough to feel the call of nature on your way home from school, so you decided to take care of it in the bushes in secret.``"
 	},
 	{
 		"type": "MSGSET",
@@ -45,7 +45,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0120.",
 		"TextJPN": "「おい！　荒川、野グソしてんぜ、野グソーッ！」",
 		"NamesENG": "Okano",
-		"TextENG": "``Hey! Arakawa, you shit in a field, shit in a field!``"
+		"TextENG": "``Hey! Arakawa's shitting outside! He's shitting outside!``"
 	},
 	{
 		"type": "MSGSET",
@@ -54,7 +54,7 @@
 		"PreTextTags": "@vS26/55/TARA_1120.",
 		"TextJPN": "「なッ！　なんだよお前らーッ！　…お前らだってトイレが近くになかったらするだろッ！？」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Ah... What the hell is wrong with you people?! ...I couldn't find a restroom, what did you expect me to do!?``"
+		"TextENG": "``Wha?! What's with you all?! ...You'd all do it too if there wasn't a bathroom nearby!``"
 	},
 	{
 		"type": "MSGSET",
@@ -63,7 +63,7 @@
 		"PreTextTags": "@vS26/56/TTON_0670.",
 		"TextJPN": "「しないよ！　普通はしない」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``I would never do that! It's not normal.``"
+		"TextENG": "``I wouldn't! I generally wouldn't.``"
 	},
 	{
 		"type": "MSGSET",
@@ -72,7 +72,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0930.",
 		"TextJPN": "「絶対お手洗いを探すわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``I'd absolutely look for a restroom.``"
+		"TextENG": "``I'd definitely go look for a bathroom.``"
 	},
 	{
 		"type": "MSGSET",
@@ -81,7 +81,7 @@
 		"PreTextTags": "@vS26/58/THOS_0100.",
 		"TextJPN": "「外でするなんて…。下劣！」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``To do it outside... Vulgar!``"
+		"TextENG": "``Doing it outside is just... gross!``"
 	},
 	{
 		"type": "MSGSET",
@@ -90,13 +90,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1300.",
 		"TextJPN": "「あ！　こっち来たよこっち来たよ！　野グソマーン！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah! Here it comes! Here it comes! Field shit man!``"
+		"TextENG": "``Ah! He's coming over here, he's coming over here! It's Shitman!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156245,
 		"TextJPN": "吉村・荒川以外は大笑い。",
-		"TextENG": "Everyone roars with laughter, except Yoshimura and Arakawa."
+		"TextENG": "All but Yoshimura and Arakawa are laughing loudly."
 	},
 	{
 		"type": "MSGSET",
@@ -105,7 +105,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1430.",
 		"TextJPN": "「野グソマンはヒット作でしたねぇ。…とにかく流行った。４年、５年、６年生、学年、クラスが変わってもあだ名はそれだ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Field shit man was a big hit. ...It became really popular. Even all the way through 4th grade, 5th grade, 6th grade, and the rest of your school years, it stayed your nickname.``"
+		"TextENG": "``Shitman was a big hit, wasn't it? ...It became pretty popular. So that became your nickname even when you changed grades and classes, all throughout fourth, fifth, and sixth grade.``"
 	},
 	{
 		"type": "MSGSET",
@@ -114,7 +114,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1440.",
 		"TextJPN": "「このあだ名を命名してくれた少女は@bひらやまゆうこ.@<平山優子@>さん。…あなたは恨みましたよね」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``The girl who named this nickname was Hirayama Yuko-san. ...You've bore a grudge ever since.``"
+		"TextENG": "``The one who gave you that nickname was a young girl named Hirayama Yuuko-san. ...You hated her, didn't you?``"
 	},
 	{
 		"type": "MSGSET",
@@ -123,7 +123,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1450.",
 		"TextJPN": "「…この子がこんなあだ名さえ付けなければこんなひどい目に遭うことはなかった」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...If that child never gave you such a nickname, you would have never had such a terrible experience.``"
+		"TextENG": "``...If that girl hadn't given you that nickname, then you wouldn't have suffered such awful treatment.``"
 	},
 	{
 		"type": "MSGSET",
@@ -132,7 +132,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1460.",
 		"TextJPN": "「…殴りかかりましたね。箒の柄で何度も何度も！　泣いても叩き続けた」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...So you beat her. Again and again with the handle of a broom! You continued hitting even when she cried.``"
+		"TextENG": "``...So you beat her, didn't you? Over and over again with a broomstick! You kept beating her even after she started crying.``"
 	},
 	{
 		"type": "MSGSET",
@@ -141,7 +141,7 @@
 		"PreTextTags": "@vS26/58/THOS_0110.",
 		"TextJPN": "「荒川君ッ！　女の子を叩くなんて最低よッ！？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``Arakawa-kun! Hitting a girl is disgusting!``"
+		"TextENG": "``Hey, Arakawa-kun! Hitting a girl, that's real low!``"
 	},
 	{
 		"type": "MSGSET",
@@ -150,7 +150,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1310.",
 		"TextJPN": "「わぁあぁあああああーん！　荒川がぶったー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Waaaahaaa! Arakawa... *mumbling*!``"
+		"TextENG": "``Waaaaaaaaaaahhn! Arakawa hit me!``"
 	},
 	{
 		"type": "MSGSET",
@@ -159,7 +159,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0940.",
 		"TextJPN": "「最低男！」",
 		"NamesENG": "Rika",
-		"TextENG": "``You're the worst!``"
+		"TextENG": "``Scumbag!``"
 	},
 	{
 		"type": "MSGSET",
@@ -168,7 +168,7 @@
 		"PreTextTags": "@vS26/56/TTON_0680.",
 		"TextJPN": "「女なんかにマジになんなよなぁ！」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``I can't seriously believe you did that to a girl!``"
+		"TextENG": "``There's no reason to do that to a girl!``"
 	},
 	{
 		"type": "MSGSET",
@@ -177,7 +177,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0130.",
 		"TextJPN": "「なぁ荒川。先生には内緒で教えてくれよな。…お前、平山の事、好きなのか？　うん？」",
 		"NamesENG": "Okano",
-		"TextENG": "``Hey, Arakawa. You can tell your sensei a secret. Do you like Hirayama? Hm?``"
+		"TextENG": "``Hey, Arakawa. You can tell me, your teacher, in secret. ...Do you like Hirayama? Hmm?``"
 	},
 	{
 		"type": "MSGSET",
@@ -186,7 +186,7 @@
 		"PreTextTags": "@vS26/55/TARA_1130.",
 		"TextJPN": "「ぅおおおぉおおぉおおおおおッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Uoooooooooooo!``"
+		"TextENG": "``Rrrrrrrrrrrrrrrrrrrrrrrrgh!``"
 	},
 	{
 		"type": "MSGSET",
@@ -195,7 +195,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1470.",
 		"TextJPN": "「中学校でも野グソマンは大流行だ。…会った事もない初対面の人間に好奇の眼差しで見られるの、…苦痛ですよねぇ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Field shit man was all the rage at your junior high school. ...Even when you met people for the first time, you saw a curious look on their face... it was painful.``"
+		"TextENG": "``Even in middle school, Shitman was all the rage. ...It hurt... when people you had never even met before looked at you with curiosity, didn't it?``"
 	},
 	{
 		"type": "MSGSET",
@@ -204,7 +204,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0950.",
 		"TextJPN": "「あいつ？　…噂の野グソ男」",
 		"NamesENG": "Rika",
-		"TextENG": "``See that guy? ...I think he's the rumored field shit man.``"
+		"TextENG": "``Him? ...The one everyone calls Shitman?``"
 	},
 	{
 		"type": "MSGSET",
@@ -213,7 +213,7 @@
 		"PreTextTags": "@vS26/58/THOS_0120.",
 		"TextJPN": "「近付かない方がいいって！　…なんか臭うらしーよぅ！」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``Stay away from him! ...He smells!``"
+		"TextENG": "``You should stay away from him! ...I hear he stinks!``"
 	},
 	{
 		"type": "MSGSET",
@@ -222,7 +222,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1320.",
 		"TextJPN": "「あははははは！　不潔不潔不潔ーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah ha ha ha ha ha! Dirty dirty dirty!``"
+		"TextENG": "``Ahahahahaha! Gross, gross, gross!``"
 	},
 	{
 		"type": "MSGSET",
@@ -231,7 +231,7 @@
 		"PreTextTags": "@vS26/55/TARA_1140.",
 		"TextJPN": "「うるせえよッ！　あれ１回きりだよッ！　うるせえなぁッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Shut up! It was only one time! You're so annoying!``"
+		"TextENG": "``Shut up! I only did it the one time! Now shut up about it!``"
 	},
 	{
 		"type": "MSGSET",
@@ -240,7 +240,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1480.",
 		"TextJPN": "「苦難の義務教育もようやく終わり、いよいよ高校生として新しいスタートを切りました」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``But, the hardships of compulsory education finally ended, and you could finally make a new start as a high school student.``"
+		"TextENG": "``Your hardship of mandatory education finally came to an end, and at long last, you were able to make a new start in high school.``"
 	},
 	{
 		"type": "MSGSET",
@@ -249,7 +249,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1490.",
 		"TextJPN": "「同学年に同じ中学の出身は１人もなく、あなたは胸をなで下ろした」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``There wasn't anyone you knew from your junior high school in your new school year, you were relieved.``"
+		"TextENG": "``You heaved a sigh of relief when you saw there wasn't a single person from your middle school in the same grade as you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -258,7 +258,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0140.",
 		"TextJPN": "「………あのさぁ！　…お前って、…野グソマン？」",
 		"NamesENG": "Okano",
-		"TextENG": "``.........Hey! ...Aren't you... field shit man?``"
+		"TextENG": "``.........Hey there! ...Are you... Shitman?``"
 	},
 	{
 		"type": "MSGSET",
@@ -267,7 +267,7 @@
 		"PreTextTags": "@vS26/55/TARA_1150.",
 		"TextJPN": "「えッ！　……ええッ！？」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Eh! ......Ehh!?``"
+		"TextENG": "``Huh?! ......Huhh?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -276,13 +276,13 @@
 		"PreTextTags": "@vS26/54/TYOS_1500.",
 		"TextJPN": "「どこから伝わったのかは今でも判りません。でも、…不幸にもどこかで誰かが聞きつけてしまったんですなぁ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``You still don't know how they knew it. But... unfortunately, they heard it from somewhere.``"
+		"TextENG": "``Even now, you have no idea how that name got passed from school to school. But... unfortunately for you, someone heard that name somewhere.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156266,
 		"TextJPN": "吉村・荒川以外は笑い続けている。荒川は傘を握りしめながらよろよろと立ち上がる。",
-		"TextENG": "Everyone continues roaring in laugher, except Yoshimura and Arakawa. Arakawa stands up, and stumbles while clutching an umbrella."
+		"TextENG": "All but Yoshimura and Arakawa continue to laugh. Arakawa clenches his umbrella and stands up, still wobbling."
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@vS26/55/TARA_1160.",
 		"TextJPN": "「うるせえうるせえうるせえよッ！　…黙れよ！　黙んねえと殺すぞッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``You're annoying, you're annoying, you're annoying! ...Shut up! I'll kill you if you don't!``"
+		"TextENG": "``Shut up, shut up, shut up! ...Be quiet! If you don't shut up, I'll kill you!``"
 	},
 	{
 		"type": "MSGSET",
@@ -300,7 +300,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1510.",
 		"TextJPN": "「女の子を殴ればすぐ悪者扱いされる。あなたは歯を食いしばって耐えた」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``You was treated like a bad person immediately after you beat that girl. But you gritted your teeth and endured it.``"
+		"TextENG": "``If you hit a girl, however, you'd quickly be treated as a villain. So you gritted your teeth and endured it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -309,13 +309,13 @@
 		"PreTextTags": "@vS26/55/TARA_1170.",
 		"TextJPN": "「馬鹿野郎ッ！　女だからって容赦しねえぞッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``You idiot! I won't forgive you just because you're a girl!``"
+		"TextENG": "``Dumbass! I won't go easy on you just because you're a woman!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156270,
 		"TextJPN": "傘を振り回しながら魅音・梨花に歩み寄る荒川。２人は笑い転げながら後退る。",
-		"TextENG": "Arakawa approaches Mion and Rika while swinging around an umbrella. The two people move backwards and continue to laugh."
+		"TextENG": "Arakawa steps toward Mion and Rika, swinging his umbrella around. They both back off, laughing all the while."
 	},
 	{
 		"type": "MSGSET",
@@ -324,7 +324,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1520.",
 		"TextJPN": "「男の子を殴ればすぐ仕返しされる。あなたは歯を食いしばって耐えた」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``If it was a boy, you would have taken your revenge immediately. But you gritted your teeth and endured it.``"
+		"TextENG": "``If you hit a guy, then they quickly fought back. So you gritted your teeth and endured it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -333,19 +333,19 @@
 		"PreTextTags": "@vS26/55/TARA_1180.",
 		"TextJPN": "「ふざけるなッ！　殺してやる！　誰だろうと殺してやるッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Don't play dumb! I'll kill you! I'll kill you and everyone else!``"
+		"TextENG": "``Fuck off! I'll kill you! I don't care who you are, I'll kill you!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156273,
 		"TextJPN": "傘を振り回しながら利根川・星野・岡野に歩み寄る荒川。３人も笑いながら後退る。",
-		"TextENG": "Arakawa approaches Tonegawa, Hoshino and Okano while swinging around an umbrella. The three people pull back and continue to laugh."
+		"TextENG": "Arakawa steps toward Tonegawa, Hoshino, and Okano, swinging his umbrella around. All three back off, laughing as they do."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156274,
 		"TextJPN": "悔しがりながら舞台中央で傘を振り回す荒川。５人はなおも大笑い。",
-		"TextENG": "Arakawa swings around the umbrella at the stage center, as his frustration continues to rise. The five people are still roaring with laughter."
+		"TextENG": "Arakawa remains center stage, swinging his umbrella around in frustration. The other five all laugh even harder."
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS26/55/TARA_1190.",
 		"TextJPN": "「殺してやる殺してやるッ！　皆殺しだぁッ！　糞どもめぇッ！　…わぁあああぁあぁああぁあああああッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``I'll kill you, I'll kill you! I'll massacre you, you piece of shit! ...Ahhhhhhhhhhhhhhhhh!``"
+		"TextENG": "``I'll kill you! I'll kill you! I'll kill you all! You shitheads! ...Waaaaaaaaaaaaaaaaaaah!``"
 	},
 	{
 		"type": "MSGSET",
@@ -363,7 +363,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1530.",
 		"TextJPN": "「苦しいでしょう。辛いでしょう！　…求めたくないですか？　…救いが！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``It was painful. It was severe! ...Don't you want to seek it out? ...Salvation!``"
+		"TextENG": "``It must have been painful. It must have been tough! ...So wouldn't you want to seek it? ...Your salvation!``"
 	},
 	{
 		"type": "MSGSET",
@@ -372,7 +372,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1540.",
 		"TextJPN": "「…求めたいはずだ！　…そうでしょうッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...You should have demanded more! ...You should have!``"
+		"TextENG": "``...Of course you'd want it! ...Yes, you definitely would!``"
 	},
 	{
 		"type": "MSGSET",
@@ -381,7 +381,7 @@
 		"PreTextTags": "@vS26/55/TARA_1200.",
 		"TextJPN": "「俺を馬鹿にするヤツは皆殺しだぁッ！　…をおおぉおおぉおおおおおッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Those people made a fool out of me, I should have killed them! ...Oooooooooooo!``"
+		"TextENG": "``I'll kill everyone who makes fun of me! ...Rrrrrrrrrrrrrrrrrrgh!``"
 	},
 	{
 		"type": "MSGSET",
@@ -390,7 +390,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1550.",
 		"TextJPN": "「…会いたく、…なってきませんか。……ふっふふふ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...You can meet it now... if you want. ......Hee hee hee hee!``"
+		"TextENG": "``...Do you want... to meet them now? ......Fufufufu!``"
 	},
 	{
 		"type": "MSGSET",
@@ -399,7 +399,7 @@
 		"PreTextTags": "@vS26/55/TARA_1210.",
 		"TextJPN": "「誰にだよッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Meet who!``"
+		"TextENG": "``Meet who?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -408,7 +408,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1560.",
 		"TextJPN": "「…近藤さんも柿沼さんも！　…たくさん辛い事があった。でも解放されたんです。…森さんも加藤さんもね！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...The one Kondo-san and Kakinuma-san met! ...It will be very painful. But you will be free. ...Mori-san and Kato-san did so, too!``"
+		"TextENG": "``...You know, both Kondou-san and Kakinuma-san... they went through plenty of hard times too. But they're free now. ...Same with Mori-san and Katou-san!``"
 	},
 	{
 		"type": "MSGSET",
@@ -417,7 +417,7 @@
 		"PreTextTags": "@vS26/55/TARA_1220.",
 		"TextJPN": "「へ！　…へへへ！　……そーかよ…！　…そーゆうわけかよ…ッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Heh! Heh heh heh! ......I see...! ...I see what you want...!``"
+		"TextENG": "``Heh! ...Hehehe! ......That so...?! ...So that's how it is...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -426,7 +426,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1570.",
 		"TextJPN": "「…会いたいでしょう？　…会いたいでしょう！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Will you meet it now? ...You want to meet it!``"
+		"TextENG": "``...You want to meet them, right? ...You want to meet them, right?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -435,7 +435,7 @@
 		"PreTextTags": "@vS26/55/TARA_1230.",
 		"TextJPN": "「来やがれよ。…俺を馬鹿にするヤツはぶっ殺してやるッ！　…なにが祟りだ！　オヤシロさまが何だってんだッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Come. ...I'll kick the asses of the people making a fool of me! What is the curse?! ...What is Oyashiro-sama?!``"
+		"TextENG": "``Bring their ass to me. ...I'll kill everyone who makes fun of me! ...Screw the curse! So what about this Oyashiro-sama crap?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -444,7 +444,7 @@
 		"PreTextTags": "@vS26/55/TARA_1240.",
 		"TextJPN": "「あっはっはっはっはっ！　会ってやろうじゃねえかッ！　…みんなみんなぶっ殺してやるッ！」",
 		"NamesENG": "Arakawa",
-		"TextENG": "``Ahahahaha! I will meet it! ...I'm just going to kick it and everyone's asses!``"
+		"TextENG": "``Hahahahahaha! I'll go ahead and meet them, then! ...And I'll kill every last one of them!``"
 	},
 	{
 		"type": "MSGSET",
@@ -453,7 +453,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1580.",
 		"TextJPN": "「会いたい？　……会いたい。……会いたい！？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Don't you want to meet it? ......You want to meet it. ......Don't you want to meet it!?``"
+		"TextENG": "``You want to meet them? ......You want to meet them. ......You want to meet them?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -462,7 +462,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1590.",
 		"TextJPN": "「……っはっはっはっは！　あーっはっはっはっはっはっはッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Ah ha ha ha ha ha! Ahh ha ha ha ha ha ha ha ha ha!``"
+		"TextENG": "``......Hahahaha! Ahhhahahahahaha!``"
 	},
 	{
 		"type": "MSGSET",
@@ -471,7 +471,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1600.",
 		"TextJPN": "「…言いましたねぇ？　…会いたい？　…はっはっはっはっはっは！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...You said it. ...You want to meet it? Ha ha ha ha ha ha!``"
+		"TextENG": "``...You said it, didn't you? ...You want to meet them? ...Hahahahahaha!``"
 	},
 	{
 		"type": "MSGSET",
@@ -480,6 +480,6 @@
 		"PreTextTags": "@vS26/54/TYOS_1610.",
 		"TextJPN": "「会わせてあげましょうとも。……オヤシロさまに……ッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``I will let you meet it. ......Oyashiro-sama......!``"
+		"TextENG": "``Then I'll help you meet them. ......I'll help you meet Oyashiro-sama......!``"
 	}
 ]

--- a/bus_stop_7.json
+++ b/bus_stop_7.json
@@ -9,13 +9,13 @@
 		"type": "MSGSET",
 		"MessageID": 156290,
 		"TextJPN": "フラッシュした後、暗転。@k@r雷鳴が轟く。",
-		"TextENG": "After the flash, the area turns dark.@k@rThunder roars."
+		"TextENG": "The scene flashes, then goes dark.@k@rThunder rumbles."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156291,
 		"TextJPN": "しばらくの沈黙。@k@r舞台は真っ暗のまま。@k@r無線の声が聞こえる。",
-		"TextENG": "Then silence.@k@rThe stage remains dark.@k@rAs the voice from a radio is heard."
+		"TextENG": "A moment of silence follows.@k@rThe stage remains dark.@k@rA voice is heard over a radio."
 	},
 	{
 		"type": "MSGSET",
@@ -24,19 +24,19 @@
 		"PreTextTags": "@vS26/57/TNIT_0010.",
 		"TextJPN": "「…本部より全車へ。……部外者の排除が終了次第、突入する。…繰り返す、部外者の排除が終了次第、突入する」",
 		"NamesENG": "Voice",
-		"TextENG": "``...Headquarters to all cars. ......It will end as soon as all outsiders are eliminated, move out. ...I repeat, it will end as soon as all outsiders are eliminated, move out.``"
+		"TextENG": "``...HQ to all cars. ......Once the outsiders have been removed, storm in. ...I repeat, once the outsiders have been removed, storm in.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156293,
 		"TextJPN": "落雷の音。@k徐々に舞台明るくなる。",
-		"TextENG": "The sound of thunder in the distance.@k@rThe stage gradually becomes brighter."
+		"TextENG": "Thunder echoes out.@k The stage steadily grows lighter."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156294,
 		"TextJPN": "喉元と指を血だらけにした荒川が倒れて、痙攣している。@k@rどうしていいか判らずおろおろする吉村。@k@r星野・岡野・魅音・梨花・利根川が戻ってくる。",
-		"TextENG": "At the stage center Arakawa falls down in convulsion,@rhis throat and fingers covered in blood.@k@rYoshimura is shaken up,@rhe doesn't know what to do.@k@rHoshino, Okano, Mion, Rika and Tonegawa@rcome back."
+		"TextENG": "Arakawa lies convulsing at center stage, his throat and fingers covered in blood.@k@rYoshimura looks around in a panic, not knowing what to do.@k@rHoshino, Okano, Mion, Rika, and Tonegawa return to the stage."
 	},
 	{
 		"type": "MSGSET",
@@ -45,7 +45,7 @@
 		"PreTextTags": "@vS26/56/TTON_0690.",
 		"TextJPN": "「荒川君ッ！？　どうしたんだ！　大丈夫かッ！？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Arakawa-kun!? What happened! Is he alright!?``"
+		"TextENG": "``Arakawa-kun?! What's going on?! Are you okay?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -54,7 +54,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0150.",
 		"TextJPN": "「何がありましたかッ！」",
 		"NamesENG": "Okano",
-		"TextENG": "``What just happened!``"
+		"TextENG": "``What happened here?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -63,7 +63,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1620.",
 		"TextJPN": "「ぼぼ、僕が聞きたいよッ！　……突然…ッ、……突然そいつが訳のわかんない事をわめきながら暴れ出したんだよ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``I-I-I was listening! ......Then Suddenly... ......suddenly he yelled a few things and started to act violent, I don't know the reason why!``"
+		"TextENG": "``T-T-That's what I'd like to know! ......He suddenly...! ......He suddenly started groaning some nonsense, and then he went crazy!``"
 	},
 	{
 		"type": "MSGSET",
@@ -72,13 +72,13 @@
 		"PreTextTags": "@vS26/54/TYOS_1630.",
 		"TextJPN": "「…殺されるかと思ったぜッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...I thought he was trying to kill me!``"
+		"TextENG": "``...I thought he was going to kill me!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156299,
 		"TextJPN": "荒川の傷口を見る星野。",
-		"TextENG": "Hoshino sees the wound on Arakawa."
+		"TextENG": "Hoshino looks at Arakawa's wounds."
 	},
 	{
 		"type": "MSGSET",
@@ -87,7 +87,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0160.",
 		"TextJPN": "「お前がやったのか！？」",
 		"NamesENG": "Okano",
-		"TextENG": "``Did you do that!?``"
+		"TextENG": "``Did you do this?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -96,7 +96,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1640.",
 		"TextJPN": "「んな訳ないでしょ！？　…そしたらそいつッ！　…突然、自分の喉を…掻きむしり出して…ッ！　……血が！　…血がッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Do you actually think I could!? ...He...! ...Just suddenly, be-began scratching... his own throat...! ......Then Blood! ...Blood!``"
+		"TextENG": "``There's no way I did! ...That man! ...He suddenly started scratching... out his own throat...! ......The blood! ...The blood!``"
 	},
 	{
 		"type": "MSGSET",
@@ -105,7 +105,7 @@
 		"PreTextTags": "@vS26/58/THOS_0130.",
 		"TextJPN": "「……末期ね。……運びましょう。岡野！　…手を貸して！」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``......He's at his deathbed. ......Let's carry him. Okano! ...Lend me a hand!``"
+		"TextENG": "``......He's gone. ......Let's carry him out. Okano! ...Lend me a hand!``"
 	},
 	{
 		"type": "MSGSET",
@@ -114,13 +114,13 @@
 		"PreTextTags": "@vS26/56/TTON_0700.",
 		"TextJPN": "「たたた、助かるんですかッ！？　ねぇ！　ねえ！？」",
 		"NamesENG": "Tonegawa",
-		"TextENG": "``Wi-Wi-Wi-Will he survive!? Hey! Hey!?``"
+		"TextENG": "``C-C-C-Can you save him?! Hey! Hey?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156304,
 		"TextJPN": "荒川を担いで星野と岡野・利根川退場。",
-		"TextENG": "Okano and Hoshino carry Arakawa using their shoulders and leave, accompanied by Tonegawa."
+		"TextENG": "Tonegawa leaves the stage, following Hoshino and Okano as they carry Arakawa."
 	},
 	{
 		"type": "MSGSET",
@@ -129,7 +129,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0960.",
 		"TextJPN": "「………突然、暴れ出して…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........Suddenly, he just began to act violent...?``"
+		"TextENG": "``.........He suddenly went crazy...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -138,7 +138,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1650.",
 		"TextJPN": "「あぁそうさッ！　…俺がやったんじゃないッ！　…あいつが自分で喉を掻きむしったんだッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``That's what happened! ...I didn't do it! ...That guy tore out his own throat by himself!``"
+		"TextENG": "``Yeah, that's right! ...I didn't do this! ...He scratched out his own throat!``"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1660.",
 		"TextJPN": "「…指紋でも何でも調べてくれよッ！　俺じゃない！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Examine his fingernails if you have to! It wasn't me!``"
+		"TextENG": "``...Go and examine the fingerprints or something! It wasn't me!``"
 	},
 	{
 		"type": "MSGSET",
@@ -156,7 +156,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0970.",
 		"TextJPN": "「……誰もあなたが殺したなんて言ってないわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Nobody said you murdered him.``"
+		"TextENG": "``......No one's saying that you killed him.``"
 	},
 	{
 		"type": "MSGSET",
@@ -165,7 +165,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1670.",
 		"TextJPN": "「……こ、殺した！？　…し、しし、死ぬのかあいつ…ッ！？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Mu-Murdered!? ...D-D-D-Do you think he'll die...!?``"
+		"TextENG": "``......K-Killed?! ...H-H-H-He's going to die...?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -174,7 +174,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0980.",
 		"TextJPN": "「……あんな風になって助かると思う？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Do you think he'll survive?``"
+		"TextENG": "``......Do you think they can save him with the state he was in?``"
 	},
 	{
 		"type": "MSGSET",
@@ -183,7 +183,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1330.",
 		"TextJPN": "「………一体……何があったって言うんですか……！」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........Someone tell me what the hell happened......!``"
+		"TextENG": "``.........What...... on earth are you saying happened here......?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -192,7 +192,7 @@
 		"PreTextTags": "@vS26/52/TRIK_0990.",
 		"TextJPN": "「…荒川さんが自分で喉を掻きむしって死んだ。…それが事実よ」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Arakawa-san tore out his own throat and died. ...It's a fact.``"
+		"TextENG": "``...Arakawa-san scratched out his own throat, and died. ...Those are the facts.``"
 	},
 	{
 		"type": "MSGSET",
@@ -201,7 +201,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1680.",
 		"TextJPN": "「なんでッ！　…どうしてそんな事を！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Why! ...Why would he do such a thing!``"
+		"TextENG": "``Why?! ...How did that happen?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -210,7 +210,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1340.",
 		"TextJPN": "「私が聞きたいですよ！　…あんた見てたんでしょ！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``I want to know! ...Did you see him do it!?``"
+		"TextENG": "``That's what I'd like to know! ...You were watching him, weren't you?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1690.",
 		"TextJPN": "「……………………あいつは……。……あいつは……ッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``........................That guy...... ......That guy......!``"
+		"TextENG": "``........................He...... ......He......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,7 +228,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1000.",
 		"TextJPN": "「……これが５人目の犠牲者なの？　…吉村さん」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Is this the fifth victim? ...Yoshimura-san.``"
+		"TextENG": "``......So this was the fifth victim, then? ...Wasn't it, Yoshimura-san?``"
 	},
 	{
 		"type": "MSGSET",
@@ -237,7 +237,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1350.",
 		"TextJPN": "「…って……オヤシロさまの…祟りのこと…っすか……？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Was it...... Oyashiro-sama's... curse......?``"
+		"TextENG": "``...Wait...... You mean this... was Oyashiro-sama's... curse......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -246,7 +246,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1010.",
 		"TextJPN": "「…いい取材になったでしょう。…写真は取れた？　…インタビューは録音できた？　……それともオフレコ？」",
 		"NamesENG": "Rika",
-		"TextENG": "``I thought you were here to collect data. ...Did you take any photographs? Record any interviews? ......Or was it all off the record?``"
+		"TextENG": "``...It'll make good material, won't it? ...Did you get your pictures? ...Did you manage to record your interview with him? ......Or was it all off the record?``"
 	},
 	{
 		"type": "MSGSET",
@@ -255,7 +255,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1700.",
 		"TextJPN": "「ばばばばばば…ばかやろう……。…それどころじゃ……ねえだろ……！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Hahhhh... you idiot...... ...Far from...... it......!``"
+		"TextENG": "``Y-Y-Y-Y-Y-Y-You idiot......! ...This isn't the time...... for that......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -264,7 +264,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1020.",
 		"TextJPN": "「…６人目の犠牲者は誰かしら？　…ねぇ吉村さん」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I wonder who the sixth victim will be... Right, Yoshimura-san?``"
+		"TextENG": "``...I wonder who the sixth victim will be? ...What do you think, Yoshimura-san?``"
 	},
 	{
 		"type": "MSGSET",
@@ -273,7 +273,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1360.",
 		"TextJPN": "「…やや、やめましょうよ梨花さん…！　…もうやめましょうよ…！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...St-St-Stop it, Rika-san...! ...Just stop it already...!``"
+		"TextENG": "``...L-L-Let's stop this, Rika-san...! ...Let's stop this already...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -282,7 +282,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1030.",
 		"TextJPN": "「…６人目は、…初めて建設省以外の人間になるかも知れませんよ？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...The sixth person... I don't know, but ever since the first one, it's always been someone from the Ministry of Construction, right?``"
+		"TextENG": "``...The sixth victim... might be the first person who wasn't with the Ministry of Construction.``"
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1040.",
 		"TextJPN": "「…ねぇ吉村さん。……インタビューより…体験手記の方が効果的じゃありませんか…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Hey, Yoshimura-san. ......Rather than an interview... don't you think an experience based report would be more effective...?``"
+		"TextENG": "``...Hey, Yoshimura-san. ......Wouldn't it be more effective to write down your own experience... instead of getting an interview...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -300,7 +300,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1710.",
 		"TextJPN": "「わわわかったッ！　…オヤシロさまの事は忘れる！　…こんな取材はもうやめるよッ！　…旅館に帰ったら荷物をまとめる！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``I got it! ...I'll forget about Oyashiro-sama! I'll stop collecting data! I'll just summarize it after I get back to the hotel!``"
+		"TextENG": "``A-A-Alright! ...I'll forget all about Oyashiro-sama! ...I'll stop covering this story! ...When I get back to my inn, I'm packing my bags and getting out of here!``"
 	},
 	{
 		"type": "MSGSET",
@@ -309,13 +309,13 @@
 		"PreTextTags": "@vS26/52/TRIK_1050.",
 		"TextJPN": "「…いい心掛けね。……でも、…オヤシロさまは許してくれるかしらね…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...That's a good intention. ......But... I wonder if Oyashiro-sama can be so forgiving...``"
+		"TextENG": "``...That's the spirit. ......But... do you think Oyashiro-sama will permit that...?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156326,
 		"TextJPN": "緊迫の沈黙。そこへ星野がやって来る。",
-		"TextENG": "A tense silence. Hoshino comes over."
+		"TextENG": "A tense silence passes between them. Then Hoshino comes up."
 	},
 	{
 		"type": "MSGSET",
@@ -324,7 +324,7 @@
 		"PreTextTags": "@vS26/58/THOS_0140.",
 		"TextJPN": "「古手梨花さん。…ちょっと来てもらえる？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``Rika Furude-san. ...Could you come over here for a moment?``"
+		"TextENG": "``Rika Furude-san. ...Could you come with me for a bit?``"
 	},
 	{
 		"type": "MSGSET",
@@ -339,7 +339,7 @@
 		"type": "MSGSET",
 		"MessageID": 156329,
 		"TextJPN": "最後の最後まで吉村を目で威嚇し、星野に伴われ退場する梨花。",
-		"TextENG": "Rika threatens Yoshimura with her eyes to the very end, and leaves accompanied by Hoshino."
+		"TextENG": "Rika leaves the stage, following Hoshino, but her eyes continue to menace Yoshimura until the very last moment."
 	},
 	{
 		"type": "MSGSET",
@@ -348,7 +348,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1720.",
 		"TextJPN": "「は！　………はぁあぁあー………。……脅し過ぎだよ…あの子は…」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Hah! .........Hah hah hah......... ......She's too scary...``"
+		"TextENG": "``Hah! .........Haaaaah......... ......That girl... is too threatening...``"
 	},
 	{
 		"type": "MSGSET",
@@ -357,7 +357,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1370.",
 		"TextJPN": "「……荒川さん、……本当に死んじゃったんですか…」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Arakawa-san...... did he really died...?``"
+		"TextENG": "``......Did Arakawa-san...... really die...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -366,7 +366,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1730.",
 		"TextJPN": "「………俺が知るかよッ！　突然だった！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``.........I don't know! It was too sudden!``"
+		"TextENG": "``.........How would I know?! It was all so sudden!``"
 	},
 	{
 		"type": "MSGSET",
@@ -375,7 +375,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1740.",
 		"TextJPN": "「…突然わめき出して…傘をぶんぶん振り回しながら暴れて……！　……俺には何の事だか…ッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...He suddenly began to shout... he rampaged while swinging an umbrella around......! I don't know what was that...!``"
+		"TextENG": "``...He suddenly started groaning to himself... then he went crazy and swung his umbrella around everywhere......! .......I had no idea what was going on...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -384,7 +384,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1380.",
 		"TextJPN": "「……オヤシロさまの祟りで死んだ、ってわけっすか…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Do you think, he died from Oyashiro-sama's curse...?``"
+		"TextENG": "``......Does that mean he died from Oyashiro-sama's curse...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -393,7 +393,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1750.",
 		"TextJPN": "「…確かにあいつは言ったよ！　…オヤシロさまって！　……こんな事って、…あるわけ…ッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...He certainly told something... about Oyashiro-sama! ......Such a thing... it doesn't exist...!``"
+		"TextENG": "``...He did say that! ...He said 'Oyashiro-sama'! ......But something like this... isn't possible...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -402,7 +402,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1390.",
 		"TextJPN": "「……本当に？　……本当にオヤシロさまって言ったんですか…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Really? ......Did he really say Oyashiro-sama...?``"
+		"TextENG": "``......Really? ......Did he really say 'Oyashiro-sama'...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -411,13 +411,13 @@
 		"PreTextTags": "@vS26/54/TYOS_1760.",
 		"TextJPN": "「…言った！　…言ったよ！　…確かにッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...He said it! He said it! I'm certain!``"
+		"TextENG": "``...He said it! ...Yes, he said it! ...I'm sure of that!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156338,
 		"TextJPN": "轟く雷鳴。",
-		"TextENG": "The thunder roars."
+		"TextENG": "Thunder rumbles."
 	},
 	{
 		"type": "MSGSET",
@@ -426,13 +426,13 @@
 		"PreTextTags": "@vS26/54/TYOS_1770.",
 		"TextJPN": "「…畜生…！　……怖ぇえよ…怖ぇえよ！　…畜生……畜生…ッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Damn it...! ......I'm afraid... I'm afraid! ...Damn it...... Damn it...!``"
+		"TextENG": "``...Dammit...! ......I'm scared... I'm scared! ...Dammit! ......Dammit...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156340,
 		"TextJPN": "吉村は俯きながらガタガタと震え、泣きかけている。",
-		"TextENG": "Yoshimura shakes and trembles while looking down, he is about to cry."
+		"TextENG": "Yoshimura shudders as he looks downward, his face on the verge of tears."
 	},
 	{
 		"type": "MSGSET",
@@ -441,7 +441,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1400.",
 		"TextJPN": "「………ねー…吉村さん。…………あんたでしょ。…やったの」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........Hey, Yoshimura-san. ............It was you. ...You did it.``"
+		"TextENG": "``.........Hey... Yoshimura-san. ............It was you, right? ...You did it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -450,7 +450,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1780.",
 		"TextJPN": "「はあッ！？　…馬鹿なこと言うなよ！　…俺がやるわけないだろッ！？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Ha!? ...Don't say such a stupid thing! ...How could I have done it!?``"
+		"TextENG": "``Huh?! ...Don't say something so stupid! ...There's no way I'd do that!``"
 	},
 	{
 		"type": "MSGSET",
@@ -459,7 +459,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1410.",
 		"TextJPN": "「………警察が探してる通り魔殺人犯って、……あんたでしょ」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........The street murderer who the police are looking for...... it's you.``"
+		"TextENG": "``.........The slasher the police were looking for..... is you, isn't it?``"
 	},
 	{
 		"type": "MSGSET",
@@ -468,7 +468,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1790.",
 		"TextJPN": "「何を言うんだよッ！　…怒るぞッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``What did you say! ...You're making me angry!``"
+		"TextENG": "``What are you saying?! ...You're pissing me off!``"
 	},
 	{
 		"type": "MSGSET",
@@ -477,7 +477,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1420.",
 		"TextJPN": "「…おっと、近寄んないで下さいよ！　…大声出せばすぐに刑事さんたちが来るんですからねー…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Uh-oh, please don't come near me! ...Otherwise the detectives and my friend will come over immediately if I shout out loud...``"
+		"TextENG": "``...Whoa, get back! ...If I start shouting, the detectives will come right back here...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -486,7 +486,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1800.",
 		"TextJPN": "「ふ、ふざけるなよッ！　…何だってんだよこいつ！　…俺が何をしたって言うんだよ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``S-Stop messing around! ...What the hell was that?! ...What did I do to deserve this?!``"
+		"TextENG": "``S-Stop screwing around! ...What are you even saying?! ...What are you claiming that I did?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -495,7 +495,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1430.",
 		"TextJPN": "「…さっきの余裕ある態度と正反対じゃないですか」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Your attitude is the complete opposite from a little while ago.``"
+		"TextENG": "``...This attitude is completely different from how calm you were earlier.``"
 	},
 	{
 		"type": "MSGSET",
@@ -504,7 +504,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1440.",
 		"TextJPN": "「……教えて下さいよ。…あんた何者ですか？　……どうして私の事、何から何まで知ってるんですか」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Please tell me. ...Who are you? ......And why, why do you know anything and everything about me?``"
+		"TextENG": "``......Please tell me. ...Who are you? ......How did you know all those things about me?``"
 	},
 	{
 		"type": "MSGSET",
@@ -513,7 +513,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1810.",
 		"TextJPN": "「だから何の話だよッ！　…さっきのヤツもこいつも…！　……どうなってんだよ！？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Anyone could have told you that story! ...It could have been this guy or that guy a little while ago...! What the hell is going on!?``"
+		"TextENG": "``What are you even talking about?! ...You and that last guy both...! ......What is wrong with you all?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -522,13 +522,13 @@
 		"PreTextTags": "@vS26/54/TYOS_1820.",
 		"TextJPN": "「…狂ってるよ！　…ここ、…狂ってやがるよッ！　…わああぁああぁああッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...You're insane! ...Y-Y-You're insane! ...Haaaaaaaah!``"
+		"TextENG": "``...You're mad! ...This whole place... is fucking mad! ...Waaaaaaaaaah!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156351,
 		"TextJPN": "膝に突っ伏して号泣する吉村。魅音は淡々としている。",
-		"TextENG": "Yoshimura falls to his knees and begins crying. Mion is calm and composed."
+		"TextENG": "Yoshimura falls to his knees and wails. Mion remains indifferent to it."
 	},
 	{
 		"type": "MSGSET",
@@ -537,13 +537,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1450.",
 		"TextJPN": "「…変なのはあんたの方じゃん…！　……だからあんた、何者なのさ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...You're the one acting strange...! ......I mean, who the hell are you?!``"
+		"TextENG": "``...You're the one that's not normal...! ......So who are you?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156353,
 		"TextJPN": "魅音の頭にずきんと激痛が走り始める。",
-		"TextENG": "A cowl and acute pain begins to run through Mion's head."
+		"TextENG": "A sharp pain races through Mion's head."
 	},
 	{
 		"type": "MSGSET",
@@ -552,7 +552,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1460.",
 		"TextJPN": "「…ぅあ、……く…！　……頭……ッ、……うう…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Uaa...... Khh...! ......My head...... ......Uuu...!``"
+		"TextENG": "``...Ah...... Kh...! ......My head......! ......Nnngh...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -561,13 +561,13 @@
 		"PreTextTags": "@vS26/54/TYOS_1830.",
 		"TextJPN": "「…はははははは、…あーっはっはっはっはっはっはッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Ha ha ha ha ha ha... ahh ha ha ha ha ha ha!``"
+		"TextENG": "``...Hahahahahaha! ...Ahhhahahahahaha!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156356,
 		"TextJPN": "吉村の泣き声はいつの間にか笑い声に変わっている。",
-		"TextENG": "Before Mion realized, the cries of Yoshimura changed to laughter all too soon."
+		"TextENG": "Yoshimura's crying somehow changes into laughter."
 	},
 	{
 		"type": "MSGSET",
@@ -576,7 +576,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1470.",
 		"TextJPN": "「……よし……むら……！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Yoshi......mura......!?``"
+		"TextENG": "``......Yoshi......mura......?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -585,7 +585,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1840.",
 		"TextJPN": "「…私が何者か？　…何度も言ってるでしょう。吉村ですよ。…フリーライターの吉村」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Who am I? ...I've told you many times. I'm Yoshimura. ...Yoshimura the freelance writer.``"
+		"TextENG": "``...Who am I? ...I've told you many times. I'm Yoshimura. ...Yoshimura, the freelance writer.``"
 	},
 	{
 		"type": "MSGSET",
@@ -594,7 +594,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1480.",
 		"TextJPN": "「…ち……近寄んないで…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...D-Don't come near me...!``"
+		"TextENG": "``...Stay...... Stay away from me...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -603,7 +603,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1850.",
 		"TextJPN": "「荒川さんをやったのは私かって？　……はははは、はっはははははは！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Would you rather have Arakawa-san than me? ......Ha ha ha ha, ahh ha ha ha ha ha ha ha!``"
+		"TextENG": "``You think I'm the one who killed Arakawa-san? ......Hahahaha, hahahahahahaha!``"
 	},
 	{
 		"type": "MSGSET",
@@ -612,7 +612,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1490.",
 		"TextJPN": "「だ、……誰かぁあぁああああッ！　来てぇええぇえええッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``S-Somebody!!! Help!!!``"
+		"TextENG": "``So......Somebodyyyyyyy! Come heeeeeeeere!``"
 	},
 	{
 		"type": "MSGSET",
@@ -621,7 +621,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1860.",
 		"TextJPN": "「………もう少し大きい声で怒鳴らないと来てもらえないんじゃあないですか？　…園崎魅音さん」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``.........Won't you trying shouting that a little more louder? ...Mion Sonozaki-san.``"
+		"TextENG": "``......You'll have to shout a little louder, or no one will come for you. ...Mion Sonozaki-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -630,13 +630,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1500.",
 		"TextJPN": "「刑事さぁあぁあんッ！　…梨花さぁああぁあ、ッ！？　…げほッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Detectives! ...Rika-saaaaaan!? ...*Cough*!``"
+		"TextENG": "``Detectiiiiiiiiiives! ...Rika-saaaaaaaaaan?! ...Ghoh!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156364,
 		"TextJPN": "吉村が、すっと手をかざすと魅音、喉を詰まらせたように咳き込む。",
-		"TextENG": "Yoshimura hold out his hands towards Mion, she tries to clear her clogged throat by coughing."
+		"TextENG": "Yoshimura gently waves his hand, and Mion coughs like something's stuck in her throat."
 	},
 	{
 		"type": "MSGSET",
@@ -645,7 +645,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1870.",
 		"TextJPN": "「はしたない。…年頃のお嬢さんが無闇に大声を出すもんではありませんよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``How vulgar. ...A young lady of age such as yourself shouldn't be shouting so recklessly.``"
+		"TextENG": "``That's improper. ...A young lady your age shouldn't be raising her voice for no reason.``"
 	},
 	{
 		"type": "MSGSET",
@@ -654,7 +654,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1510.",
 		"TextJPN": "「…な、なんで！？　……みんなどこ行っちゃったの！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...W-Why!? ......Where has everyone gone!?``"
+		"TextENG": "``...H-How?! ......Where did everybody go?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -663,7 +663,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1880.",
 		"TextJPN": "「最初のあなたの質問に答えましょう。…荒川さんを殺したのは私か？　……ふっふふふふ！　…答えはイエスです！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Let's answer your first question. ...Is it me who killed Arakawa-san? ......Hee hee hee hee hee! ...The answer is yes!``"
+		"TextENG": "``Allow me to answer your first question. ...Was it me that killed Arakawa-san? ......Fufufufufu! ...The answer is yes!``"
 	},
 	{
 		"type": "MSGSET",
@@ -672,7 +672,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1520.",
 		"TextJPN": "「……なッ……！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Ah......!``"
+		"TextENG": "``......Wha......?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -681,7 +681,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1890.",
 		"TextJPN": "「次の質問に答えましょう。…通り魔殺人犯は私か？　……それもイエスです！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Let's answer the next question. ...Is the street murderer me? ......That is also yes!``"
+		"TextENG": "``Allow me to answer your second question. ...Am I the slasher? ......That is also a yes!``"
 	},
 	{
 		"type": "MSGSET",
@@ -690,7 +690,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1530.",
 		"TextJPN": "「……いや……近寄らないで……ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......No...... don't come near me......!``"
+		"TextENG": "``......No...... Stay away from me......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -699,7 +699,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1900.",
 		"TextJPN": "「どうしてあなたの事を何から何まで知っているか？　……イエス・ノーで答えられない質問は遠慮させてもらいますよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Why do I know anything and everything about you? ......I'll refrain from that question since it can't be answered with a yes or a no.``"
+		"TextENG": "``How did I know all those things about you? ......I won't be answering questions that can't be answered with yes or no.``"
 	},
 	{
 		"type": "MSGSET",
@@ -708,7 +708,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1540.",
 		"TextJPN": "「…な……何で殺すの…！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Wh-Why did you kill him...!?``"
+		"TextENG": "``...Wh...... Why did you kill him...?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -717,7 +717,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1910.",
 		"TextJPN": "「…理由が必要ですか？　…これは面白い。……つまり、理由如何によっては許される殺しもあると、…そう仰るんですね…？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Is a reason necessary? ...This is interesting. ......In other words, if you were asked why did you kill someone... what would you say...?``"
+		"TextENG": "``...Does one need a reason? ...Now this is interesting. ......That suggests some murders are permitted, depending on their reason... Is that what you're telling me...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -726,13 +726,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1550.",
 		"TextJPN": "「ひ……人殺しぃいぃいッ！　……ふぐッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Mu-Murderer! ......Aghhrr!``"
+		"TextENG": "``You...... You murdererrrrr! ......Fggh!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156375,
 		"TextJPN": "再び吉村が手をかざすと魅音、喉を詰まらせたように咳き込む。",
-		"TextENG": "Yoshimura continues holding out his hands towards Mion, she again coughs trying to clear her clogged throat."
+		"TextENG": "Yoshimura waves his hand once more, and Mion coughs like something's stuck in her throat."
 	},
 	{
 		"type": "MSGSET",
@@ -741,7 +741,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1920.",
 		"TextJPN": "「……はしたないからおやめなさい。…叫ぶのは」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Abandon your vulgarness. ...This crying, too.``"
+		"TextENG": "``......That's improper, so stop that. ...No shouting.``"
 	},
 	{
 		"type": "MSGSET",
@@ -750,7 +750,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1560.",
 		"TextJPN": "「た、…たたた…助けて……ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``H-H-H-H-Help......!``"
+		"TextENG": "``He... h-h-he... help me...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -759,7 +759,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1930.",
 		"TextJPN": "「……仕方がないじゃないですか。…あなたは雛見沢なんか田舎だから嫌だと仰られる」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......You don't have a choice. ...You say you don't like Hinamizawa because it's in the country.``"
+		"TextENG": "``......What are we going to do with you? ...You say you hate Hinamizawa because it's so rural.``"
 	},
 	{
 		"type": "MSGSET",
@@ -768,7 +768,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1940.",
 		"TextJPN": "「…都会がいい。東京がいい。…そう仰っておられる。…それじゃあ駄目ですよ。オヤシロさまは許してくれません」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...The city is good. Tokyo is good. ...If you say so. ...But it is no use. Because Oyashiro-sama doesn't permit that.``"
+		"TextENG": "``...You prefer the big city. You prefer Tokyo. ...You keep saying these things. ...That's no good, you know. Oyashiro-sama won't allow it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -777,7 +777,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1570.",
 		"TextJPN": "「…オ、…オヤシロさま……ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...O-Oyashiro-sama......!``"
+		"TextENG": "``...O...Oyashiro-sama......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -786,7 +786,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1950.",
 		"TextJPN": "「…死んだお婆ちゃんにあれだけ脅されたのに…。……東京に心を奪われてしまった。…情けない」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...You were even threatened so much by your dead grandma... ......But you lost your mind and became fascinated with Tokyo. ...You should feel ashamed.``"
+		"TextENG": "``...Your dead grandmother warned you so much, too... ......Yet you still let Tokyo steal your heart. ...What a shame.``"
 	},
 	{
 		"type": "MSGSET",
@@ -804,7 +804,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1960.",
 		"TextJPN": "「建設省の皆さんはよそ者ですからね。…オヤシロさまの事をよく知らなかったので多少、大目にも見ましたが」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``All the people from the Ministry of Construction are outsiders. Since they didn't know Oyashiro-sama that well,  they were not taking him seriously.``"
+		"TextENG": "``All those men from the Ministry of Construction were outsiders, after all. ...They didn't know Oyashiro-sama very well, so he was lenient with them.``"
 	},
 	{
 		"type": "MSGSET",
@@ -813,7 +813,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1970.",
 		"TextJPN": "「…あなたには、…雛見沢の人間には…容赦しませんよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...But you... you're a person from Hinamizawa... I can't forgive you.``"
+		"TextENG": "``...But you... a villager of Hinamizawa... you will receive no mercy.``"
 	},
 	{
 		"type": "MSGSET",
@@ -822,7 +822,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1590.",
 		"TextJPN": "「ややや、やめて殺さないで…許して……！」",
 		"NamesENG": "Mion",
-		"TextENG": "``S-S-S-Stop, don't kill me... forgive me......!``"
+		"TextENG": "``S-S-S-Stop, don't kill me...! Forgive me......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -831,7 +831,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1980.",
 		"TextJPN": "「…許して……ほしいですか…？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Forgiveness...... do you want that...?``"
+		"TextENG": "``...You want...... forgiveness...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -849,7 +849,7 @@
 		"PreTextTags": "@vS26/54/TYOS_1990.",
 		"TextJPN": "「…お父さんに言われたでしょう。…ハイは１回で充分だと。…２回言うと誠意が伝わりませんよ？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Your father should have told you.. ...Saying once should be enough. Saying it twice won't convey your sincerity.``"
+		"TextENG": "``...Your father's told you before, hasn't he? ...You only need to say yes once. ...If you say it twice, you aren't being sincere.``"
 	},
 	{
 		"type": "MSGSET",
@@ -867,7 +867,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2000.",
 		"TextJPN": "「…もう今後一切、東京に憧れませんか？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...In the future, will you no longer long for Tokyo anymore?``"
+		"TextENG": "``...Will you agree to never again long for Tokyo?``"
 	},
 	{
 		"type": "MSGSET",
@@ -885,7 +885,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2010.",
 		"TextJPN": "「…雛見沢に生き、雛見沢に死ぬ事を誓えますか？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Do you swear that you will live and die in Hinamizawa?``"
+		"TextENG": "``...Will you swear to live your life in Hinamizawa, and die in Hinamizawa?``"
 	},
 	{
 		"type": "MSGSET",
@@ -903,7 +903,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2020.",
 		"TextJPN": "「返事は１回で結構！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``One is enough!``"
+		"TextENG": "``One yes is enough!``"
 	},
 	{
 		"type": "MSGSET",
@@ -921,7 +921,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2030.",
 		"TextJPN": "「…ダムなんて到底受け入れられませんね？　…反対しますね？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Will you no longer accept the possibility of a dam? ...Will you oppose it?``"
+		"TextENG": "``...So you surely can't possibly accept the existence of the dam project, can you? ...You'll oppose it, won't you?``"
 	},
 	{
 		"type": "MSGSET",
@@ -930,7 +930,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1650.",
 		"TextJPN": "「は…、はいッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Y-Yes!``"
+		"TextENG": "``Ye...Yes!``"
 	},
 	{
 		"type": "MSGSET",
@@ -939,7 +939,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2040.",
 		"TextJPN": "「…素晴らしい。……あなたは郷土思いの本当に素晴らしいお嬢さんだ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Wonderful. ......You truly are a splendid young lady who loves her hometown like I thought.``"
+		"TextENG": "``...Wonderful. ......You're now a truly wonderful young lady who loves her homeland.``"
 	},
 	{
 		"type": "MSGSET",
@@ -948,7 +948,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2050.",
 		"TextJPN": "「……わかりました。…あなたが今の誓いを生涯守れると言うならば…今回は特別に！　……大目に見ない事もありません」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......I now understand. ...And since you have pledged an oath to keep your promise throughout your life... this time particularly! ......I will overlook what you have done.``"
+		"TextENG": "``......Very well. ...If you agree to uphold the vows you just made for the rest of your life... then we can make an exception this time! ......We could perhaps overlook this.``"
 	},
 	{
 		"type": "MSGSET",
@@ -957,7 +957,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1660.",
 		"TextJPN": "「あああ、ありがとうございますッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Th-Th-Th-Thank you!``"
+		"TextENG": "``T-T-T-Thank you so much!``"
 	},
 	{
 		"type": "MSGSET",
@@ -966,7 +966,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2060.",
 		"TextJPN": "「……ただし、…そのままという訳には行きません」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......But... you can't go just yet.``"
+		"TextENG": "``......However... we can't just leave you as you are right now.``"
 	},
 	{
 		"type": "MSGSET",
@@ -975,7 +975,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2070.",
 		"TextJPN": "「……あなたのお腹の中に真っ黒にこびりついている、雛見沢を捨てようとする悪い汚れを綺麗に吐き出さなくてはなりません」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......That deep black stuck to your stomach, it must be cleaned and thrown up so that abominable filth can never harm Hinamizawa.``"
+		"TextENG": "``......We need to cleanse you. To make you spit up that foul, black corruption stuck in your stomach that made you want to abandon Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -984,7 +984,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1670.",
 		"TextJPN": "「な！　何でもいいですッ！　…許してさえもらえれば何でも構いません！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ah! I'll do anything! ...If you forgive me, I don't mind!``"
+		"TextENG": "``I! I'll do anything! ...I'll do anything to be forgiven!``"
 	},
 	{
 		"type": "MSGSET",
@@ -993,7 +993,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2080.",
 		"TextJPN": "「……痛いですよ？　…苦しいですよ？　……耐えられなければ、…そのまま死んでしまうかも知れません。……よろしいですね？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......Even if it hurts? ...Even if it's painful? ......If you can't endure it, I don't know, but you may die. ......Is that alright?``"
+		"TextENG": "``......It's going to hurt, you know? ...It'll be painful, you know? ......If you can't endure it... then you may very well still die. ......So are you sure?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1002,7 +1002,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1680.",
 		"TextJPN": "「え、……あの……痛いんですか……？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Eh...... umm...... will it hurt......?``"
+		"TextENG": "``Huh? ......Umm......It's going to hurt......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1011,13 +1011,13 @@
 		"PreTextTags": "@vS26/54/TYOS_2090.",
 		"TextJPN": "「その痛みを乗り越えてこそ、…あなたは雛見沢の人間に戻れるんですよ。…………行きますよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``If you overcome the pain... you will return as a person of Hinamizawa. ............Let us go.``"
+		"TextENG": "``But overcoming that pain... will make you a villager of Hinamizawa once more. ............Here I go.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156407,
 		"TextJPN": "吉村が手をかざすと、魅音の腹に激痛が走る。たまらず悲鳴をあげる魅音。",
-		"TextENG": "Yoshimura hold out his hand, and a severe pain runs through Mion's belly. Mion finds it unbearable, falls to the ground and screams."
+		"TextENG": "Yoshimura waves his hand, and intense pain races through Mion's stomach. Mion can't hold back her scream."
 	},
 	{
 		"type": "MSGSET",
@@ -1026,7 +1026,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1690.",
 		"TextJPN": "「やッ…やめて下さい…ッ！　……ぃぃぃいいいぃ…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Pl-Please stop...! ……I-i-iiii-i...!``"
+		"TextENG": "``Pl...Please stop...! ......Aaaaaah...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1035,7 +1035,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2100.",
 		"TextJPN": "「…我慢なさい。…バチだと思って受け入れる事です」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Endure it. ...Accept this punishment.``"
+		"TextENG": "``...Bear with it. ...Accept this as your punishment.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1044,13 +1044,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1700.",
 		"TextJPN": "「ぅがあああがああ…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ghaaaaaaa...!``"
+		"TextENG": "``Ngaaaaaaagaaah...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156411,
 		"TextJPN": "激痛に呻く魅音。やがて、荒川の落とした傘を手によろよろと立ち上がる。",
-		"TextENG": "Mion groans in severe pain. Eventually, she unsteadily stands up with the umbrella Arakawa dropped in her hands."
+		"TextENG": "Mion groans over and over. Eventually she takes up the umbrella Arakawa dropped and stands unsteadily."
 	},
 	{
 		"type": "MSGSET",
@@ -1059,7 +1059,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2110.",
 		"TextJPN": "「……何の真似ですか…？」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``......What imitation is this...?``"
+		"TextENG": "``......What do you think you're doing...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1068,7 +1068,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1710.",
 		"TextJPN": "「ぐおぉおおぉおお…ッ！　……こ……殺して…やる…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Hhhhhhhhaaaaaaa...! ......I-I...... will kill you......!``"
+		"TextENG": "``Ghooooooooh...! ......I'll...... I'll kill... you...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1077,7 +1077,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2120.",
 		"TextJPN": "「…ふ、……ははははははは！　私を殺す？　…はっははははははは！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Hee...... ha ha ha ha ha ha ha! Do you intend to kill me? ...Ahh ha ha ha ha ha ha!``"
+		"TextENG": "``...Fu...... hahahahahahahaha! Kill me? ...Hah, hahahahahahaha!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1086,7 +1086,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1720.",
 		"TextJPN": "「がぁああぁあ…ッ！　…今すぐやめろ。…やめるんだよこれッ！　今すぐッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ahhhhhhhhh...! ...Stop that right now. ...I told you to stop it! Right now!``"
+		"TextENG": "``Gaaaaaaah...! ...Stop this at once. ...Stop this! Right now!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1095,7 +1095,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2130.",
 		"TextJPN": "「…やめたらあなたの中の汚れが出て行きませんよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...The filth won't come out if I stop.``"
+		"TextENG": "``...If we stop, then the corruption within you won't come out.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1104,7 +1104,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1730.",
 		"TextJPN": "「やめろ…。やめろぉおぉ…ッ！　……やめないと殺すぞ…ッ！　…殺すぞぉおおッ！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Stop... Stop it...! ......I'll kill you if you don't stop...! ...I'll kill you!!``"
+		"TextENG": "``Stop it... Stop iiiiiit...! ......If you don't stop, I'll kill you...! ...I'll kill youuuuuu!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1113,7 +1113,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2140.",
 		"TextJPN": "「…残念ですねぇ。…結局あなたは駄目だった。…残念ですよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...I'm disappointed. ...You were useless after all. ...How unfortunate.``"
+		"TextENG": "``...What a shame. ...In the end, you were hopeless. ...What a shame.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1122,13 +1122,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1740.",
 		"TextJPN": "「おおおぉおおおぉおおッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Oooooooooo!``"
+		"TextENG": "``Ooooooohhhh!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156420,
 		"TextJPN": "雄叫びを上げながら傘で殴り掛かる魅音。吉村は難なく避ける。",
-		"TextENG": "Mion lifts the umbrella, and tries to hit him while raising a roar. Yoshimura avoids it without any difficulty."
+		"TextENG": "Mion swings the umbrella at him with a roar. Yoshimura easily dodges it."
 	},
 	{
 		"type": "MSGSET",
@@ -1137,7 +1137,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2150.",
 		"TextJPN": "「…死んでしまいなさい。体中の汚物を吐き尽くして！　…汚物の海に這いつくばりながら死ぬといい！　…荒川君のようにッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...Now die. Vomit that filth from your body! ...You will die groveling in a sea of filth! ...Just like Arakawa-kun!``"
+		"TextENG": "``...Now you die. Coughing up the filth inside of you! ...You can die, crawling on your knees in a sea of filth! ...Just like Arakawa-kun!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1146,7 +1146,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1750.",
 		"TextJPN": "「ぁがあッ！　……登ってくる…！　……登ってくる…ッ！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ghaa! ...Something's climbing...! ......Something's climbing...!!!``"
+		"TextENG": "``Aggaah! ......It's climbing up...! ......It's climbing up...?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1155,7 +1155,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2160.",
 		"TextJPN": "「…胃から食道あたりまで登ってきたようですね。……あなたのお腹の底の汚れがウジとなって登ってきてるんですよ」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``...It seems to have climbed from your stomach to your esophagus area. ...The dirt at the bottom of your stomach which has been climbing is maggots.``"
+		"TextENG": "``...Looks like it's started to climb out of your stomach and up your esophagus. ...The corruption deep within your stomach will climb up... in the form of maggots.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1164,7 +1164,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1760.",
 		"TextJPN": "「ウ、…ウジぃ！？　…いやぁああぁぁあああぁああッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ma-Maggots!? No... Nooo...! Noooooooooooo!``"
+		"TextENG": "``M...  Maggots?! ...Noooooooooooo!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1173,7 +1173,7 @@
 		"PreTextTags": "@vS26/54/TYOS_2170.",
 		"TextJPN": "「さぁ！　吐き出してしまいなさいッ！　さぁ！　さあ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Come on! Spit them out! Come on! Come on!``"
+		"TextENG": "``Now! Spit them all up! Go on! Go on!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1182,6 +1182,6 @@
 		"PreTextTags": "@vS26/53/TMIO_1770.",
 		"TextJPN": "「嫌！　嫌ッ！　嫌ぁああぁああッ！　助けて誰かッ！　梨花さん！　…梨花さぁああぁあんッ！　…ああぁぁあぁぁあああああッ！　の、喉がぁッ、か、かゆいっぃいっ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``No! No! Nooooooo! Someone help me! Rika-san! ...Rika-saaaaaan! Ahhhhhhhhhhh! M-My throat, it-it's so itchy!``"
+		"TextENG": "``No! No! Nooooooooo! Somebody help me! Rika-san! ...Rika-saaaaaaaaaaaan! ...Aaaaaaaaaaaaaaaaaaaaah! M-My throat, i-it itchessss!``"
 	}
 ]

--- a/bus_stop_8.json
+++ b/bus_stop_8.json
@@ -12,13 +12,13 @@
 		"PreTextTags": "@vS26/52/TRIK_1070.",
 		"TextJPN": "「魅音ッ！　…魅音ッ！　…誰か来てッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Mion! ...Mion! ...Anyone, come here!``"
+		"TextENG": "``Mion! ...Mion! ...Somebody come here!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156428,
 		"TextJPN": "梨花が駆けて来て、魅音に飛びつく。@k@r驚いて後退る吉村。@k@r星野と岡野も遅れて駆けてきて、吉村を弾き飛ばす。",
-		"TextENG": "Rika runs over, and jumps at Mion.@k@rYoshimura steps back in wonder.@k@rNot long after Hoshino and Okano@rrun over to Yoshimura."
+		"TextENG": "Rika flies to Mion's side.@k@rYoshimura steps back in shock.@k@rHoshino and Okano both race over a moment later and shove Yoshimura away."
 	},
 	{
 		"type": "MSGSET",
@@ -27,13 +27,13 @@
 		"PreTextTags": "@vS26/54/TYOS_2180.",
 		"TextJPN": "「なッ、ななななな何すんだよッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``Wh-Wh-Wh-Wh-Wh-Wh-What are you doing!``"
+		"TextENG": "``Wha?! W-W-W-W-W-W-What are you doing?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156430,
 		"TextJPN": "混乱しながら岡野に掴みかかる吉村。だがあっさりと組み伏せられてしまう。",
-		"TextENG": "While in a state of confusion, Yoshimura is grabbed by Okano. However, he is pinned down plainly."
+		"TextENG": "Yoshimura grabs at Okano in confusion. However, Okano easily forces him to the ground."
 	},
 	{
 		"type": "MSGSET",
@@ -42,7 +42,7 @@
 		"PreTextTags": "@vS26/58/THOS_0150.",
 		"TextJPN": "「悪いけど、ちょっと来てもらうわよ」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``I'm sorry, but you'll have to come with us.``"
+		"TextENG": "``Sorry, but you'll be coming with us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -51,13 +51,13 @@
 		"PreTextTags": "@vS26/54/TYOS_2190.",
 		"TextJPN": "「だから俺が何したって言うんだよ！　痛てててッ！　離せよぉッ！」",
 		"NamesENG": "Yoshimura",
-		"TextENG": "``So what the hell did I do?! That hurts! Let me go!``"
+		"TextENG": "``What are you people claiming I've done?! Owww! Let go of me!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156433,
 		"TextJPN": "吉村を掴んだまま岡野退場。@k@r星野も梨花に目配せしてから退場する。@k@rほんの少し遅れてから魅音、号泣する。",
-		"TextENG": "Okano leaves while holding Yoshimura.@k@rHoshino follows after winking at Rika.@k@rAfter they leave, Mion begins to cry."
+		"TextENG": "Okano leaves the stage, holding onto Yoshimura.@k@rHoshino glances at Rika and then leaves as well.@k@rA short moment later, Mion begins to sob."
 	},
 	{
 		"type": "MSGSET",
@@ -66,7 +66,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1780.",
 		"TextJPN": "「梨花さん！　梨花さん！　…わぁああぁああぁあああッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Rika-san! Rika-san! ...Waaaaaaaaaaa!``"
+		"TextENG": "``Rika-san! Rika-san! ...Waaaaaaaaaaaaaaah!``"
 	},
 	{
 		"type": "MSGSET",
@@ -75,7 +75,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1080.",
 		"TextJPN": "「もう大丈夫よ！　もう大丈夫！　……ごめんね。ごめんね！」",
 		"NamesENG": "Rika",
-		"TextENG": "``You're alright now! You're alright now! ......I'm sorry. I'm sorry!``"
+		"TextENG": "``It's alright now! It's alright now! ......I'm sorry. I'm sorry!``"
 	},
 	{
 		"type": "MSGSET",
@@ -84,7 +84,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1790.",
 		"TextJPN": "「わぁあぁあああああぁあああぁあああッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Waaaaaaaaaaaaaaaaa!``"
+		"TextENG": "``Waaaaaaaaaaaaaaaaaaaaaaah!``"
 	},
 	{
 		"type": "MSGSET",
@@ -93,7 +93,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1090.",
 		"TextJPN": "「辛い目にあった！？　辛かった！？　……ごめんね！　ごめんね！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Was it a painful experience!? Did it hurt!? ......I'm sorry! I'm sorry!``"
+		"TextENG": "``Did you go through something terrible?! Was it painful?! ......I'm sorry! I'm sorry!``"
 	},
 	{
 		"type": "MSGSET",
@@ -102,7 +102,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1800.",
 		"TextJPN": "「ウジがいっぱい！　うぅッ！　…ああぁああぁあああん！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Maggots everywhere...! Uuu! ...Ahhhhhhhh!``"
+		"TextENG": "``There were so many maggots! Hhhn! ...AAaaaaaaahn!``"
 	},
 	{
 		"type": "MSGSET",
@@ -111,7 +111,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1100.",
 		"TextJPN": "「もう大丈夫！　私が一緒だから！　…ね！」",
 		"NamesENG": "Rika",
-		"TextENG": "``You're alright now! Because we're together! Right?``"
+		"TextENG": "``It's alright now! I'm here with you! ...Okay!``"
 	},
 	{
 		"type": "MSGSET",
@@ -126,7 +126,7 @@
 		"type": "MSGSET",
 		"MessageID": 156441,
 		"TextJPN": "梨花の胸で泣きじゃくる魅音。@k@r舞台、徐々に暗転。@k@rしばらくの沈黙。@k@r舞台は真っ暗のまま。@k@r無線の声が聞こえる。",
-		"TextENG": "Mion sobs into Rika's chest.@k@rThe stage gradually turns dark.@k@rAnd now, silence.@k@rThe stage remains dark.@k@rAs the voice from a radio is heard."
+		"TextENG": "Mion sobs into Rika's chest.@k@rThe stage steadily goes dark.@k@rA moment of silence passes.@k@rThe stage remains dark.@k@rA voice plays over the radio."
 	},
 	{
 		"type": "MSGSET",
@@ -135,13 +135,13 @@
 		"PreTextTags": "@vS26/60/TODA_0020.",
 		"TextJPN": "「…本部どうぞ。本部どうぞ。…部外者の排出完了。繰り返します。部外者の排出完了」",
 		"NamesENG": "Voice",
-		"TextENG": "``...Headquarters, come in. Headquarters, come in. ...The discharge of the outsiders is complete. I repeat. The discharge of the outsiders is complete.``"
+		"TextENG": "``...HQ, over. HQ, over. ...The outsiders have been removed. I repeat. The outsiders have been removed.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156443,
 		"TextJPN": "落雷の音。@k@r徐々に舞台明るくなる。@k@rどしゃぶりの音、遠くなっていく。@k@r魅音と梨花だけしかいない。@k@r雨の音と沈黙。",
-		"TextENG": "The sound of lightning.@k@rThe stage gradually becomes brighter.@k@rThe sound of the downpour has now distanced itself.@k@rThere is now only Mion and Rika.@k@rTogether with silence and the sound of the rain."
+		"TextENG": "Thunder roars.@k@rThe stage steadily grows brighter.@k@rThe sound of heavy rainfall fades into the distance.@k@rOnly Mion and Rika remain.@k@rAll is silent save for the rain."
 	},
 	{
 		"type": "MSGSET",
@@ -168,7 +168,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1120.",
 		"TextJPN": "「…元気出して。…私は元気なあなたが好きよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Show some spirit. ...I like a cheerful you.``"
+		"TextENG": "``...Cheer up. ...I love it when you're full of life.``"
 	},
 	{
 		"type": "MSGSET",
@@ -177,7 +177,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1830.",
 		"TextJPN": "「もう大丈夫です。…もう」",
 		"NamesENG": "Mion",
-		"TextENG": "``I'm alright now...``"
+		"TextENG": "``I'm okay now. ...I'm good.``"
 	},
 	{
 		"type": "MSGSET",
@@ -186,7 +186,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1840.",
 		"TextJPN": "「…荒川さんを殺したのはあいつだったんです」",
 		"NamesENG": "Mion",
-		"TextENG": "``...It was that guy who killed Arakawa-san.``"
+		"TextENG": "``...That man was the one who killed Arakawa-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -195,7 +195,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1130.",
 		"TextJPN": "「……吉村さんが…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Yoshimura-san...?``"
+		"TextENG": "``......Yoshimura-san, you mean...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -204,7 +204,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1850.",
 		"TextJPN": "「あいつ…変な超能力みたいな力が使えるんですよ。…その力で…荒川さんを…！」",
 		"NamesENG": "Mion",
-		"TextENG": "``That guy... he used some sort of weird ESP power. ...And he used that power... on Arakawa-san...!``"
+		"TextENG": "``He... was capable of using some kind of strange, supernatural power. ...He used that power... on Arakawa-san...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -213,7 +213,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1860.",
 		"TextJPN": "「……もうすぐで…私も……殺される所だった……！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......If you didn't come here in time... I... I would have been killed, too......!``"
+		"TextENG": "``......He nearly... He nearly killed me too......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -222,7 +222,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1140.",
 		"TextJPN": "「……無事でよかった」",
 		"NamesENG": "Rika",
-		"TextENG": "``......It's okay, you're safe now.``"
+		"TextENG": "``......I'm glad you're safe.``"
 	},
 	{
 		"type": "MSGSET",
@@ -231,7 +231,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1870.",
 		"TextJPN": "「市内で起こった通り魔殺人の犯人もあいつなんです。…あいつがそう、自分で言いました」",
 		"NamesENG": "Mion",
-		"TextENG": "``The criminal who did those street murders that happened in town must have been that guy. ...That guy, he said so himself.``"
+		"TextENG": "``He was the one behind the murders in the city too. ...He said so himself.``"
 	},
 	{
 		"type": "MSGSET",
@@ -240,7 +240,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1880.",
 		"TextJPN": "「……私たちは…なんて恐ろしいヤツと一緒に……！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......We... we were with such a terrible person......!``"
+		"TextENG": "``......We were right here with... With such a terrifying person......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -249,7 +249,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1150.",
 		"TextJPN": "「…………でももう終わったわ。…刑事さんが連れて行っちゃったもの。…もうあなたを苛める人はいないわ…」",
 		"NamesENG": "Rika",
-		"TextENG": "``............But it's over now. ...The detectives have taken him away. ...That person can't torment you anymore...``"
+		"TextENG": "``............But it's all over now. ...The detectives have taken him away. ...There's no one who'll hurt you anymore...``"
 	},
 	{
 		"type": "MSGSET",
@@ -258,7 +258,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1890.",
 		"TextJPN": "「…梨花さん…。…助けてくれて、ありがとう。……梨花さんが来てくれなかったら……私……私…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Rika-san... Thank you for helping me. ......If you didn't come, Rika-san...... I...... I...!``"
+		"TextENG": "``...Rika-san... ...Thank you for saving me. ......If you hadn't come for me...... I...... I......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -285,7 +285,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1170.",
 		"TextJPN": "「……もう充分よ。……もうやめて。…私はあなたにお礼を言われるような事は何もしてないもの」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Enough already. ......You can stop it now. ...I haven't done anything for which you can thank me.``"
+		"TextENG": "``......That's enough. ......You can stop now. ...I haven't done anything to deserve your gratitude.``"
 	},
 	{
 		"type": "MSGSET",
@@ -294,7 +294,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1180.",
 		"TextJPN": "「………せめて。……こうして一緒にいてあげる事が私にできる全て…」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........At the very least. ......All I can do is be together with you...``"
+		"TextENG": "``.........All I can do...... is stay here beside you like this...``"
 	},
 	{
 		"type": "MSGSET",
@@ -303,13 +303,13 @@
 		"PreTextTags": "@vS26/53/TMIO_1910.",
 		"TextJPN": "「………ありがとう……」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........Thank you......``"
+		"TextENG": "``.........Thank you.........``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156462,
 		"TextJPN": "雨の音。ようやく落ち着き梨花から離れる魅音。",
-		"TextENG": "The sound of the rain. Mion finally lets go of Rika."
+		"TextENG": "The sound of rain continues. Mion finally calms down enough to separate herself from Rika."
 	},
 	{
 		"type": "MSGSET",
@@ -318,7 +318,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1920.",
 		"TextJPN": "「…へへ…すみません。……お見苦しいトコ、お見せしちゃって……」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Heh... I'm sorry. ......I'm sorry you had to see that......``"
+		"TextENG": "``...Hehe... I'm sorry. ......For letting you see me like that......``"
 	},
 	{
 		"type": "MSGSET",
@@ -327,7 +327,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1190.",
 		"TextJPN": "「………ねぇ魅音。………どうして魅音は私と友達になってくれたの…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........Hey, Mion. .........Why did you make friends with me...?``"
+		"TextENG": "``.........Hey, Mion. .........Why did you become my friend...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -336,7 +336,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1930.",
 		"TextJPN": "「…え、…なんですか、突然」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Eh... This was... unexpected.``"
+		"TextENG": "``...Huh? ...What's this out of the blue?``"
 	},
 	{
 		"type": "MSGSET",
@@ -345,7 +345,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1200.",
 		"TextJPN": "「……私ってさ。…無口で存在感ないでしょ。…面白い話なんかちっともできないし。……無論、友達なんかひとりもいない」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Because, you know. ...I'm a taciturn who has no presence. ...I'm not even interesting to talk to at all. ......And of course, I don't have any friends.``"
+		"TextENG": "``......I'm, you know. ...I'm all quiet. I'm barely there, right? ...It's not like I can talk about anything interesting. ......And of course, I don't have any other friends.``"
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1210.",
 		"TextJPN": "「…あの時、魅音が話しかけてくれた事が全ての始まりだったの。…嬉しかった」",
 		"NamesENG": "Rika",
-		"TextENG": "``...At that time, even knowing the fact that in the beginning you were the only one talking, Mion. ...I was happy.``"
+		"TextENG": "``...That day we talked for the first time... was the start of everything for me. ...I was so happy.``"
 	},
 	{
 		"type": "MSGSET",
@@ -363,7 +363,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1940.",
 		"TextJPN": "「そんな梨花さん、大仰な」",
 		"NamesENG": "Mion",
-		"TextENG": "``Rika-san, you're exaggerating.``"
+		"TextENG": "``You're exaggerating, Rika-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -372,7 +372,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1220.",
 		"TextJPN": "「ねぇ教えて。……どうして私に、…話しかけてくれたの？　……私より愉快な人は大勢いたはずでしょ」",
 		"NamesENG": "Rika",
-		"TextENG": "``Hey, tell me. ......Why... did you talk to me? ......There should have been a lot of people who were more pleasant than me.``"
+		"TextENG": "``So tell me. ......Why... did you talk to me? ......There were plenty of other, happier people, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -390,7 +390,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1950.",
 		"TextJPN": "「…へっへー！　…それはですねぇ！　…梨花さんと私とは赤い糸でー、」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Heh! ...You see! Rika-san, you and I are connected with red thread...``"
+		"TextENG": "``...Heheh! ...Well, that's because! ...You and I are tied by the red string of fate!``"
 	},
 	{
 		"type": "MSGSET",
@@ -399,13 +399,13 @@
 		"PreTextTags": "@vS26/52/TRIK_1240.",
 		"TextJPN": "「……真面目な話なの。……教えて」",
 		"NamesENG": "Rika",
-		"TextENG": "``......I'm trying to have a serious talk. ......Tell me.``"
+		"TextENG": "``......I'm being serious here. ......Tell me.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156473,
 		"TextJPN": "真面目な顔で魅音の瞳を見つめる梨花。",
-		"TextENG": "Rika stares into Mion's eyes with a serious face."
+		"TextENG": "Rika stares into Mion's eyes with a stern look."
 	},
 	{
 		"type": "MSGSET",
@@ -423,7 +423,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1250.",
 		"TextJPN": "「…お願い。……どうしても知りたいの…。……教えて……」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Please, I'm asking you. ......I want to know... ......Tell me......``"
+		"TextENG": "``...Please. ......I have to know... ......Tell me......``"
 	},
 	{
 		"type": "MSGSET",
@@ -432,7 +432,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1970.",
 		"TextJPN": "「………お……怒んないで……下さいよぅ…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........You won't be angry...?``"
+		"TextENG": "``.........Don't...... Don't get mad...... please...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -441,7 +441,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1260.",
 		"TextJPN": "「……怒らない」",
 		"NamesENG": "Rika",
-		"TextENG": "``......I won't.``"
+		"TextENG": "``......I won't get mad.``"
 	},
 	{
 		"type": "MSGSET",
@@ -450,7 +450,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1980.",
 		"TextJPN": "「………梨花さん、………寂しそうだなー…って…」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........Rika-san......... you looked lonely......``"
+		"TextENG": "``.........I thought......... that you looked... lonely...``"
 	},
 	{
 		"type": "MSGSET",
@@ -459,7 +459,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1270.",
 		"TextJPN": "「…え…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Eh...?``"
+		"TextENG": "``...Huh...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -468,7 +468,7 @@
 		"PreTextTags": "@vS26/53/TMIO_1990.",
 		"TextJPN": "「……いっつも教室でぽつんとしてて……誰も話しかけないし……何か気の毒で……そういう気持ちで話しかけたんですよ…」",
 		"NamesENG": "Mion",
-		"TextENG": "``......You always looked so lonely in the classroom...... nobody talked to you...... I felt sorry...... so I talked to you feeling that...``"
+		"TextENG": "``......You always seemed so isolated in the classroom...... No one would talk to you. ......I felt bad for you...... So that's why I spoke up...``"
 	},
 	{
 		"type": "MSGSET",
@@ -477,7 +477,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2000.",
 		"TextJPN": "「…あ！　今は違いますよ！　今は一番の親友ですもん！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Ah! It's different now! Now you're my best friend!``"
+		"TextENG": "``...Oh! But that's not the case anymore! Now you're my best friend!``"
 	},
 	{
 		"type": "MSGSET",
@@ -486,7 +486,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2010.",
 		"TextJPN": "「…私にも…梨花さんみたいな頃があったんですよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``...I... hope you feel the same way, Rika-san.``"
+		"TextENG": "``...There was a time... when I was just like you were.``"
 	},
 	{
 		"type": "MSGSET",
@@ -495,7 +495,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2020.",
 		"TextJPN": "「…でもさ、人って結構残酷で…暗い顔してるとますます話しかけてくれなくなるんですよね」",
 		"NamesENG": "Mion",
-		"TextENG": "``...But you know, people can be pretty cruel.... If you look gloomy, they'll talk to you less and less more.``"
+		"TextENG": "``...But you know, people can be pretty cruel... When you look all gloomy, it makes them even less inclined to talk to you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -504,7 +504,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2030.",
 		"TextJPN": "「…こっちは…ひとりでもいいからお友達が欲しいのに…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Everybody should have a friend... Even just one...``"
+		"TextENG": "``...Even though... all you want is at least one friend...``"
 	},
 	{
 		"type": "MSGSET",
@@ -522,7 +522,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2040.",
 		"TextJPN": "「…だから…、……同情なんかじゃなくて……、梨花さんとお友達になろうと決めたんです！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...So... ......it wasn't out of pity...... I just decided that I wanted to make friends with you, Rika-san!``"
+		"TextENG": "``...So... ......It wasn't just out of pity...... I decided myself that I was going to be your friend!``"
 	},
 	{
 		"type": "MSGSET",
@@ -531,7 +531,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2050.",
 		"TextJPN": "「……じゃなかったら……梨花さんが……可哀相で……」",
 		"NamesENG": "Mion",
-		"TextENG": "``......If I didn't do that...... Rika-san...... would look sad......``"
+		"TextENG": "``......Otherwise...... It would be too sad...... for you......``"
 	},
 	{
 		"type": "MSGSET",
@@ -540,13 +540,13 @@
 		"PreTextTags": "@vS26/53/TMIO_2060.",
 		"TextJPN": "「……す！　…すみません！　…決して…そういうつもりで言ったんじゃ……、…！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......I-I'm sorry! ...That's not what I meant...... ...!?``"
+		"TextENG": "``......I! ...I'm sorry! ...I didn't... mean to say it like that.........?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156489,
 		"TextJPN": "涙をぼろぼろこぼし始める梨花。何事かと驚く魅音。",
-		"TextENG": "Rika begins shedding drops of tears. Mion is surprised by her reaction."
+		"TextENG": "Tears start streaming from Rika's eyes. Mion becomes shocked and confused."
 	},
 	{
 		"type": "MSGSET",
@@ -564,7 +564,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2070.",
 		"TextJPN": "「な、…ど、…どうしたんすか…。…梨花さん…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Wh-Wh-What's wrong... ...Rika-san...?``"
+		"TextENG": "``Wha? ...Wha... What's wrong...? ...Rika-san...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -573,7 +573,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1300.",
 		"TextJPN": "「…私のたったひとりの…お友達なのに……ごめん！　……ごめんなさいッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I thought I was alone... even though you were my friend...... I'm sorry! ......I'm sorry!``"
+		"TextENG": "``...You've been my only friend... and I...... I'm sorry! ......I'm sorry!``"
 	},
 	{
 		"type": "MSGSET",
@@ -582,7 +582,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2080.",
 		"TextJPN": "「…り、…梨花さん……」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Ri-Rika-san......``"
+		"TextENG": "``...R... Rika-san......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -591,13 +591,13 @@
 		"PreTextTags": "@vS26/52/TRIK_1310.",
 		"TextJPN": "「…私は……私は……何て事を……ッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I...... What I...... was thinking......!``"
+		"TextENG": "``...What...... What...... have I done......?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156495,
 		"TextJPN": "梨花、ポケットから小さな錠剤の瓶を取り出し魅音に託す。",
-		"TextENG": "Rika takes out a small bottle of tablets from her pocket and entrusts it to Mion."
+		"TextENG": "Rika pulls a small bottle of pills from her pocket and hands them to Mion."
 	},
 	{
 		"type": "MSGSET",
@@ -606,7 +606,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1320.",
 		"TextJPN": "「………逃げて」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........Escape.``"
+		"TextENG": "``.........Run.``"
 	},
 	{
 		"type": "MSGSET",
@@ -615,7 +615,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2090.",
 		"TextJPN": "「へ！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Heh!?``"
+		"TextENG": "``Huh?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -624,7 +624,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1330.",
 		"TextJPN": "「…我慢できないくらい頭が痛くなったら１錠だけ飲むの！　…持って行って！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...If your headache becomes so painful you can't stand, take one of these tablets and drink it! ...Take it!``"
+		"TextENG": "``...When your head hurts too much to bear, take only one! ...Bring them with you!``"
 	},
 	{
 		"type": "MSGSET",
@@ -633,7 +633,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2100.",
 		"TextJPN": "「ななな、何の話ですか梨花さん！？　…よくわかんないんですけど」",
 		"NamesENG": "Mion",
-		"TextENG": "``Wh-Wh-Wh-What are you talking about, Rika-san!? ...You aren't making any sense.``"
+		"TextENG": "``W-W-W-What are you talking about, Rika-san?! ...I don't understand.``"
 	},
 	{
 		"type": "MSGSET",
@@ -642,7 +642,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1340.",
 		"TextJPN": "「逃げてッ！　どこでもいいから早くッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Run away! Before it's too late!``"
+		"TextENG": "``Run! It doesn't matter where, just hurry!``"
 	},
 	{
 		"type": "MSGSET",
@@ -651,7 +651,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2110.",
 		"TextJPN": "「逃げるったって…、どこへ？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Run away... to where?``"
+		"TextENG": "``Run...? To where?``"
 	},
 	{
 		"type": "MSGSET",
@@ -660,7 +660,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1350.",
 		"TextJPN": "「……う…………、…とにかく自宅はだめ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``..................At any rate, your home's no use!``"
+		"TextENG": "``......Nh............... ...Anywhere but your home!``"
 	},
 	{
 		"type": "MSGSET",
@@ -669,7 +669,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2120.",
 		"TextJPN": "「そ、そんな事いきなり言われても…！　…何で…、」",
 		"NamesENG": "Mion",
-		"TextENG": "``Even if you suddenly tell me to do this...! ...Why...``"
+		"TextENG": "``Y-You telling me this all of sudden doesn't mean...! ...Why...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -678,7 +678,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1360.",
 		"TextJPN": "「どこでもいいから早くッ！　逃げてッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``It doesn't matter where! Now run!``"
+		"TextENG": "``It doesn't matter where, just hurry! Get out of here!``"
 	},
 	{
 		"type": "MSGSET",
@@ -687,7 +687,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2130.",
 		"TextJPN": "「訳を教えて下さいよ！　訳を！　…何で私が逃げなくちゃいけないんですか！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Please tell me the reason! The Reason! ...Why do I have to escape!?``"
+		"TextENG": "``Please explain why! Tell me the reason! ...Why do I have to run away?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -696,7 +696,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2140.",
 		"TextJPN": "「…梨花さんはどうすんですか！？　…逃げないんですか！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...And what about you, Rika-san!? ...You are not escaping!?``"
+		"TextENG": "``...And what about you, Rika-san?! ...Are you not running?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -705,7 +705,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1370.",
 		"TextJPN": "「…後は私が全部やるから…。…もう私の事は忘れて…、……逃げて…！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I'll do it afterwards... ...Just forget about me... ......and run away...!``"
+		"TextENG": "``...I'll take care of everything... ...So forget about me now... ......and run...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -723,19 +723,19 @@
 		"PreTextTags": "@vS26/52/TRIK_1380.",
 		"TextJPN": "「早く行ってッ！　早くしないと…！　…あいつらがッ！　…逃げてぇええぇえッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Go quickly! You have to hurry...! ...Before they get here! ...Now run away!``"
+		"TextENG": "``Just go! If you don't hurry...! ...Then they'll! ...Ruuuuuuuuuun!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156510,
 		"TextJPN": "星野と岡野がぬっと現れる。@k@r続いて@bにった.@<新田@>を先頭に@bほとだ.@<保土田@>・@bおだ.@<織田@>が入ってくる。",
-		"TextENG": "Okano and Hoshino appear.@k@rAnd with Nitta in the lead,@rHotoda and Oda appear also."
+		"TextENG": "Hoshino and Okano suddenly appear.@k@rHotoda and Oda appear as well, following behind Nitta."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156511,
 		"TextJPN": "梨花は魅音の前に立ち、魅音をかばう。",
-		"TextENG": "Rika stands in front of Mion, protecting her."
+		"TextENG": "Rika stands in front of Mion, shielding her."
 	},
 	{
 		"type": "MSGSET",
@@ -744,7 +744,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0020.",
 		"TextJPN": "「逃がされては困ります。梨花さん」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Escape would trouble us dearly. Rika-san.``"
+		"TextENG": "``We can't have you running away on us, Rika-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -753,7 +753,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1390.",
 		"TextJPN": "「………来ないで」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........Don't come any closer.``"
+		"TextENG": "``.........Stay back.``"
 	},
 	{
 		"type": "MSGSET",
@@ -762,7 +762,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2160.",
 		"TextJPN": "「…警察の人ですよね…？　…何の用でしょうね…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Aren't those people from the police...? ...What do they want...``"
+		"TextENG": "``...You're the police, right...? ...What do you need...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -771,7 +771,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1400.",
 		"TextJPN": "「…こいつらは…警察なんかじゃないわ…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Those people... they're not the police...``"
+		"TextENG": "``...These men... are not police...``"
 	},
 	{
 		"type": "MSGSET",
@@ -780,7 +780,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0030.",
 		"TextJPN": "「おぉ…。…お初にお目にかかります。あなたが園崎魅音さんですね…？」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Oh... I've seen you for the first time. Aren't you Mion Sonozaki...?``"
+		"TextENG": "``Ohh... ...Pleasure to meet you. You must be Mion Sonozaki-san, right...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -789,7 +789,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2170.",
 		"TextJPN": "「えぇ、はい、どーも…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Eh, yes, hello...``"
+		"TextENG": "``Uhh, yes. Hello...``"
 	},
 	{
 		"type": "MSGSET",
@@ -798,7 +798,7 @@
 		"PreTextTags": "@vS26/58/THOS_0160.",
 		"TextJPN": "「係長。…すでに末期症状です。刺激しないように注意して下さい」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``Assistant manager. She's already at a terminally ill stage. Please be careful not to stimulate her.``"
+		"TextENG": "``Chief. ...She's already at the terminal stage. Please take care not to agitate her.``"
 	},
 	{
 		"type": "MSGSET",
@@ -807,7 +807,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0040.",
 		"TextJPN": "「自己紹介しましょう。…私は@bにった.@<新田@>@bひろあき.@<博昭@>と申します。厚生省保険医療局感染症対策課に勤務しています。…こっちは岡野君」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Let's introduce ourselves. ...My name is Nitta Hiroaki. I work for the Ministry of Health and Welfare Insurance Medical Station Measures Against Infectious Diseases Department. ...And this here is Okano-kun.``"
+		"TextENG": "``Allow me to introduce myself. ...I'm Hiroaki Nitta. I work in the Infectious Diseases Control Division of the Ministry of Health's Service Bureau. ...This is Okano-kun.``"
 	},
 	{
 		"type": "MSGSET",
@@ -816,7 +816,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0170.",
 		"TextJPN": "「@bおかの.@<岡野@>です。同じく感染症対策課に勤務しています。…先程は警察と名乗りましたが、嘘でした。申し訳ありません」",
 		"NamesENG": "Okano",
-		"TextENG": "``I'm Okano. Similarly, I also work in the Measures Against Infectious Diseases Department. ...Some time ago I introduced myself as working for the police, that was a lie. I'm sorry.``"
+		"TextENG": "``I'm Okano. I work in the same Infectious Diseases Control Division. ...I know we introduced ourselves as police before, but that was false. I apologize.``"
 	},
 	{
 		"type": "MSGSET",
@@ -825,7 +825,7 @@
 		"PreTextTags": "@vS26/60/TODA_0030.",
 		"TextJPN": "「同じく感染症対策課の@bおだ.@<織田@>です」",
 		"NamesENG": "Oda",
-		"TextENG": "``Similarly, Oda of the Measures Against Infectious Diseases Department.``"
+		"TextENG": "``I'm Oda, also from the same Infectious Diseases Control Division.``"
 	},
 	{
 		"type": "MSGSET",
@@ -834,7 +834,7 @@
 		"PreTextTags": "@vS26/61/THOT_0020.",
 		"TextJPN": "「同じく@bほとだ.@<保土田@>です。よろしく」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``Similarly, I am Hotoda. Nice to meet you.``"
+		"TextENG": "``Hotoda, with the same. Nice to meet you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -843,7 +843,7 @@
 		"PreTextTags": "@vS26/58/THOS_0170.",
 		"TextJPN": "「@bほしの.@<星野@>です。よろしく、園崎さん」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``I am Hoshino. Nice to meet you, Sonozaki-san.``"
+		"TextENG": "``I'm Hoshino. Nice to meet you, Sonozaki-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -852,7 +852,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0050.",
 		"TextJPN": "「星野主任は国立予防衛生研究所、寄生虫部からの出向です。今回の件のスペシャリストとして派遣されています」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Chief Hoshino's from National Institute of Health, on a temporary transfer from the parasite department. She was dispatched as a specialist on this matter.``"
+		"TextENG": "``Hoshino is with us from the Division of Parasites in the National Institute for Infectious Diseases. She's been sent to us as a specialist to help with this matter.``"
 	},
 	{
 		"type": "MSGSET",
@@ -861,7 +861,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2180.",
 		"TextJPN": "「…はぁ…。……何か今日はお役人のオンパレードですねぇ…。…建設省に厚生省。文部省とか大蔵省も来ますかねぇ？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Huh... ......What is today, a parade for government officials... ...First the Ministry of Construction and now the Ministry of Health and Welfare. Should I expect the Ministry of Education and Ministry of Finance to come, too?``"
+		"TextENG": "``...Okay... ......We're sure seeing a parade of government officials today, huh... ...First the Ministry of Construction, now the Ministry of Health. Are the Ministry of Education and the Ministry of Finance coming too?``"
 	},
 	{
 		"type": "MSGSET",
@@ -870,7 +870,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0060.",
 		"TextJPN": "「それは来ません。…ご安心を」",
 		"NamesENG": "Nitta",
-		"TextENG": "``They won't come. ...Don't worry.``"
+		"TextENG": "``They won't be coming. ...Rest assured.``"
 	},
 	{
 		"type": "MSGSET",
@@ -879,7 +879,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1410.",
 		"TextJPN": "「……帰って！　……魅音は渡さない」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Stay back! ......I won't let you lay a hand on Mion.``"
+		"TextENG": "``......Go home! ......I'm not handing Mion over.``"
 	},
 	{
 		"type": "MSGSET",
@@ -888,7 +888,7 @@
 		"PreTextTags": "@vS26/60/TODA_0040.",
 		"TextJPN": "「梨花さん。…今さらそれは困ります」",
 		"NamesENG": "Oda",
-		"TextENG": "``Rika-san. ...You're in trouble now.``"
+		"TextENG": "``Rika-san. ...That's not an option at this point.``"
 	},
 	{
 		"type": "MSGSET",
@@ -897,7 +897,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2190.",
 		"TextJPN": "「…な、なんかいやーな雰囲気なんですけど…。…なんすか？　私に何かご用ですか…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Wh-What's up with this unpleasant atmosphere... ...What is going? Is there something you want from me...?``"
+		"TextENG": "``...I-I'm getting kind of a bad feeling here... ...But, what's going on? Do you need me for something...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -906,7 +906,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0070.",
 		"TextJPN": "「おぉ、それはもちろんです。魅音さんにぜひご協力いただきたい事がありまして、…職員一同で出向かせてもらいました」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Oh, of course there is. If you're that eager to help, Mion-san... just cooperate with my staff by all means.``"
+		"TextENG": "``Oh, of course we do. We would love to have your cooperation, Mion-san... That's why we've brought all of our staff here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -915,7 +915,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0080.",
 		"TextJPN": "「…無礼の程はお許し下さい」",
 		"NamesENG": "Nitta",
-		"TextENG": "``...Please forgive me, I meant no disrespect.``"
+		"TextENG": "``...Please pardon our earlier rudeness.``"
 	},
 	{
 		"type": "MSGSET",
@@ -924,7 +924,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2200.",
 		"TextJPN": "「な、…なんかＶＩＰ待遇って感じっすよねぇ…。…はは！　なんか悪い気しないなー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Wh-Why do I feel like I'm getting some kind of VIP treatment... ...Ha ha! I guess you're not that bad!``"
+		"TextENG": "``I... I feel like I'm getting the VIP treatment here... ...Haha! It doesn't feel that bad, though!``"
 	},
 	{
 		"type": "MSGSET",
@@ -933,7 +933,7 @@
 		"PreTextTags": "@vS26/61/THOT_0030.",
 		"TextJPN": "「…もちろんそうですとも。園崎さんには今後、最高の待遇で当たらせていただきます」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``...Of course you will. Your future, Sonozaki-san, is best within our treatment.``"
+		"TextENG": "``...Well, of course you are. We'll be providing you with the best possible living conditions, Sonozaki-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -942,7 +942,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2210.",
 		"TextJPN": "「ははッ！　やったね！@k@|@y@vS26/53/TMIO_2211.　………なんて言う訳ないじゃん。バーカ。……理由もなくうまい話が来るわけないでしょー」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ha ha! I did it!@k@|@y@vS26/53/TMIO_2211. .........How could I say that, idiots? ......You don't get a good deal for no reason.``"
+		"TextENG": "``Haha! Hooray!@k@|@y@vS26/53/TMIO_2211. .........Did you really think I'd say that? Idiots. ......There's no way such a sweet deal would come without strings attached.``"
 	},
 	{
 		"type": "MSGSET",
@@ -951,7 +951,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0090.",
 		"TextJPN": "「仰る通りです。ですが理由はあります。…今からその理由を申し上げますので、どうか冷静にお聞き下さい」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Exactly. However, we do have a reason. ...And since you talked about our reason just now, please listen to us calmly.``"
+		"TextENG": "``You would be correct. Though there is a reason for it. ...I'll explain that reason to you now, so please listen calmly.``"
 	},
 	{
 		"type": "MSGSET",
@@ -960,7 +960,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0100.",
 		"TextJPN": "「…少々その、信じ難い話ですからね。……星野さん。お願いします」",
 		"NamesENG": "Nitta",
-		"TextENG": "``...Although it may be a slightly unbelievable story. ......Hoshino-san. If you would.``"
+		"TextENG": "``...It will be slightly difficult to believe, you see. ......Hoshino-san. Would you please?``"
 	},
 	{
 		"type": "MSGSET",
@@ -969,7 +969,7 @@
 		"PreTextTags": "@vS26/58/THOS_0180.",
 		"TextJPN": "「雛見沢の方ですからご存知ですね？　…オヤシロさまの祟りの話は」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``You're from Hinamizawa, correct? ...So you must know the story about the curse of Oyashiro-sama.``"
+		"TextENG": "``Since you're from Hinamizawa, you must already know, right? ...About Oyashiro-sama's curse?``"
 	},
 	{
 		"type": "MSGSET",
@@ -978,7 +978,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2220.",
 		"TextJPN": "「……すみません。…オヤシロさまの話はパスしたいんですけど…」",
 		"NamesENG": "Mion",
-		"TextENG": "``......I'm sorry. ...I'll pass on talk of Oyashiro-sama...``"
+		"TextENG": "``......I'm sorry. ...I'd rather pass on talking about Oyashiro-sama again...``"
 	},
 	{
 		"type": "MSGSET",
@@ -987,7 +987,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0110.",
 		"TextJPN": "「時間は取らせませんよ」",
 		"NamesENG": "Nitta",
-		"TextENG": "``It shouldn't take long.``"
+		"TextENG": "``We won't take much of your time.``"
 	},
 	{
 		"type": "MSGSET",
@@ -996,7 +996,7 @@
 		"PreTextTags": "@vS26/58/THOS_0190.",
 		"TextJPN": "「…結論から申し上げますと、…オヤシロさまの祟りは実在します」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...I'll say it straight... The curse of Oyashiro-sama is real.``"
+		"TextENG": "``...To start from the conclusion... Oyashiro-sama's curse does indeed exist.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1005,7 +1005,7 @@
 		"PreTextTags": "@vS26/58/THOS_0200.",
 		"TextJPN": "「…先程、建設省の職員が悶死したのをご覧になったでしょう。あれがまさにそうです」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...Earlier, I had a look at the Ministry of Construction employee who died in agony. It was just as I thought.``"
+		"TextENG": "``...You witnessed the agonizing death of the man from the Ministry of Construction a few moments ago, right? That was a result of the curse.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1014,7 +1014,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2230.",
 		"TextJPN": "「…そんなッ！　……じゃあ吉村は…何者なんですか！？　…あいつは…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Impossible! ......If it wasn't Yoshimura... then who!? ...It was him...!``"
+		"TextENG": "``...No way! ......Then what on earth... was Yoshimura?! ...He was...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1023,7 +1023,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0180.",
 		"TextJPN": "「@bよしむら.@<吉村@>@bみつる.@<満@>は本人の申請通り、ただのフリーライターです」",
 		"NamesENG": "Okano",
-		"TextENG": "``Mitsuru Yoshimura, according to his own personal application, is just a freelance writer.``"
+		"TextENG": "``Mitsuru Yoshimura was an ordinary freelance writer, just as he said.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1032,7 +1032,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2240.",
 		"TextJPN": "「そんな訳ないでしょッ！？　…あいつが荒川さんを殺して！」",
 		"NamesENG": "Mion",
-		"TextENG": "``What are you talking about!? ...That guy killed Arakawa-san!``"
+		"TextENG": "``That can't be true. ...He killed Arakawa-san!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1041,7 +1041,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2250.",
 		"TextJPN": "「…通り魔殺人だって！　…あいつが自分がやったって、自分で言ったんですよッ！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...He's also the street murderer! ...He's the one who did it, didn't you hear him say that!?``"
+		"TextENG": "``...He was the slasher! ...He himself said that he was the one who did it?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1050,7 +1050,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0190.",
 		"TextJPN": "「通り魔殺人は嘘です。部外者を連れ出す為に用意した我々の嘘です」",
 		"NamesENG": "Okano",
-		"TextENG": "``The street murder was a lie. It was a lie prepared in order to remove the outsiders.``"
+		"TextENG": "``We lied about there being a slasher. That was a lie we used in order to lead the outsiders away.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1059,7 +1059,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2260.",
 		"TextJPN": "「えぇッ！？　…だって吉村がそうだって自分で…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Eh!? ...But Yoshimura even said so himself...!``"
+		"TextENG": "``Huhh?! ...But Yoshimura himself said that he...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1068,7 +1068,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0200.",
 		"TextJPN": "「吉村は何もしていません。誰も殺してなんかいない」",
 		"NamesENG": "Okano",
-		"TextENG": "``Yoshimura didn't do anything. He never murdered anyone.``"
+		"TextENG": "``Yoshimura hasn't done anything. He hasn't killed anyone.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1077,7 +1077,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2270.",
 		"TextJPN": "「でも現に私が殺されかけたんですよッ！？　あいつの変な力でお腹の中を掻き回されてッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``But in fact, didn't you see he nearly killed me!? That guy rummaged around in my stomach using strange powers!``"
+		"TextENG": "``But I was nearly killed myself?! He used some kind of strange power to stir up the insides of my stomach!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1086,7 +1086,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0120.",
 		"TextJPN": "「冷静に冷静に。…最後までお聞きになって下さい。星野さん。続けて下さい」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Calm down, calm down. ...Please listen until the very last minute. Hoshino-san, please continue.``"
+		"TextENG": "``Stay calm, stay calm. ...Please let us finish speaking. Hoshino-san, please continue.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1095,7 +1095,7 @@
 		"PreTextTags": "@vS26/58/THOS_0210.",
 		"TextJPN": "「祟りが実在すると申しましたが、当然、この祟りにも正体があります。……虫です」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``We said that the curse is real. Naturally, we also know the true identity of this curse. ......An insect.``"
+		"TextENG": "``I mentioned that the curse does exist, but naturally that means there's a real cause behind the curse. ...It's a bug.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1104,7 +1104,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2280.",
 		"TextJPN": "「虫ぃ！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``An insect!?``"
+		"TextENG": "``A bug?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1113,7 +1113,7 @@
 		"PreTextTags": "@vS26/58/THOS_0220.",
 		"TextJPN": "「極めて珍しい虫で、我々は“ヒナミザワアリ”と呼んでいます。…アリに姿が似ているんですよ。生態はまったく異なりますが」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``It's an extremely rare insect, we call it ``Hinamizawaari``. ...It's appearance resembles an ant. Although it's ecology is completely different.``"
+		"TextENG": "``It's an extremely rare bug, and we've taken to calling it the Hinamizawa Ant. ...It resembles an ant in its appearance. Though its behavior is completely different.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1122,7 +1122,7 @@
 		"PreTextTags": "@vS26/58/THOS_0230.",
 		"TextJPN": "「ヒナミザワアリは…信じられない事ですが脳に寄生します。寄生経路は今でもはっきりしません」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``Hinamizawaari is... an unbelievable thing parasitic to the brain. Even now, the parasites course is still not clear.``"
+		"TextENG": "``The Hinamizawa Ant... as unbelievable as it may sound, is a parasite that inhabits the brain. How it enters its hosts is still unclear to us at present.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1131,7 +1131,7 @@
 		"PreTextTags": "@vS26/58/THOS_0240.",
 		"TextJPN": "「…無論、治療法も確立していない奇病です」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...Of course, this is a rare disease so a cure has not yet been established.``"
+		"TextENG": "``...Of course this is also a rare infection, for which no treatment has been established.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1140,7 +1140,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0130.",
 		"TextJPN": "「あぁ、あんまり想像しない方がいいですよ。…脳味噌の溝の部分に極小のアリがびっしり住み着いてるなんて気持ち悪いでしょう…？」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Oh, you shouldn't imagine about it too much. ...Wouldn't you have a bad feeling if a very small ant settled down in a part of your brain's groove...?``"
+		"TextENG": "``Yeah, you shouldn't try too hard to think about it. ...It's disturbing enough to think that a minuscule ant is living packed in tight in the folds of the brain, right...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1149,7 +1149,7 @@
 		"PreTextTags": "@vS26/58/THOS_0250.",
 		"TextJPN": "「特殊な環境下でしか生きられず、雛見沢以外の土地では長生きできません。…つまり雛見沢土着の虫なのです」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``It can only live in a special environment, that is, it can't live a long life in any other land than Hinamizawa. ...In other words, this insect is indigenous to Hinamizawa.``"
+		"TextENG": "``This organism can only live in a unique environment, and outside of Hinamizawa, it doesn't live for very long. ...Which makes the bug endemic to Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1158,7 +1158,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2290.",
 		"TextJPN": "「…あの、…そのナントカアリって……私の脳にも住み着いてるんですか…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Umm... do you mean...... that something like that has already settled in my brain...?``"
+		"TextENG": "``...Umm... So is this ant or whatever... living inside of my brain as well...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1167,7 +1167,7 @@
 		"PreTextTags": "@vS26/58/THOS_0260.",
 		"TextJPN": "「はい。……でも怖がる事はありません。雛見沢一帯の住民の９割は寄生されています」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``Yes. ......But I'm afraid it doesn't stop there. 90％ of the inhabitants of the entire Hinamizawa area have this parasite.``"
+		"TextENG": "``Yes. ......But there's nothing to fear. Approximately 90% of the residents in Hinamizawa are hosts to it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1176,7 +1176,7 @@
 		"PreTextTags": "@vS26/58/THOS_0270.",
 		"TextJPN": "「…でも日常生活を営む上で支障はないでしょう？　…立派な共生なんです」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...But, this isn't something that will trouble you in your everyday life, right? ...What a splendid symbiosis.``"
+		"TextENG": "``...Yet despite that, no one's lives seem to be particularly impeded by it, right? ...It's quite symbiotic.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1185,7 +1185,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2300.",
 		"TextJPN": "「で、でも気持ちよくないですよ！　…頭の中に…変な虫が住んでるなんて！」",
 		"NamesENG": "Mion",
-		"TextENG": "``B-But this doesn't feel good at all! ...In my head... having a strange insect live there!``"
+		"TextENG": "``B-But that's still creepy! ...To think there's... some weird bug living in my head!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1194,7 +1194,7 @@
 		"PreTextTags": "@vS26/58/THOS_0280.",
 		"TextJPN": "「人間の体もひとつの宇宙ですよ。全てを否定はできません」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``It is one with the space of the human body. You cannot deny that.``"
+		"TextENG": "``The human body is a universe of its own. We can't just eject whatever we don't like about it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1203,7 +1203,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0140.",
 		"TextJPN": "「星野さん。脱線してます」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Hoshino-san. You're deviating.``"
+		"TextENG": "``Hoshino-san, you're getting sidetracked.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1212,7 +1212,7 @@
 		"PreTextTags": "@vS26/58/THOS_0290.",
 		"TextJPN": "「…失礼。…そしてこのアリには親虫がいます」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...How rude of me. And there is also a parent insect to this ant.``"
+		"TextENG": "``...Pardon me. ...So, this ant of course has a queen.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1221,7 +1221,7 @@
 		"PreTextTags": "@vS26/58/THOS_0300.",
 		"TextJPN": "「…アリたちは親虫から遠く離されると、…つまり寄生された人間が雛見沢を遠く離れると、…狂い出すのです」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...When the ants are separated a great distance from the parent insect... That is, the infested humans who leave and head far away from Hinamizawa... start to go crazy.``"
+		"TextENG": "``...Now, if these ants grow too far separated from their queen ...In other words, if the host human goes too far away from Hinamizawa... then they go insane.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1230,7 +1230,7 @@
 		"PreTextTags": "@vS26/61/THOT_0040.",
 		"TextJPN": "「様々な脳内物質をでたらめに分泌し、宿主の人間の情緒を不安定にします」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``Various substances are then secreted into the brain at random, causing the host to become unstable and fluctuate its human emotions.``"
+		"TextENG": "``They start secreting various neurochemicals at random, causing the host's emotions to become unstable.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1239,7 +1239,7 @@
 		"PreTextTags": "@vS26/61/THOT_0050.",
 		"TextJPN": "「被害妄想を肥大させ、自分は誰かに監視されている、誰かに命を狙われている、と言った感情を膨らませて行きます」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``It enlarges a persecution complex, making yourself think you are being watched by someone, and that someone is trying to kill you. That said, it inflates your emotions.``"
+		"TextENG": "``This leads to the growth of a persecution complex, with the host believing that someone is watching over them, or that someone is after their life, and those emotions grow even stronger.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1248,7 +1248,7 @@
 		"PreTextTags": "@vS26/58/THOS_0310.",
 		"TextJPN": "「最後には幻覚を見、幻聴を聞き、…視界に入る全てが自分の命を狙っているように感じます」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``Finally, you will see hallucinations, and hear auditory hallucinations... feeling that everyone in sight is aiming to take your life.``"
+		"TextENG": "``Ultimately, they begin seeing and hearing hallucinations... so that eventually it feels like everything that enters their vision is after their life.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1257,7 +1257,7 @@
 		"PreTextTags": "@vS26/58/THOS_0320.",
 		"TextJPN": "「…この時、惨劇が起こるのです。…自宅であれば家族を殺し、職場であれば同僚を殺そうとする」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...At this point, a tragedy will occur. ...If you're at home, you'll murder your family, if you're at the workplace, you'll try to murder a colleague.``"
+		"TextENG": "``...That's when tragedy strikes. ...If they're home, they try to kill their families, and if they're at work, they try to kill their colleagues.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1266,7 +1266,7 @@
 		"PreTextTags": "@vS26/58/THOS_0330.",
 		"TextJPN": "「末期には自分の体内に異物が蠢いているように感じられるそうです」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``You will feel this alien substance wriggling through your body until the very end.``"
+		"TextENG": "``In the terminal stages, they've claimed to feel like some foreign substance is crawling around inside of their body.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1275,7 +1275,7 @@
 		"PreTextTags": "@vS26/58/THOS_0340.",
 		"TextJPN": "「…それらが喉元に込み上げて来るように感じ、…犠牲者たちは喉を掻きむしって死ぬのです」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...You will feel it welling up your throat... and then the victim will tear at their own throat and die.``"
+		"TextENG": "``...Then they feel that sensation climbing up their esophagus... and the victims then scratch their throats until they die.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1284,7 +1284,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0150.",
 		"TextJPN": "「…恐ろしいでしょう？　…ですが雛見沢に住んでいる限り安全なのです」",
 		"NamesENG": "Nitta",
-		"TextENG": "``...Wouldn't that be terrible? ...However, you're safe as long as you live in Hinamizawa.``"
+		"TextENG": "``...Terrifying, isn't it? ...However, it's perfectly safe so long as they live in Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1293,7 +1293,7 @@
 		"PreTextTags": "@vS26/58/THOS_0350.",
 		"TextJPN": "「どれくらいの期間、どれくらいの距離を離れればアリが狂い出すのか。…これは個人差が激しく一概には言えません」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``You must be wondering how long will it take for the ant to act up depending on the distance you move away. ...Although, I cannot necessarily say due to individual differences and unconditional violence."
+		"TextENG": "``How long does it take to start? How far can the host go before the ant goes crazy? ...Those have varied greatly between individual cases, so we can't make any broad generalizations, unfortunately.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1302,7 +1302,7 @@
 		"PreTextTags": "@vS26/58/THOS_0360.",
 		"TextJPN": "「極端な例では雛見沢を離れた初日で発症した例があります。…もちろん何年も雛見沢を離れても発症しない人もいます」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``In extreme cases, there was an example where one developed on the first day of leaving Hinamizawa. ...Of course, there are even many who have lived far away from Hinamizawa for many years and still didn't develop.``"
+		"TextENG": "``In one extreme case, they developed symptoms on the first day after leaving Hinamizawa. ...But of course, there's also a case where the person lived outside of Hinamizawa for many years before displaying any symptoms.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1311,7 +1311,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2310.",
 		"TextJPN": "「…あのー……その気持ち悪い話と私が…どう関係あるんです…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Umm...... how is this bad story and I... connected to one another...?``"
+		"TextENG": "``...Umm...... so how does all this creepy stuff... have anything to do with me...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1320,6 +1320,6 @@
 		"PreTextTags": "@vS26/57/TNIT_0160.",
 		"TextJPN": "「１匹だけいる親虫。…これの宿主が彼女。…梨花さんなんですよ」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Because there is only one parent insect. ...The host is her. It is Rika-san.``"
+		"TextENG": "``There only exists one queen. ...And its host is this woman right here, Rika-san.``"
 	}
 ]

--- a/bus_stop_9.json
+++ b/bus_stop_9.json
@@ -12,7 +12,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2320.",
 		"TextJPN": "「はぁ……！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Huh......!?``"
+		"TextENG": "``Huh......?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -21,7 +21,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1420.",
 		"TextJPN": "「……私が近くにいると…頭が痛くならないでしょ？　……変なものを見たり、聞いたりってこともないでしょ…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......When you're near me... doesn't your head stop becoming painful? ......Then, when you began to see or hear strange things, didn't it stop when I was there...?``"
+		"TextENG": "``......When I'm nearby... your head doesn't hurt, right? ......You don't see strange things, and you don't hear strange things, do you...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -30,7 +30,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2330.",
 		"TextJPN": "「……え……、…あの……」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Eh...... ...Umm......``"
+		"TextENG": "``......Huh...... ...Umm......``"
 	},
 	{
 		"type": "MSGSET",
@@ -39,7 +39,7 @@
 		"PreTextTags": "@vS26/58/THOS_0370.",
 		"TextJPN": "「…もしも！　…梨花さんに何かがあって、親虫が死んでしまったら。…どうなると思います？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...Even so! ...If something were to happen to you, Rika-san, the parent insect would die. ...Do you know what would happen then?``"
+		"TextENG": "``...So, if! ...If something were to happen to Rika-san, and the queen were to die... what do you believe would happen?``"
 	},
 	{
 		"type": "MSGSET",
@@ -48,7 +48,7 @@
 		"PreTextTags": "@vS26/58/THOS_0380.",
 		"TextJPN": "「……雛見沢一帯に住む数万人のアリの宿主たちは一斉に…発症するんですよ。…町中の人間が一斉に…！　……恐ろしい大惨事になるでしょう」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``......All the tens of thousands of ants living inside the hosts would act up simultaneously all across the whole area of Hinamizawa... they would develop. ...Every single human being in the whole town at once...! ......It would be a terrible catastrophe.``"
+		"TextENG": "``......Every single one of the tens of thousands of hosts to the ant living in Hinamizawa... would all develop symptoms at once. ...Every single person in town, all at once...! ......It would lead to an unfathomable tragedy.``"
 	},
 	{
 		"type": "MSGSET",
@@ -57,7 +57,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0210.",
 		"TextJPN": "「町中の人間が殺し合う…地獄のような光景になります」",
 		"NamesENG": "Okano",
-		"TextENG": "``Every person in town would kill each other... it would become a scene from hell.``"
+		"TextENG": "``The people of this city would begin killing each other... like an image straight out of hell.``"
 	},
 	{
 		"type": "MSGSET",
@@ -66,7 +66,7 @@
 		"PreTextTags": "@vS26/60/TODA_0050.",
 		"TextJPN": "「…ですから我々は梨花さんの身の安全には最高の注意を払っています。…梨花さんにもしもの事があれば一大事です」",
 		"NamesENG": "Oda",
-		"TextENG": "``...Therefore, we are paying the highest attention of safety to Rika-san herself. ...If anything were to happen to Rika-san, it would be a serious affair.``"
+		"TextENG": "``...However, we are placing the greatest of cautions in securing Rika-san's safety. ...If something were to happen to Rika-san, it would be terrible.``"
 	},
 	{
 		"type": "MSGSET",
@@ -75,7 +75,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2340.",
 		"TextJPN": "「…へ、…ぇー……。…梨花さんて…すごいんだぁ…。…へぇー……」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Eh... Eh...... ...Rika-san... you're amazing... ...Heh......``"
+		"TextENG": "``...Wow... huh...... ...Rika-san's... amazing, huh... ...Wow......``"
 	},
 	{
 		"type": "MSGSET",
@@ -84,7 +84,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0170.",
 		"TextJPN": "「ここで困った問題が２つ発生しました。…ひとつはご存知の通り、雛見沢のダム計画です」",
 		"NamesENG": "Nitta",
-		"TextENG": "``However, two embarrassing problems occurred. ...As you know one, the Hinamizawa dam project.``"
+		"TextENG": "``So now here come along two unfortunate problems. ...The one is the Hinamizawa Dam Project that you already know about.``"
 	},
 	{
 		"type": "MSGSET",
@@ -93,7 +93,7 @@
 		"PreTextTags": "@vS26/58/THOS_0390.",
 		"TextJPN": "「親虫は雛見沢という極めて限られた環境でしか生きられません」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``The parent insect can only live in the extremely limited environment that is Hinamizawa.``"
+		"TextENG": "``The queen can only live within the limited environment of Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -102,7 +102,7 @@
 		"PreTextTags": "@vS26/58/THOS_0400.",
 		"TextJPN": "「…雛見沢がダム湖に沈めば、親虫の生きられる唯一の環境を破壊する事になる！」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...So if Hinamizawa were to be submerged by a dam into a lake, it would destroy the only environment where the parent insect can live!``"
+		"TextENG": "``...If Hinamizawa is submerged under a dam, then the queen won't have anywhere she can survive!``"
 	},
 	{
 		"type": "MSGSET",
@@ -111,7 +111,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0180.",
 		"TextJPN": "「この問題は上層部が対応中です。近日中にダム計画は撤回されるでしょう」",
 		"NamesENG": "Nitta",
-		"TextENG": "``The top brass are dealing with this problem. So the dam project will be withdrawn in a few days.``"
+		"TextENG": "``Our upper brass are currently taking measures to handle that problem. The Dam Project will probably be rescinded in a few days.``"
 	},
 	{
 		"type": "MSGSET",
@@ -120,7 +120,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0190.",
 		"TextJPN": "「もうひとつが問題なのです。…梨花さんは生まれつき体が弱く、親虫の寄生に耐えられないんですよ」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Now, onto the other problem. ...Rika-san's body is physically weak by nature, and is not able to withstand the parent insect parasite.``"
+		"TextENG": "``Then there's the other problem. ...Rika-san was born with a poor constitution, and she can't stand hosting the queen.``"
 	},
 	{
 		"type": "MSGSET",
@@ -129,7 +129,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0200.",
 		"TextJPN": "「…このままでは梨花さんは数年を待たずに衰弱死してしまうでしょう。…これは大変な事です」",
 		"NamesENG": "Nitta",
-		"TextENG": "``...In this state, Rika-san will eventually die due to debility in a few years. ...This is a serious matter.``"
+		"TextENG": "``...If nothing is done, then Rika-san will grow debilitated within the next few years, and die. ...That will have the consequences we've already described.``"
 	},
 	{
 		"type": "MSGSET",
@@ -138,7 +138,7 @@
 		"PreTextTags": "@vS26/58/THOS_0410.",
 		"TextJPN": "「親虫を健康な肉体に移殖する必要があるんです。幸いに手術は容易です。…ですが親虫の適応できる宿主が難しい」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``So it is necessary to transplant the parent insect into a healthy body. Fortunately, operation is easy. ...But, it has been difficult to find a host whose body can be adapted for the parent insect.``"
+		"TextENG": "``The queen needs to be transplanted into a healthy body. Fortunately, the surgery for that is quite simple. ...However, it's more difficult finding a suitable host for the queen.``"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@vS26/58/THOS_0420.",
 		"TextJPN": "「…数万人に一人いるかいないかの適合者を探さなくてはならないのです」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...We have been looking for one among the tens of thousands of people for someone who is compatible.``"
+		"TextENG": "``...We have to find the one person who may or not exist within the tens of thousands of hosts.``"
 	},
 	{
 		"type": "MSGSET",
@@ -156,7 +156,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2350.",
 		"TextJPN": "「………あのー…ひょっとして……それが……」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........Umm... by any chance...... do you mean......``"
+		"TextENG": "``.........Umm... are you telling me...... that I'm......``"
 	},
 	{
 		"type": "MSGSET",
@@ -165,7 +165,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0210.",
 		"TextJPN": "「…あなたです。園崎さん」",
 		"NamesENG": "Nitta",
-		"TextENG": "``...It is you, Sonozaki-san.``"
+		"TextENG": "``...That's you, Sonozaki-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -174,7 +174,7 @@
 		"PreTextTags": "@vS26/61/THOT_0060.",
 		"TextJPN": "「あなたが適合者だと確定できたのはつい最近です。…ですがあなたは…すでに発症していた」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``We were only recently able to confirm you were a compatible person. ...But you... you had already developed.``"
+		"TextENG": "``We only recently identified that you were a suitable host. ...However... you're already displaying symptoms.``"
 	},
 	{
 		"type": "MSGSET",
@@ -183,7 +183,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2360.",
 		"TextJPN": "「発症！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Developed!?``"
+		"TextENG": "``Symptoms?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -192,7 +192,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1430.",
 		"TextJPN": "「…遊びに行ったでしょう？　東京に…！　……あなたは運悪く…その時発症してしまったのよ…ッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Didn't you go out to play? In Tokyo...! ......You unfortunately... at that time, ended up developing...!``"
+		"TextENG": "``...You left to go have fun, right? In Tokyo...! ......Unfortunately... you began displaying symptoms back then...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -201,7 +201,7 @@
 		"PreTextTags": "@vS26/58/THOS_0430.",
 		"TextJPN": "「頭がガンガンするでしょう？　…夜、眠れないでしょう？　…梨花さんが近くにいないと…奇怪な体験をするでしょう？」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``Wasn't your head pounding? ...And at night, you couldn't sleep? Then, when Rika-san wasn't near... didn't you have a bizzare experience?``"
+		"TextENG": "``Your head starts pounding, right? ...You can't sleep at night, right? ...When Rika-san isn't close by......you go through bizarre experiences, don't you?``"
 	},
 	{
 		"type": "MSGSET",
@@ -210,7 +210,7 @@
 		"PreTextTags": "@vS26/58/THOS_0440.",
 		"TextJPN": "「……あなたはもう末期なんです。…現にあなたはさっき！　…自分の喉を掻きむしろうとした…！」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``......You are already terminal. ...In fact, a little while ago! ...You tried to tear out your own throat...!``"
+		"TextENG": "``......You are already at the terminal stages. ...Case in point, just now! ...You were trying to scratch out your own throat...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2370.",
 		"TextJPN": "「……奇怪な体験って……じゃあ……吉村が襲ってきたのは……」",
 		"NamesENG": "Mion",
-		"TextENG": "``......A bizzare experience...... you mean...... when Yoshimura attacked me......``"
+		"TextENG": "``......Bizarre experiences...... Then...... the man Yoshimura assaulted......``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,7 +228,7 @@
 		"PreTextTags": "@vS26/61/THOT_0070.",
 		"TextJPN": "「…吉村が奇怪な行動を取ったような…幻覚を見ただけなの。…吉村は何もしてない。…あなたがひとりで、…暴れ出しただけなのよ」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``...Yoshimura's strange behavior... you were seeing a hallucination. ...Yoshimura didn't do anything. ...You were alone... and then you began to act violently.``"
+		"TextENG": "``...You just saw a hallucination of Yoshimura... behaving bizarrely. ...Yoshimura hasn't done anything. ...You just went wild... all on your own.``"
 	},
 	{
 		"type": "MSGSET",
@@ -237,7 +237,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2380.",
 		"TextJPN": "「……そんな…ッ！？　……じゃあ……おかしいのは……私なのッ！？　…梨花さん！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Impossible...! ......So you mean...... the strange one...... is me? ...Rika-san!?``"
+		"TextENG": "``......No way...?! ......Then......I'm the one...... who's crazy?! ...Rika-san?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -246,7 +246,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1440.",
 		"TextJPN": "「……だから…。……東京なんかに行っちゃだめって…言ったのに…！」",
 		"NamesENG": "Rika",
-		"TextENG": "``......That's why... ......I said you it was no good for you to visit Tokyo...!``"
+		"TextENG": "``......This is why... ......I told you that you shouldn't go to Tokyo...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -255,7 +255,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2390.",
 		"TextJPN": "「……私……おかしくなって……死んじゃうんですか？　…そんな……そんな……！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Since I...... became strange...... will I die? ...This cannot be true...... This......!``"
+		"TextENG": "``......Am I...... going to go crazy...... and die too? ...No way...... No way......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -264,7 +264,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1450.",
 		"TextJPN": "「大丈夫。私と一緒にいれば平気なの！　…私はずーっと魅音の側にいるわ。だから大丈夫！」",
 		"NamesENG": "Rika",
-		"TextENG": "``It'll be alright. You're fine as long as you stay near me! ...I'll be by your side all the way, Mion. So you'll be alright!``"
+		"TextENG": "``You're alright. As long as you're with me, you're fine! ...I'll stay beside you forever. So you'll be alright!``"
 	},
 	{
 		"type": "MSGSET",
@@ -273,7 +273,7 @@
 		"PreTextTags": "@vS26/58/THOS_0450.",
 		"TextJPN": "「お風呂やお手洗いまで一緒に行けるわけじゃないでしょう？　…一生二人で寄り添って生きていくなんて不可能よ」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``It's not like you can go to the bathroom or the lavatory together. ...It's impossible for the both of you to snuggle up and live for the rest of your lives.``"
+		"TextENG": "``You can't go with her to the bathroom, or follow her into the tub when she bathes, right? ...It's impossible for you two to live your entire lives clinging to each other.``"
 	},
 	{
 		"type": "MSGSET",
@@ -282,7 +282,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2400.",
 		"TextJPN": "「死ぬんですか私！　…死ぬんですかッ！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Do you mean I have to die?! ...To die!?``"
+		"TextENG": "``Am I going to die then?! ...Am I going to die?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@vS26/61/THOT_0080.",
 		"TextJPN": "「このままなら死にます！　…でも親虫の移殖を受ければ助かります！」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``You'll die as it is! ...But you can be saved if you receive the transplantation of the parent insect!``"
+		"TextENG": "``At this rate, you will! ...But if we transplant the queen, we can save you!``"
 	},
 	{
 		"type": "MSGSET",
@@ -300,7 +300,7 @@
 		"PreTextTags": "@vS26/58/THOS_0460.",
 		"TextJPN": "「…梨花さんも親虫を摘出されれば、衰弱する事もない」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...If we remove the parent insect from Rika-san, she also won't debilitate.``"
+		"TextENG": "``...Rika-san won't grow increasingly debilitated anymore either once we extract the queen.``"
 	},
 	{
 		"type": "MSGSET",
@@ -309,7 +309,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0220.",
 		"TextJPN": "「梨花さんから魅音さんに親虫を移殖すれば、…２人とも助かるんです」",
 		"NamesENG": "Nitta",
-		"TextENG": "``And, if we transplant the parent insect from Rika-san to you, Mion-san... the both of you will survive.``"
+		"TextENG": "``So once we transplant the queen from Rika-san into you... both of you will be saved.``"
 	},
 	{
 		"type": "MSGSET",
@@ -318,7 +318,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2410.",
 		"TextJPN": "「……ホントにそれで……助かるんですね…！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Is that true...... will we be saved...!?``"
+		"TextENG": "``......Can you really save me...... by doing that...?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -327,7 +327,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0230.",
 		"TextJPN": "「助かります」",
 		"NamesENG": "Nitta",
-		"TextENG": "``You will be saved.``"
+		"TextENG": "``We can save you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -336,7 +336,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2420.",
 		"TextJPN": "「……梨花さん」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Rika-san.``"
+		"TextENG": "``......Rika-san?``"
 	},
 	{
 		"type": "MSGSET",
@@ -345,7 +345,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1460.",
 		"TextJPN": "「…言いくるめられちゃ駄目。…こいつらはあなたを人間として扱う気なんか最初からない」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Talking to them is useless . ...They didn't have it in mind to treat you like a human being from a beginning.``"
+		"TextENG": "``...Don't let them hoodwink you. ...These people were never planning to treat you like a human being.``"
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS26/61/THOT_0090.",
 		"TextJPN": "「そんな事はありませんよ。あなたの協力がなければ雛見沢の数万人の人々が犠牲になるんです。それをどうして粗末に扱えましょう」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``That's not true. Without your cooperation, the tens of thousands of people living in Hinamizawa will be sacrificed. We can't treat you poorly.``"
+		"TextENG": "``That's not true. Without your cooperation, tens of thousands of people in Hinamizawa will fall victim to this bug. So why would we treat you without care?``"
 	},
 	{
 		"type": "MSGSET",
@@ -363,7 +363,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1470.",
 		"TextJPN": "「耳を貸しちゃ駄目。…………よく思い出して。…今日、私と一緒に学校をさぼって遊びに行ったでしょ？　…あなた、その事を誰かに言った？」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's useless to listen. ............Remember. ...You skipped school with me today to go play...... Have you told anyone about it?``"
+		"TextENG": "``Don't listen to them. ............Think back. ...You skipped school with me today to come play around, right? ...Did you say anything about that to anyone else?``"
 	},
 	{
 		"type": "MSGSET",
@@ -372,7 +372,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2430.",
 		"TextJPN": "「……学校さぼるってわざわざ公言する訳、ないじゃないですか」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Why would I go out of my way to announce that I'm skipping school?``"
+		"TextENG": "``......Why would I ever make a point of publicly declaring that I was skipping school?``"
 	},
 	{
 		"type": "MSGSET",
@@ -381,7 +381,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1480.",
 		"TextJPN": "「…つまり、…今日のあなたの動向を知る者はひとりもいない、って事よね」",
 		"NamesENG": "Rika",
-		"TextENG": "``Which means... no one else knows what you're up to today.``"
+		"TextENG": "``...Which means... that no one knows what you've been doing today, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -390,7 +390,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2440.",
 		"TextJPN": "「……そりゃそうですよ。…誰にも言ってないんですから」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Exactly. ...I didn't say to anyone.``"
+		"TextENG": "``......Well, sure. ...I didn't tell anyone, after all.``"
 	},
 	{
 		"type": "MSGSET",
@@ -399,7 +399,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1490.",
 		"TextJPN": "「……今日、あなたが着てきてくれたその服。…私がリクエストしたのよね」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Today, even the clothes you wore. ...I requested them.``"
+		"TextENG": "``......Those clothes you're wearing today. ...I asked you to wear them, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -408,7 +408,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2450.",
 		"TextJPN": "「…梨花さんがこの服が一番可愛いって言ってくれたから、わざわざ着てきたんじゃないですか」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Because you said these clothes were the most cute, Rika-san, so I wore them because of that.``"
+		"TextENG": "``...You told me I looked cutest in this outfit, so I made a point of wearing it for you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -417,7 +417,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1500.",
 		"TextJPN": "「…つまり、…今日のあなたの服装は事前に把握されていた、って事よね」",
 		"NamesENG": "Rika",
-		"TextENG": "``Which means... you knew what you were going to wear today before you got here.``"
+		"TextENG": "``...Which means... the outfit you'd be wearing today was known beforehand, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -426,7 +426,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2460.",
 		"TextJPN": "「……そりゃそうですよ。…梨花さんのリクエストなんですから」",
 		"NamesENG": "Mion",
-		"TextENG": "``......I already know that. ...Because you requested them, Rika-san.``"
+		"TextENG": "``......Well, sure. ...You asked me to wear it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -435,7 +435,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1510.",
 		"TextJPN": "「……あなた学校で、いつもいつも東京に引っ越したい、逃げ出したいって話してたわよね。…何人くらいの人に言った？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......In school, you always talked of moving to Tokyo, and said to me about running away to there. How many people did you say that to?``"
+		"TextENG": "``......When you're at school, you're always, always talking about wanting to escape from here and move to Tokyo, right? ...How many people have you said that to?``"
 	},
 	{
 		"type": "MSGSET",
@@ -444,7 +444,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2470.",
 		"TextJPN": "「……いちいち覚えてないですよ。会う度に言ってましたからね」",
 		"NamesENG": "Mion",
-		"TextENG": "``......I don't remember every single time. I just said it whenever I met someone.``"
+		"TextENG": "``......I don't remember every time I brought it up. I say it to everyone I met.``"
 	},
 	{
 		"type": "MSGSET",
@@ -453,7 +453,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1520.",
 		"TextJPN": "「…つまり、…あなたが東京に過度に憧れてる事は誰もが知っている事実って事よね」",
 		"NamesENG": "Rika",
-		"TextENG": "``...In other words... it's a fact that everyone knows you excessively long for Tokyo.``"
+		"TextENG": "``...Which means... it's a known fact that everyone knew you held an excessive admiration for Tokyo, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -462,7 +462,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2480.",
 		"TextJPN": "「梨花さん、…何の話なんですか？　それとこれとどーゆう関係が…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Rika-san...! What are you talking about? How does that have any connection to this...``"
+		"TextENG": "``Rika-san... what are you talking about? How is any of that related to this...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -471,7 +471,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1530.",
 		"TextJPN": "「…今朝の９時にね、あなたの貯金、全額引き出されてるのよ。…偽造カードで、あなたと同じ服を着たそっくりの子によって」",
 		"NamesENG": "Rika",
-		"TextENG": "``...At 9:00 this morning, all your savings were drawn in full. ...By a child looking just like you wearing the exact same clothes, using a counterfeit card.``"
+		"TextENG": "``...At nine this morning, all the money in your bank account was withdrawn. ...A girl who looks like you, dressed up in that same outfit, did it with a forged card.``"
 	},
 	{
 		"type": "MSGSET",
@@ -480,7 +480,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2490.",
 		"TextJPN": "「えぇッ！？　…何ですかそれッ！　…だって暗証番号が！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Eh!? ...What is this! ...I didn't tell anyone my PIN!``"
+		"TextENG": "``Huh?! ...What did you say?! ...But my PIN number!``"
 	},
 	{
 		"type": "MSGSET",
@@ -489,7 +489,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1540.",
 		"TextJPN": "「……あなた私に教えてくれたでしょ。…誕生日が暗証番号だ、って」",
 		"NamesENG": "Rika",
-		"TextENG": "``......You told me. ...You said your PIN was your birthday.``"
+		"TextENG": "``......You told me before, didn't you? ...That your PIN number was your birthday.``"
 	},
 	{
 		"type": "MSGSET",
@@ -498,7 +498,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2500.",
 		"TextJPN": "「だ、誰ですか！？　私のお金盗った人ーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Wh-Who did it!? The person who stole all my money!``"
+		"TextENG": "``W-Who?! Who stole my money?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -507,13 +507,13 @@
 		"PreTextTags": "@vS26/52/TRIK_1550.",
 		"TextJPN": "「…あなたよ。…郵便局の防犯カメラにはあなたそっくりの子が映ってる」",
 		"NamesENG": "Rika",
-		"TextENG": "``...You. ...A girl looking just like you was reflected in the security cameras of the post office.``"
+		"TextENG": "``...You did. ...Someone looking just like you is what's been recorded on the post office's security cameras.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156633,
 		"TextJPN": "何が何やら判らなくなって、よろよろと梨花から離れる魅音、舞台中央へ。また頭痛が始まる。",
-		"TextENG": "Mion doesn't understand what is going on, and steadily stumbles away from Rika, towards the stage center. Also, her headache starts again."
+		"TextENG": "Mion can't understand any of what's going on, and she totters away from Rika toward the center of the stage. Then her head begins to ache once more."
 	},
 	{
 		"type": "MSGSET",
@@ -522,7 +522,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2510.",
 		"TextJPN": "「痛たた…。……頭、……痛い……」",
 		"NamesENG": "Mion",
-		"TextENG": "``It hurts... ......My head...... it hurts......``"
+		"TextENG": "``Owww... ......My head...... hurts......``"
 	},
 	{
 		"type": "MSGSET",
@@ -531,7 +531,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1560.",
 		"TextJPN": "「東京行きの新幹線の中でね。…あなたそっくりの子が切符をなくしたって言って大騒ぎするの」",
 		"NamesENG": "Rika",
-		"TextENG": "``It was on a bullet train to Tokyo. ...A child looking just like you lost her ticket and made a fuss.``"
+		"TextENG": "``On the bullet train heading into Tokyo... there was someone looking just like you who, claiming to have lost her ticket, caused a big commotion about it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -540,7 +540,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1570.",
 		"TextJPN": "「…結局、切符は見つかるんだけどね、…車掌はその子の印象を強く持ったわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Eventually, the ticket was found... and the conductor got a strong impression of the girl.``"
+		"TextENG": "``...In the end, the ticket was found... but that girl left a strong impression on the conductor.``"
 	},
 	{
 		"type": "MSGSET",
@@ -549,7 +549,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1580.",
 		"TextJPN": "「…東京ではね。何カ所かの交番にあなたそっくりの子が現れるのよ。…財布を落としたって大騒ぎしてね」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Then, in Tokyo. A girl looking just like you appeared at several police stations. ...Making a fuss since you dropped your wallet.``"
+		"TextENG": "``...So then in Tokyo, someone looking just like you appeared at several different police boxes. ...She made a big fuss about losing her wallet.``"
 	},
 	{
 		"type": "MSGSET",
@@ -558,7 +558,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1590.",
 		"TextJPN": "「…住所氏名を聞こうとすると逃げちゃうのよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``...And when they asked her for her name and address, she ran away.``"
+		"TextENG": "``...But each time, she ran away when they tried to ask for her address.``"
 	},
 	{
 		"type": "MSGSET",
@@ -567,7 +567,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1600.",
 		"TextJPN": "「……お巡りさんは家出少女じゃないかと怪しんでね。……今頃は周辺の交番にあなたの特徴を書いたＦＡＸが回っているわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......The policeman then suspected you're a runaway girl. ......By now, they've probably wrote down your characteristics and sent them to other police stations via fax.``"
+		"TextENG": "``......The officers all suspect that she was a girl running away from home. ......So right about now, the officers in the area are circulating a fax with your description on it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -576,7 +576,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2520.",
 		"TextJPN": "「……何で……そんな事を……？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Why...... why is this happening......?``"
+		"TextENG": "``......Why...... is all that happening......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -585,7 +585,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1610.",
 		"TextJPN": "「…園崎魅音は学校へは行かず、貯金を全て引き出し新幹線に乗って東京に消えた」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Mion Sonozaki didn't go to school, she withdrew all her savings and disappeared in Tokyo after boarding a bullet train.``"
+		"TextENG": "``...Instead of going to school, Mion Sonozaki withdrew her savings and boarded the bullet train to Tokyo where she disappeared.``"
 	},
 	{
 		"type": "MSGSET",
@@ -594,7 +594,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1620.",
 		"TextJPN": "「…そういう事になってるのよ。…あなた中学の時、家出で補導歴もあるしね…」",
 		"NamesENG": "Rika",
-		"TextENG": "``...That's what happened. ...When you were in Junior High School, you ran away from home and got this in records...``"
+		"TextENG": "``...That's how the story is going to be. ...You have a previous record of running away from home in middle school too, after all...``"
 	},
 	{
 		"type": "MSGSET",
@@ -603,7 +603,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2530.",
 		"TextJPN": "「……バカなこと言わないで下さいよ…。…私は東京なんかじゃなく、…ここにいるんですよ？　……ぅぅう……」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Please don't say such stupid things... ...I'm not in Tokyo... can't you see I'm right here? ......Uuu......``"
+		"TextENG": "``......Please stop saying these ridiculous things... ...I'm not in Tokyo... I'm right here. ......Nnngh......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -612,7 +612,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1630.",
 		"TextJPN": "「…気付いてよ。…これは罠なのよッ！　……あなたを誘拐する為の巧妙な罠！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Take notice. ...This is a trap! ......A clever trap made in order to kidnap you!``"
+		"TextENG": "``...Piece it together. ...This is a trap! ......It's a clever trap to kidnap you!``"
 	},
 	{
 		"type": "MSGSET",
@@ -621,7 +621,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1640.",
 		"TextJPN": "「…こいつらは最初からあなたを人間扱いする気なんかない！　…あなたの脳味噌にしか興味がないのよッ！　あなたは…研究材料にされるだけッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...These people never had it in mind to treat you like a human being from a beginning! ...They're only interested in your brain! They...  only consider you research material!``"
+		"TextENG": "``...These people were never planning to treat you like a human being! ...They're only interested in your brain! You'll... only be used as their guinea pig!``"
 	},
 	{
 		"type": "MSGSET",
@@ -630,7 +630,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2540.",
 		"TextJPN": "「…う……嘘だ…ッ！　……ぅぅ…嘘だ…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...T-That's a lie...! ......That's a lie...!``"
+		"TextENG": "``...Ngh...... Lies...! ......nnngh... Lies...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -639,7 +639,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1650.",
 		"TextJPN": "「…こいつらは厚生省なんて名乗ってるけど、実際の所属は違う。…こいつらは国家、」",
 		"NamesENG": "Rika",
-		"TextENG": "``...These people say they're from the Ministry of Health and Welfare, but their actual affiliation is different. ...They are a nation...``"
+		"TextENG": "``...These people claim they're from the Ministry of Health, but they're actually with a different organization! ...These people are from the National P-``"
 	},
 	{
 		"type": "MSGSET",
@@ -648,7 +648,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0240.",
 		"TextJPN": "「結構ッ！　梨花さんの態度は判りました。少々態度を変えさせてもらいます」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Wonderful! ...Since Rika-san has changed her attitude. I'll change my own attitude a little.``"
+		"TextENG": "``Enough! We understand your attitude on this, Rika-san. So we'll change our attitude as well.``"
 	},
 	{
 		"type": "MSGSET",
@@ -657,7 +657,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0250.",
 		"TextJPN": "「……園崎さん。全て梨花さんの言う通りなんですよ。我々はあなたの脳味噌にしか興味がない」",
 		"NamesENG": "Nitta",
-		"TextENG": "``......Sonozaki-san. Rika-san is right. We are only interested in your brain.``"
+		"TextENG": "``......Sonozaki-san. Everything Rika-san told you is true. We're only interested in your brain.``"
 	},
 	{
 		"type": "MSGSET",
@@ -666,7 +666,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2550.",
 		"TextJPN": "「…ちッ…近寄るなッ！　……がぁ…ああぁあ…ッ…！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...D-Don't come any closer! ......Ga...aaaa......!``"
+		"TextENG": "``...Sta... Stay back! ......Gaah... Aaaaagh...! ...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -675,7 +675,7 @@
 		"PreTextTags": "@vS26/58/THOS_0470.",
 		"TextJPN": "「…辛いでしょう？　手術すれば楽になるわ。…さぁ！　…私たちを受け入れてッ！」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...Are you in pain? You'll feel more comfortable if we operate. ...Now! ...Come with us!``"
+		"TextENG": "``...It hurts, doesn't it? If you have the surgery, it'll stop. ...Now! ...Come with us!``"
 	},
 	{
 		"type": "MSGSET",
@@ -684,7 +684,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2560.",
 		"TextJPN": "「…嫌ぁあぁあぁ…ッ、…研究材料にされるなんて嫌…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Noooooo... ...No, I don't want to become research material...!``"
+		"TextENG": "``...Noooooooo...! ...I don't want to be a guinea pig...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -693,7 +693,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1660.",
 		"TextJPN": "「…魅音ッ！　私から離れないで！　…症状が進んでしまう！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Mion! Don't get separated from me! ...Your symptoms will only get worse!``"
+		"TextENG": "``...Mion! Stay beside me! ...Or your symptoms will advance even further!``"
 	},
 	{
 		"type": "MSGSET",
@@ -702,7 +702,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0260.",
 		"TextJPN": "「梨花さんが誘拐劇の重要な役割を率先して果たした事をお忘れなくッ！」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Don't forget, Rika-san took the initiative and played an important role in the kidnapping drama, too!``"
+		"TextENG": "``Don't you forget, Rika-san here also voluntarily played an important role in this abduction plan!``"
 	},
 	{
 		"type": "MSGSET",
@@ -711,7 +711,7 @@
 		"PreTextTags": "@vS26/60/TODA_0060.",
 		"TextJPN": "「むしろ今回の作戦を提案したのは彼女の方です！」",
 		"NamesENG": "Oda",
-		"TextENG": "``Moreover, it was her who suggested this strategy!``"
+		"TextENG": "``Why in fact, she's the one who proposed this very operation!``"
 	},
 	{
 		"type": "MSGSET",
@@ -720,7 +720,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2570.",
 		"TextJPN": "「……梨花さんがッ！？　……嘘…だッ…！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Rika-san!? ......That's a lie...!``"
+		"TextENG": "``......Rika-san did?! ......You're... lying...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -729,7 +729,7 @@
 		"PreTextTags": "@vS26/61/THOT_0100.",
 		"TextJPN": "「梨花さんは親虫の負担に耐えきれなくなってね。…誰かに親虫を移殖できないかって提案したの」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``Rika-san could no longer endure the burden of the parent insect. ...So, Rika-san suggested to us that we should find someone to transplant the parent insect into.``"
+		"TextENG": "``Rika-san couldn't bear the burden of hosting the queen anymore. ...So she's the one who proposed trying to transplant it into someone else.``"
 	},
 	{
 		"type": "MSGSET",
@@ -738,7 +738,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0220.",
 		"TextJPN": "「…調査の結果！　…あなたが適合者だと言う事がわかりました」",
 		"NamesENG": "Okano",
-		"TextENG": "``...And as a result of that investigation... We found out that you were a compatible person.``"
+		"TextENG": "``...And, after our investigation! ...We learned that you were a compatible host.``"
 	},
 	{
 		"type": "MSGSET",
@@ -747,7 +747,7 @@
 		"PreTextTags": "@vS26/60/TODA_0070.",
 		"TextJPN": "「しかし誘拐の前段階として、あなたと梨花さんが接触しても不自然でないよう、…友人関係を結んでおく必要があった」",
 		"NamesENG": "Oda",
-		"TextENG": "``However, before the first step of the kidnapping... It was unnatural for you and Rika-san to come into contact... so it was necessary to bind the both of you into a friendly relationship.``"
+		"TextENG": "``However, to first set up this abduction, Rika-san needed to build a friendship with you... so that it wouldn't seem unnatural for you two to be together.``"
 	},
 	{
 		"type": "MSGSET",
@@ -756,7 +756,7 @@
 		"PreTextTags": "@vS26/61/THOT_0110.",
 		"TextJPN": "「でもその努力は必要なかった。あなたから梨花さんに接触してくれたから」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``But that effort was not necessary. Because you and Rika-san had already come into contact.``"
+		"TextENG": "``But there was no need to spend any effort on that. Because as it turned out, you were the one who approached her first.``"
 	},
 	{
 		"type": "MSGSET",
@@ -765,7 +765,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2580.",
 		"TextJPN": "「……こ…いつら…！　…何言ってやがる…！？　…ぅうぅ…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......You people...! ...What are you saying...!? ...Uuu...!``"
+		"TextENG": "``......You... people...! ...What the hell are you saying...?! ...Nnnngh...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -774,7 +774,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0270.",
 		"TextJPN": "「園崎さんと梨花さんが友人になったのは、偶然ではない。作為的なものなんだよ」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Sonozaki-san and Rika-san becoming friends, it was no accident. It was intentional.``"
+		"TextENG": "``It was no coincidence that you and Rika-san became friends. It was intentional.``"
 	},
 	{
 		"type": "MSGSET",
@@ -783,7 +783,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1670.",
 		"TextJPN": "「それは違うッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``It was different!``"
+		"TextENG": "``No it wasn't!``"
 	},
 	{
 		"type": "MSGSET",
@@ -792,7 +792,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1680.",
 		"TextJPN": "「…出会いは…偶然じゃなかったかも知れない…ッ！　……でも…本当に魅音の事が好きになったのッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Our encounter... may have not been an accident...! ......But... I really came to like Mion!``"
+		"TextENG": "``...Maybe... maybe it wasn't coincidence that we met...! ......But... I really came to like you, Mion!``"
 	},
 	{
 		"type": "MSGSET",
@@ -801,7 +801,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1690.",
 		"TextJPN": "「……魅音の笑い顔を見るだけで…どれだけ救われた事か…ッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``......I just had to look at Mion's smiling face... and know how much I was saved...!``"
+		"TextENG": "``......Just seeing your smile... it saved me...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -810,7 +810,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0280.",
 		"TextJPN": "「梨花さんの世迷い言に耳を貸す必要はない！」",
 		"NamesENG": "Nitta",
-		"TextENG": "``You shouldn't listen to any of Rika-san's nonsense!``"
+		"TextENG": "``There's no need for you to listen to Rika-san's nonsense!``"
 	},
 	{
 		"type": "MSGSET",
@@ -819,7 +819,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0290.",
 		"TextJPN": "「…死にたくなかったら我々に従うことだ。協力的な態度さえとってくれれば、我々も君を好意的に扱うことを約束する！」",
 		"NamesENG": "Nitta",
-		"TextENG": "``...If you don't want to die, then follow us. I promise we will treat you favorably, and in a cooperative manner!``"
+		"TextENG": "``...If you don't want to die, then follow our directions. So long as you remain cooperative, we promise to treat you favorably too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -828,7 +828,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1700.",
 		"TextJPN": "「こいつらに付いて行ってはだめッ！　…魅音ッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``You mustn't follow them! ...Mion!``"
+		"TextENG": "``You can't go with them! ...Mion!``"
 	},
 	{
 		"type": "MSGSET",
@@ -837,7 +837,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2590.",
 		"TextJPN": "「…ぁああぁあ…ッ！　……うるせえよ…頭が…がんがんするってぇのに…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Ahhhh...! ......Everything's so noisy... my head... I want it to stop pounding...!``"
+		"TextENG": "``...Aaaaaaagh...! ......Shut up...! I told you... my head is pounding...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -846,7 +846,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0300.",
 		"TextJPN": "「さぁ、園崎さん！　…あなたも助かり、梨花さんも助かるんだ。どこにためらう理由があります！？」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Now, Sonozaki-san! ...You can be saved, Rika-san can be saved. What reason do you have to hesitate!?``"
+		"TextENG": "``Come, Sonozaki-san! ... We can save both you and Rika-san. What reason is there to hesitate?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -855,7 +855,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2600.",
 		"TextJPN": "「…ぁあぁ…ッ、……痛いよ…！　…痛いッ！　…助けて…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Ahhh... ......It's so painful...! ...It hurts! ...Help me...!``"
+		"TextENG": "``...Aaagh...! ......It hurts...! ...It hurts! ...Save me...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -864,7 +864,7 @@
 		"PreTextTags": "@vS26/58/THOS_0480.",
 		"TextJPN": "「…末期症状です！　……確保して下さい！」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...She's at the final stage of the symptoms! ......Please secure her!``"
+		"TextENG": "``...She's in terminal condition! ......Secure her now!``"
 	},
 	{
 		"type": "MSGSET",
@@ -879,7 +879,7 @@
 		"type": "MSGSET",
 		"MessageID": 156674,
 		"TextJPN": "魅音を捕らえようと男たちが飛び掛かろうとした瞬間、@r梨花が魅音を捕らえ、@rその首筋にどこからか取り出した刃物を当てる。@k@rその途端、男たちは一斉に銃を抜く。",
-		"TextENG": "Within a moment, the men throw themselves@rand attempt to capture Mion,@rbut Rika grabs her, she pulls out a knife@rand places it at nape of her neck.@k@rImmediately, the men pull out@rtheir guns simultaneously."
+		"TextENG": "The moment the men spring forth to capture Mion, Rika grabs hold of Mion and puts a knife she drew from somewhere against Mion's throat.@k@rThe moment she does, the men simultaneously draw their guns."
 	},
 	{
 		"type": "MSGSET",
@@ -897,7 +897,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1720.",
 		"TextJPN": "「私たちを解放してッ！　……さもないと魅音を殺すわよッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Let us go! ......Otherwise, I'll kill Mion!``"
+		"TextENG": "``Let us go! ......If you don't, then I'll kill Mion!``"
 	},
 	{
 		"type": "MSGSET",
@@ -906,7 +906,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0310.",
 		"TextJPN": "「なッ、馬鹿な真似はやめろッ！」",
 		"NamesENG": "Nitta",
-		"TextENG": "``S-Stop this stupid imitation!``"
+		"TextENG": "``D-Don't do anything foolish!``"
 	},
 	{
 		"type": "MSGSET",
@@ -915,7 +915,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1730.",
 		"TextJPN": "「そう。…私は馬鹿だった」",
 		"NamesENG": "Rika",
-		"TextENG": "``Well. ...I'm stupid then.``"
+		"TextENG": "``Yes. ...I was a fool.``"
 	},
 	{
 		"type": "MSGSET",
@@ -924,7 +924,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1740.",
 		"TextJPN": "「…毎晩、嫌な夢にうなされ、…衰弱していく自分。…プライバシーもなく…こいつらの研究材料として弄ばれる日々」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Every night, I have nightmares and unpleasant dreams... as I continue to debilitate. ...And without privacy... all these people did was toy with me like research material day after day.``"
+		"TextENG": "``...Every night I was haunted by bad dreams... feeling myself grow more and more debilitated. ...I spent every day without privacy... used as a guinea pig by these people.``"
 	},
 	{
 		"type": "MSGSET",
@@ -933,7 +933,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1750.",
 		"TextJPN": "「…嫌だった。…抜け出したかったの」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I hated it. ...I wanted to get away.``"
+		"TextENG": "``...I hated it. ...I wanted out.``"
 	},
 	{
 		"type": "MSGSET",
@@ -942,7 +942,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1760.",
 		"TextJPN": "「…適合者が見つかった時、…これで苦しみから解放されると思った。…私はその時、あなたをこいつらの生贄に差し出す事に同意した」",
 		"NamesENG": "Rika",
-		"TextENG": "``...So I found a compatible person, and thought they could free me from this suffering. ...At that time, I agreed to hold you out as a sacrifice for these people.``"
+		"TextENG": "``...When they found someone compatible... I thought I could finally be free of this suffering. ...That was when I agreed to hand you over as a sacrifice.``"
 	},
 	{
 		"type": "MSGSET",
@@ -951,7 +951,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1770.",
 		"TextJPN": "「……でも間違ってた…！　……魅音は適合者なんかじゃない！　生贄なんかじゃない！　……私のたったひとりの……親友なんだもん…ッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``......But I was wrong...! ......You shouldn't be the compatible person, Mion! ......I don't want you to be sacrificed! ......I use to be all alone...... but now you're my best friend...!``"
+		"TextENG": "``......But I was wrong...! ......You weren't just someone compatible! You weren't some sacrifice! ......You were my one and only...... my very best friend...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -960,7 +960,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2620.",
 		"TextJPN": "「………梨花さ…ん……」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........Rika...san......``"
+		"TextENG": "``......Rika-sa... n......``"
 	},
 	{
 		"type": "MSGSET",
@@ -969,7 +969,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1780.",
 		"TextJPN": "「…あなたの事を親友なんて呼ぶ資格は……あなたに会った時からなかったの！　…ごめんッ！　…ごめんねッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I shouldn't be entitled to call you my best friend...... not after what I've done since the moment I met you! ...I'm sorry! ...I'm sorry!``"
+		"TextENG": "``...Though I have no right to call you my best friend...... I never did, from the moment we met! ...I'm sorry! ...I'm so sorry!``"
 	},
 	{
 		"type": "MSGSET",
@@ -978,7 +978,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2630.",
 		"TextJPN": "「……そんなこと……ないよ……、……梨花さんは…親友だよ…」",
 		"NamesENG": "Mion",
-		"TextENG": "``......I never knew...... you considered me...... ......your best friend, Rika-san...``"
+		"TextENG": "``......That's not...... true...... ......Rika-san... you really are my best friend...``"
 	},
 	{
 		"type": "MSGSET",
@@ -996,7 +996,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0320.",
 		"TextJPN": "「園崎さん！　冷静になって考えて下さい！　あなたが梨花さんと心中すれば雛見沢一帯の数万人も道連れになるのですッ！」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Sonozaki-san! Please calm down and think for a moment! If you commit a double suicide with Rika-san, the tens of thousands of people living in the whole Hinamizawa area will die!``"
+		"TextENG": "``Sonozaki-san! Please think about this logically! If you and Rika-san commit suicide together, then you're dragging the tens of thousands of people living in Hinamizawa down with you!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1005,7 +1005,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0330.",
 		"TextJPN": "「……手術を受け入れれば！　…あなたたちが助かるだけじゃない！　…その数万人も助かるのですッ！」",
 		"NamesENG": "Nitta",
-		"TextENG": "``......However, if you accept the operation! ...Not just the both of you will survive! But tens of thousands of people will be saved as well!``"
+		"TextENG": "``......You have to have the surgery! ...The surgery won't just save you two! ...It'll save tens of thousands of lives!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1014,7 +1014,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2640.",
 		"TextJPN": "「……いいじゃないですか…手術…。…梨花さんだって助かるんですよ…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......I don't know if it's okay... this operation... ...But will even Rika-san survive...?``"
+		"TextENG": "``......I'll have the surgery... then... ...That'll save Rika-san too, right...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1023,7 +1023,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1800.",
 		"TextJPN": "「…魅音。あいつらの言う事に騙されては駄目。……よく考えて。…あいつらはどうしてオヤシロさまに寄生されないの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Mion. You mustn't be deceived by what these people say. ......Think carefully. ...These people, why do you think they're interested in the Oyashiro-sama parasite?``"
+		"TextENG": "``...Mion. Don't let them fool you. ......Think about it. ...Why aren't they hosts to Oyashiro-sama?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1032,7 +1032,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1810.",
 		"TextJPN": "「…あいつらはね、…とっくに…治療薬を開発してるのよ。……なのにどうして研究したがると思う？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...These people... a long time ago... wanted to develop a therapeutic drug. ......However, why do you think they wanted to research it?``"
+		"TextENG": "``...Because they... they've already developed a cure. ......So why do you think they want to research it further?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1041,7 +1041,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1820.",
 		"TextJPN": "「……あいつらはね、……治療以外の目的の為に……研究を……！」",
 		"NamesENG": "Rika",
-		"TextENG": "``......These people...... they aren't doing it for the purpose of treatment...... but research......!``"
+		"TextENG": "``......Those people...... they're conducting their research to develop more than just a cure......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1050,7 +1050,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0340.",
 		"TextJPN": "「…滅多な事は言わないでもらいましょう」",
 		"NamesENG": "Nitta",
-		"TextENG": "``...Now, let's not say such silly things.``"
+		"TextENG": "``...Could you not speak such slander?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1059,7 +1059,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0350.",
 		"TextJPN": "「…梨花さんの言っておられる行為は国際法でいかなる研究も開発も禁じられています」",
 		"NamesENG": "Nitta",
-		"TextENG": "``...As for the act which Rika-san is talking about, both it, its study and development are forbidden by international law.``"
+		"TextENG": "``...The kinds of research and development that you're suggesting are banned under international law.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1068,7 +1068,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0360.",
 		"TextJPN": "「…我が国は国連加盟の法治国家ですよ。…そんな真似はしません」",
 		"NamesENG": "Nitta",
-		"TextENG": "``...So, with our country a member of the United Nations, we abide by their laws. ...And therefore, cannot do such a thing.``"
+		"TextENG": "``...Our nation is a constitutional state and a member of the UN. ...We would never do such a thing.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1077,7 +1077,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1830.",
 		"TextJPN": "「…親虫は私が飼うわ！　…私が死ぬまでの２～３年間で、寄生されてる人みんなを治療できるはずよ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...I'm keeping the parent insect! ...Before I die in 2-3 years, you should be able to treat everyone with the parasite!``"
+		"TextENG": "``...I'll keep hosting the queen! ...You should be able to cure everyone hosting this bug in the two or three years left before I die!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1086,7 +1086,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0370.",
 		"TextJPN": "「…ですから治療薬はないんですよ」",
 		"NamesENG": "Nitta",
-		"TextENG": "``...Drug is not ready yet.``"
+		"TextENG": "``...We told you, we have no cure yet.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1095,7 +1095,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1840.",
 		"TextJPN": "「魅音を治してッ！　…治せるくせにッ！　…治さないなら殺すわよッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Cure Mion! ...I know you can cure her! ...I'll kill you if you don't cure her!``"
+		"TextENG": "``Cure Mion! ...I know you can cure her! ...If you won't cure her, then I'll kill her!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1104,7 +1104,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2650.",
 		"TextJPN": "「があぁあぁあぁあッ！　…ああぁあああッ！　…痛いッ！　……痛いよッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Gaaaaaaaa! ...Ahhhhhhh! ...It hurts! ...It hurts!``"
+		"TextENG": "``Gaaaaaaaaah! ...Aaaaaaaaagh! ...It hurts! ......It hurts!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1113,7 +1113,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1850.",
 		"TextJPN": "「大丈夫！　…私が助けてあげるッ！　しっかりッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's alright! ...I'll help you! Just stay strong!``"
+		"TextENG": "``Don't worry! ...I'll save you! Hang in there!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1122,7 +1122,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0380.",
 		"TextJPN": "「治すには手術しかありません」",
 		"NamesENG": "Nitta",
-		"TextENG": "``We only need to perform one operation to cure her.``"
+		"TextENG": "``The only cure for her is the surgery.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1131,7 +1131,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2660.",
 		"TextJPN": "「た……助けて……梨花…さんッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``H-Help...... Rika... san!``"
+		"TextENG": "``Sa...... Save me...... Rika...san!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1140,7 +1140,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1860.",
 		"TextJPN": "「薬をッ！　魅音を治して！　…お願いッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``The medicine! Give it to Mion! ...Please!``"
+		"TextENG": "``Give me the cure! Cure Mion! ...Please!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1149,7 +1149,7 @@
 		"PreTextTags": "@vS26/58/THOS_0490.",
 		"TextJPN": "「…もう園崎さんは持ちません」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...That won't help Sonozaki-san anymore.``"
+		"TextENG": "``...Sonozaki-san won't last much longer.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1167,7 +1167,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1870.",
 		"TextJPN": "「…私を撃つつもりッ！？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Do you intend to shoot me!?``"
+		"TextENG": "``...You're planning to shoot me?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1176,7 +1176,7 @@
 		"PreTextTags": "@vS26/58/THOS_0500.",
 		"TextJPN": "「ふん。死後１２時間、遺体の脳内でアリが生存する事は確認済みです」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``It has been confirmed that the ant can live in the brain of a corpse posthumously, 12 hours after death.``"
+		"TextENG": "``We've already confirmed the ants can survive in the brain of a corpse for twelve hours postmortem.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1185,7 +1185,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0400.",
 		"TextJPN": "「どの道、親虫さえ取り出せば、知り過ぎた人間だ」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Which means, we can take out the parent insect from someone who knows too much.``"
+		"TextENG": "``Either way, once we extract the queen from you, you're just a girl who knows too much.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1194,6 +1194,6 @@
 		"PreTextTags": "@vS26/52/TRIK_1880.",
 		"TextJPN": "「この……人でなしぃッ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Murderers!``"
+		"TextENG": "``...You monster!``"
 	}
 ]

--- a/bus_stop_end.json
+++ b/bus_stop_end.json
@@ -9,7 +9,7 @@
 		"type": "MSGSET",
 		"MessageID": 156710,
 		"TextJPN": "狙いを定めた織田の拳銃が火を噴く。@k@r胸を撃ち抜かれ一撃で絶命する梨花。",
-		"TextENG": "Oda aims his handgun, and fires.@k@rThe bullet is fired straight through Rika's chest,@rshe dies in a single blow."
+		"TextENG": "Oda takes careful aim, and then light flashes from his handgun.@k@rRika meets her end with a single shot straight through her chest."
 	},
 	{
 		"type": "MSGSET",
@@ -18,7 +18,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2670.",
 		"TextJPN": "「わああぁあぁあぁあっぁあぁあッ！？　……梨花さん！？　梨花さん！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ahhhhhhhhhhhhh! ......Rika-san!? Rika-san!?``"
+		"TextENG": "``Waaaaaaaaaaaaaahhhh?! ......Rika-san?! Rika-san?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -27,13 +27,13 @@
 		"PreTextTags": "@vS26/57/TNIT_0410.",
 		"TextJPN": "「捕らえろ。手術は急を要するぞ」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Seize her. We need to perform the operation urgently.``"
+		"TextENG": "``Capture her. We have to conduct the surgery immediately.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156713,
 		"TextJPN": "魅音、すばやく梨花の刃物をひったくり身構える。",
-		"TextENG": "Mion quickly snatches the knife from Rika and stands ready."
+		"TextENG": "Mion nimbly snatches the knife away from Rika and readies herself."
 	},
 	{
 		"type": "MSGSET",
@@ -51,7 +51,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2680.",
 		"TextJPN": "「…梨花さん！？　…梨花さん！？　……梨花…さ…ん……ぐぐ…ッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Rika-san? ...Rika-san! ......Rika...san...... *groans*...!``"
+		"TextENG": "``...Rika-san?! ...Rika-san?! ......Rika...sa...n...... gggghn...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -60,7 +60,7 @@
 		"PreTextTags": "@vS26/61/THOT_0120.",
 		"TextJPN": "「さぁ手術をッ！　…もう時間がないのよ！」",
 		"NamesENG": "Hotoda",
-		"TextENG": "``Now, surgery! ...We're already running out of time!``"
+		"TextENG": "``Now, the surgery! ...We don't have any time to waste!``"
 	},
 	{
 		"type": "MSGSET",
@@ -69,7 +69,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2690.",
 		"TextJPN": "「…梨花さんを……殺したなあぁああッ！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Rika-san...... did you kill her!?``"
+		"TextENG": "``...You... killed Rika-saaaaaaaaan?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -78,7 +78,7 @@
 		"PreTextTags": "@vS26/58/THOS_0510.",
 		"TextJPN": "「…落ち着いて園崎さん！　…私たちは誰も殺してないわよッ！？　…それが幻覚なのよッ！　…末期症状なのよッ！」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...Calm down, Sonozaki-san! ...None of us killed anyone! ...This is all a hallucination! ...You're at the terminal stage!``"
+		"TextENG": "``...Calm down, Sonozaki-san! ...We haven't killed anyone! ...You're hallucinating! ...You're in a terminal condition right now!``"
 	},
 	{
 		"type": "MSGSET",
@@ -87,7 +87,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2700.",
 		"TextJPN": "「う…そだ…ッ！　…お前らが…こ……殺したんだッ！　…殺してやるッ！　…殺してやるッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``You're lying...! ...You people...... killed her! ...I'll kill you! ...I'll kill you!``"
+		"TextENG": "``You... lie...! ...You all... ki...... killed her! ...I'll kill you! ...I'll kill you!``"
 	},
 	{
 		"type": "MSGSET",
@@ -96,7 +96,7 @@
 		"PreTextTags": "@vS26/57/TNIT_0430.",
 		"TextJPN": "「冷静に冷静に！　…全て幻覚だッ！　…ナイフを捨てろッ！」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Calm down, calm down! ...This is all just a hallucination! ...Throw away the knife!``"
+		"TextENG": "``Calm down! Calm down! ...That's all a hallucination! ...Drop the knife!``"
 	},
 	{
 		"type": "MSGSET",
@@ -105,13 +105,13 @@
 		"PreTextTags": "@vS26/53/TMIO_2710.",
 		"TextJPN": "「…黙れ黙れぇッ！　…殺してやる殺してやるッ！　…うがぁあぁあぁああッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Shut up, shut up! ...I'll kill you, I'll kill you! ...Uaaaaaaaa!``"
+		"TextENG": "``...Be quiet, be quiet! ...I'll kill you, I'll kill you all! ...Ughaaaaaaaaaagh!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156722,
 		"TextJPN": "魅音、織田に飛びつき刃物を突きたてる。織田はその場にうずくまる。",
-		"TextENG": "Mion jumps at Oda and sticks the knife into his stomach. Oda crouches down on the spot."
+		"TextENG": "Mion leaps at Oda and shoves her knife into his stomach. Oda falls and curls up on the spot."
 	},
 	{
 		"type": "MSGSET",
@@ -120,7 +120,7 @@
 		"PreTextTags": "@vS26/59/TOKA_0230.",
 		"TextJPN": "「き、…貴様…ッ！」",
 		"NamesENG": "Okano",
-		"TextENG": "``You...!``"
+		"TextENG": "``Wh...Why you...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -129,7 +129,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2720.",
 		"TextJPN": "「殺してやるぞ殺してやるぞッ！　…梨花さんを殺したヤツらは皆殺しにしてやるッ！　…おおおぉぉおおおおおッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``I'll kill you all, I'll kill you all! ...I'll massacre everyone who killed Rika-san! ...Oooooooooo!``"
+		"TextENG": "``I'll kill you, I'll kill you! ...I'll kill everyone who killed Rika-san! ...Hoooooooooooooooh!``"
 	},
 	{
 		"type": "MSGSET",
@@ -138,13 +138,13 @@
 		"PreTextTags": "@vS26/57/TNIT_0440.",
 		"TextJPN": "「落ち着け！　落ち着くんだッ！　…園崎君！　………ッ！」",
 		"NamesENG": "Nitta",
-		"TextENG": "``Calm down! Calm down! ...Sonozaki-kun! .........!``"
+		"TextENG": "``Calm down! Calm down now! ...Sonozaki-kun! .........!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156726,
 		"TextJPN": "魅音に飛びつかれ、刺される新田。",
-		"TextENG": "Mion jumps and stabs Nitta."
+		"TextENG": "Mion leaps forward and stabs him."
 	},
 	{
 		"type": "MSGSET",
@@ -153,19 +153,19 @@
 		"PreTextTags": "@vS26/59/TOKA_0240.",
 		"TextJPN": "「この野郎ッ！」",
 		"NamesENG": "Okano",
-		"TextENG": "``You bastard!``"
+		"TextENG": "``You bitch!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156728,
 		"TextJPN": "魅音に後ろから掴みかかる岡野。揉み合いの途中で魅音のナイフが刺さる。倒れる岡野。",
-		"TextENG": "Okano grabs Mion from behind. She stabs the knife into his neck midway into their struggle. Okano's voice is suppressed, he falls down."
+		"TextENG": "Okano grabs hold of Mion from behind. During their grapple, Mion's knife pierces his neck. Okano falls back, clutching his throat."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156729,
 		"TextJPN": "保土田は悲鳴をあげて逃げようとする。それを魅音は捕まえ刃を突きたてる。",
-		"TextENG": "Hotoda screams and tries to escape. Mion catches up and thrusts the blade into her back."
+		"TextENG": "Hotoda screams and tries to flee. Yet Mion catches her and shoves her blade into her back."
 	},
 	{
 		"type": "MSGSET",
@@ -174,7 +174,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2730.",
 		"TextJPN": "「があぁああぁああッ！　…梨花さんを殺したのは誰だッ！　…畜生畜生畜生ッ！　…殺してやる殺してやる殺してやるッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Gaaaaaaaaa! ...Who else killed Rika-san! ...Damn it all, damn it all, damn it all! ...I'll kill you, I'll kill you, I'll kill you!``"
+		"TextENG": "``Gaaaaaaaagh! ...Who was the one that killed Rika-san?! ...Dammit, dammit, dammit! ...I'll kill you, I'll kill you, I'll kill you!``"
 	},
 	{
 		"type": "MSGSET",
@@ -183,7 +183,7 @@
 		"PreTextTags": "@vS26/58/THOS_0520.",
 		"TextJPN": "「…園崎さん！　…落ち着いて！　私たちは何もしてないわ！　本当よ！　…あなたが…幻覚を見てひとりで暴れてるだけなのよ！　…落ち着いてッ！」",
 		"NamesENG": "Hoshino",
-		"TextENG": "``...Sonozaki-san! ...Calm down! We didn't do anything! It's the truth! You... you acted violent all by yourself after seeing hallucinations! Calm down!``"
+		"TextENG": "``...Sonozaki-san! ...Calm down! We haven't done anything! Honest! ...You're... just hallucinating! You're being violent for no reason! ...Calm down!``"
 	},
 	{
 		"type": "MSGSET",
@@ -192,25 +192,25 @@
 		"PreTextTags": "@vS26/53/TMIO_2740.",
 		"TextJPN": "「うるせぇよ…！　…梨花さんを返せよッ！　…おああぁぁああぁあッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Liar...! ...Give Rika-san back to me! ...Ahhhhhhhhhh!``"
+		"TextENG": "``Shut up...! ...Give me back Rika-san! ...Hoaaaaaaaaaaagh!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156733,
 		"TextJPN": "星野に飛び掛かり刃を思い切り振り下ろす。",
-		"TextENG": "Mion throws herself onto Hoshino and stabs deeply into her stomach."
+		"TextENG": "She springs onto Hoshino and stabs the knife deep into her stomach."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156734,
 		"TextJPN": "…累々と転がる屍。…土砂降りの雨と肩で息をする魅音の荒い息。",
-		"TextENG": "...Corpses pilled and rolled in heaps. Mion breaths roughly among the pouring rain gasping for breath."
+		"TextENG": "...Corpses are piled up all around her. ...The sound of heavy rain is accompanied by Mion's heaving breathing as her shoulders shudder with each breath."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156735,
 		"TextJPN": "我に返り、梨花にゆっくりと近付く。",
-		"TextENG": "She turns around, and slowly approaches Rika."
+		"TextENG": "She regains her senses and slowly approaches Rika."
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2750.",
 		"TextJPN": "「…梨花さん…。……梨花さん…！　…起きて下さいよぅ…！　…そろそろ帰りましょうよぅ……」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Rika-san... ......Rika-san...! ...Please wake up...! ...Come back......``"
+		"TextENG": "``...Rika-san... ......Rika-san...! ...Please wake up...! ...It's time for us to go home......``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,13 +228,13 @@
 		"PreTextTags": "@vS26/53/TMIO_2760.",
 		"TextJPN": "「ぎゃああぁあぁあぁぁああああぁああああッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Gyaaaaaaaaaaaaaaaaa!``"
+		"TextENG": "``Gyaaaaaaaaaaaaaaaaaaaaaaaah!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156738,
 		"TextJPN": "舞台は真っ赤なライトで照らされる。泣いて絶叫する魅音。",
-		"TextENG": "The stage is illuminated with a bright red light. Mion cries and screams."
+		"TextENG": "A bright red light shines down on the stage. Mion weeps and screams."
 	},
 	{
 		"type": "MSGSET",
@@ -243,7 +243,7 @@
 		"PreTextTags": "@vS26/00/TOYA_0000.",
 		"TextJPN": "「……可哀相に。……辛いでしょう」",
 		"NamesENG": "Oyashiro-sama",
-		"TextENG": "``......You poor thing. ......That must have been painful.``"
+		"TextENG": "``......Poor thing. ......It must have been tough.``"
 	},
 	{
 		"type": "MSGSET",
@@ -252,7 +252,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2770.",
 		"TextJPN": "「梨花さん！　…梨花さん！　…嘘だぁあぁああああッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Rika-san! ...Rika-san! ...This cannot be true!!!``"
+		"TextENG": "``Rika-san! ...Rika-san! ...It's all a lieeeeeeee!``"
 	},
 	{
 		"type": "MSGSET",
@@ -261,7 +261,7 @@
 		"PreTextTags": "@vS26/00/TOYA_0010.",
 		"TextJPN": "「……ねぇ、魅音さん。……今度こそ、…私が解放してあげましょう」",
 		"NamesENG": "Oyashiro-sama",
-		"TextENG": "``......Hey, Mion-san. ......This time... let me free you.``"
+		"TextENG": "``......Hey, Mion-san. ......This time... I'll free you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -270,7 +270,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2780.",
 		"TextJPN": "「梨花さんに会わせてッ！　……会わせてよぅッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Let me meet Rika-san! ......I want to meet her!``"
+		"TextENG": "``Let me see Rika-san! ......Let me see her!``"
 	},
 	{
 		"type": "MSGSET",
@@ -279,7 +279,7 @@
 		"PreTextTags": "@vS26/00/TOYA_0020.",
 		"TextJPN": "「……会いたい…？　…会いたいですか？　…会いたい。……ふっふふふ！　…いいでしょう。…会わせてあげましょう」",
 		"NamesENG": "Oyashiro-sama",
-		"TextENG": "``......You want to meet...? ...Do you want to meet it? ...You want to meet it. ......Hee hee hee hee! ...All right. ...I will let you meet it.``"
+		"TextENG": "``......You want to meet them...? ...You want to meet them, do you? ...You want to meet them. ......Fufufufu! ...Very well. ...Then I'll help you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -288,7 +288,7 @@
 		"PreTextTags": "@vS26/00/TOYA_0030.",
 		"TextJPN": "「……近藤さんも、柿沼さんも。……森さんも加藤さんも。…そして荒川君も会いました」",
 		"NamesENG": "Oyashiro-sama",
-		"TextENG": "``......Kondo-san, Kakinuma-san. ......Even Mori-san and Kato-san. ...And also, Arakawa-kun met it.``"
+		"TextENG": "``......Kondou-san and Kakinuma-san both. ......Mori-san and Katou-san too. ...Arakawa-kun met them all.``"
 	},
 	{
 		"type": "MSGSET",
@@ -297,7 +297,7 @@
 		"PreTextTags": "@vS26/00/TOYA_0040.",
 		"TextJPN": "「……あなたにも…会わせてあげましょうとも」",
 		"NamesENG": "Oyashiro-sama",
-		"TextENG": "``......And you too... I will let you meet it.``"
+		"TextENG": "``......Now you too... shall meet them, of course.``"
 	},
 	{
 		"type": "MSGSET",
@@ -306,19 +306,19 @@
 		"PreTextTags": "@vS26/53/TMIO_2790.",
 		"TextJPN": "「会わせてよ！　…会わせてよッ！　……梨花さぁあああぁあああんッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Let me meet it! ...Let me meet it! ......Rika-saaaaaaaaan!``"
+		"TextENG": "``Let me see her! ...Let me see her! ......Rika-saaaaaaaaaaaann!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156747,
 		"TextJPN": "おおきな雷鳴。@k@r舞台フラッシュして暗転。@k@r雨の音だけがしとしと続く。@k@r長い沈黙。",
-		"TextENG": "Big thunder.@k@rThe stage's flash bulb@ris darkened by a theatrical blackout.@k@rFollowed by the sound of the rain.@k@rA long silence."
+		"TextENG": "There's a loud crack of thunder.@k@rThe stage flashes bright, then goes dark.@k@rOnly the gentle sound of rain continues.@k@rA long silence follows."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156748,
 		"TextJPN": "徐々に明るくなる。@k@r魅音と梨花しかいない。@k@r魅音は梨花の膝に頭を預け眠っている。",
-		"TextENG": "It gradually becomes brighter.@k@rThere is only Mion and Rika.@k@rMion is sleeping with her head on Rika's knee."
+		"TextENG": "Steadily the stage grows lit.@k@rOnly Mion and Rika are present.@k@rMion is sleeping with her head in Rika's lap."
 	},
 	{
 		"type": "MSGSET",
@@ -327,7 +327,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1890.",
 		"TextJPN": "「……起きちゃった…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Are you awake...?``"
+		"TextENG": "``......Are you awake now...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -336,7 +336,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2800.",
 		"TextJPN": "「……ん、……んん、……頭……痛い…」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Oww...... ......my head...... ......it hurts...``"
+		"TextENG": "``......Nnh...... Nnnh...... My head...... hurts...``"
 	},
 	{
 		"type": "MSGSET",
@@ -345,7 +345,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1900.",
 		"TextJPN": "「…まだ薬が効いて来ない？　…もう少し寝てていいのに」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Did the medicine not work? ...I think you should have slept a little more.``"
+		"TextENG": "``...The medicine still isn't working yet? ...You can sleep a little longer, you know.``"
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2810.",
 		"TextJPN": "「……梨花さん…？　……梨花さんなんですよね…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Rika-san...? ......Is that you, Rika-san...?``"
+		"TextENG": "``......Rika-san...? ......Rika-san, it is you, right...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -363,7 +363,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1910.",
 		"TextJPN": "「…他の誰に見える…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Who else would it be...?``"
+		"TextENG": "``...Do I look like someone else...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -378,13 +378,13 @@
 		"type": "MSGSET",
 		"MessageID": 156755,
 		"TextJPN": "梨花に抱きつく魅音。",
-		"TextENG": "Mion embraces Rika."
+		"TextENG": "Mion clings to Rika."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156756,
 		"TextJPN": "梨花は一瞬面食らうが、やさしく抱きしめる。",
-		"TextENG": "Rika is confused for a moment, but gently hugs her back."
+		"TextENG": "Rika is confused for a moment, then gently hugs her back."
 	},
 	{
 		"type": "MSGSET",
@@ -393,7 +393,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2830.",
 		"TextJPN": "「本当に梨花さんなんですよね！　…梨花さんなんですよね！？　…わぁあぁあああああッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``It's really you, Rika-san! ...Is it you, Rika-san!? ...Waaaaaaaaa!``"
+		"TextENG": "``It's really you, right?! ...You're Rika-san, right?! ...Waaaaaaaaaah!``"
 	},
 	{
 		"type": "MSGSET",
@@ -402,7 +402,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1920.",
 		"TextJPN": "「……私はここよ。…ここにいるわ。…悲しい夢を見たの…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......I'm here. ...I'm here. ...Did you have a sad dream...?``"
+		"TextENG": "``......I'm here. ...I'm right here. ...Did you have a sad dream...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -411,13 +411,13 @@
 		"PreTextTags": "@vS26/53/TMIO_2840.",
 		"TextJPN": "「……ぅぅ、……わぁああぁあああああぁあああッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Uuu...... waaaaaaaaaaaaaa!``"
+		"TextENG": "``......Nnh...... Waaaaaaaaaaaaaaaaaaaaaaaaaaaaah!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 156760,
 		"TextJPN": "慈しむ表情で魅音を抱きしめる梨花。",
-		"TextENG": "Rika hugs Mion with an expression of love."
+		"TextENG": "Rika hugs Mion with an affectionate expression."
 	},
 	{
 		"type": "MSGSET",
@@ -426,7 +426,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1930.",
 		"TextJPN": "「………落ち着いた…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........Have you calmed down...?``"
+		"TextENG": "``.........Have you settled down now...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -435,7 +435,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2850.",
 		"TextJPN": "「はは、はははは、……はい。……どーもすみません…。…ははは…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ha ha, ha ha ha ha...... Yes. ......I'm sorry... ...Ha ha ha...``"
+		"TextENG": "``Haha, hahahaha...... Yes. ......I'm sorry about that... ...Hahaha...``"
 	},
 	{
 		"type": "MSGSET",
@@ -444,7 +444,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1940.",
 		"TextJPN": "「…ねぇ魅音。……あなたを起こすの、…悪いと思ってね。…バスを１本、見送っちゃったの」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Hey, Mion. ......I didn't wake you up... I thought that would be wrong. ...So I let the bus pass by.``"
+		"TextENG": "``...Hey, Mion. ......I felt bad... about waking you up. ...So we missed the bus that passed by.``"
 	},
 	{
 		"type": "MSGSET",
@@ -453,7 +453,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2860.",
 		"TextJPN": "「えぇー！？　…そんじゃ次のバスはいつ来るんですかぁ！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Eh!? ...Then when will the next bus arrive!?``"
+		"TextENG": "``Whaaa?! ...But then when is the next bus coming here?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -462,7 +462,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1950.",
 		"TextJPN": "「…もう待つの嫌でしょ？　……ねぇ。…歩いて行かない？　…近道を通って行けばそんなに時間はかからないと思うの」",
 		"NamesENG": "Rika",
-		"TextENG": "``...Would you hate it if we had to wait? ......Hey. ...Want to walk instead? ...It won't take that long if we use the shortcut.``"
+		"TextENG": "``...You don't want to wait anymore, right? ......So hey. ...Why don't we walk? ...If we take a shortcut, it shouldn't take that long.``"
 	},
 	{
 		"type": "MSGSET",
@@ -471,7 +471,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2870.",
 		"TextJPN": "「…って、私たち傘ないですよ。…降りは幾分、弱くなったようですけど…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Hey, but we don't have umbrellas. ...Although, the rain seems to have eased a little...``"
+		"TextENG": "``...But wait, we don't have an umbrella. ...Though it looks like the rain let up a lot...``"
 	},
 	{
 		"type": "MSGSET",
@@ -480,7 +480,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1960.",
 		"TextJPN": "「……私と雨の中を歩くの、…嫌い…？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Want to walk with me in the rain then... or you don't want...?``"
+		"TextENG": "``......You don't want to walk through the rain... with me...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -489,7 +489,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2880.",
 		"TextJPN": "「とんでもないッ！　…梨花さんの為なら例え火の中、水の中ー！　いいでしょー！　お伴申し上げますわーん！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Far from it! ...I'd go with you anywhere, Rika-san, through fire and water for example! Great! I'll accompany you then!``"
+		"TextENG": "``Of course I do! ...I'd go through fire or water for you, Rika-san! Alright then! Allow me to accompany you!``"
 	},
 	{
 		"type": "MSGSET",
@@ -498,7 +498,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1970.",
 		"TextJPN": "「……本当にいいの…？　……傘がないから、…ずぶ濡れになるわよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Really...? ......But, since we have no umbrellas... we're gonna get soaked.``"
+		"TextENG": "``......Are you really sure...? ......Without an umbrella... we'll both end up soaked.``"
 	},
 	{
 		"type": "MSGSET",
@@ -507,7 +507,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2890.",
 		"TextJPN": "「勿論！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Of course!``"
+		"TextENG": "``Of course I'm sure!``"
 	},
 	{
 		"type": "MSGSET",
@@ -516,7 +516,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1980.",
 		"TextJPN": "「泥だらけになるわよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``We'll get muddy.``"
+		"TextENG": "``You'll get covered in mud.``"
 	},
 	{
 		"type": "MSGSET",
@@ -525,7 +525,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2900.",
 		"TextJPN": "「覚悟の上です！」",
 		"NamesENG": "Mion",
-		"TextENG": "``I'm ready for anything!``"
+		"TextENG": "``I'm prepared for that!``"
 	},
 	{
 		"type": "MSGSET",
@@ -534,7 +534,7 @@
 		"PreTextTags": "@vS26/52/TRIK_1990.",
 		"TextJPN": "「…風邪をひくかもね」",
 		"NamesENG": "Rika",
-		"TextENG": "``...We may catch a cold.``"
+		"TextENG": "``...You might catch a cold.``"
 	},
 	{
 		"type": "MSGSET",
@@ -543,7 +543,7 @@
 		"PreTextTags": "@vS26/53/TMIO_2910.",
 		"TextJPN": "「雨ですからーッ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Because of the rain!``"
+		"TextENG": "``Well, it is raining!``"
 	},
 	{
 		"type": "MSGSET",
@@ -551,7 +551,7 @@
 		"PreTextTags": "@s70.",
 		"TextJPN": "立ち上がる２人。",
 		"AfterTextTags": "@e",
-		"TextENG": "Both of them stand up."
+		"TextENG": "Both of them stand there for a moment.@e"
 	},
 	{
 		"type": "MSGSET",
@@ -561,7 +561,7 @@
 		"TextJPN": "「…私がずっと側に居てあげるから。…離れないでね」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Rika",
-		"TextENG": "``...I'll be forever by your side. ...I'll never leave.``"
+		"TextENG": "``...I'll stay with you forever. ...So don't leave me, okay?``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -571,7 +571,7 @@
 		"TextJPN": "「あぁん！　離れないどころか密着してたいですわーん！」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Mion",
-		"TextENG": "``Yes! I want to be glued to you so I'll never leave your side!``"
+		"TextENG": "``Ahhn! I'd never leave you! I'd rather cling to you instead!``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -581,7 +581,7 @@
 		"TextJPN": "「……うん。…それでいいわ。……行きましょ」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Rika",
-		"TextENG": "``......Yes. ...That's good. ......Let's go.``"
+		"TextENG": "``......Yeah. ...That's good. ......Let's go.``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -589,7 +589,7 @@
 		"PreTextTags": "@s70.",
 		"TextJPN": "魅音の手を取り、歩き出す梨花。魅音はドキドキして緊張している。",
 		"AfterTextTags": "@e",
-		"TextENG": "Rika begins walking while holding Mion's shoulder. Mion's heart throbs in tension."
+		"TextENG": "Rika starts walking, still holding Mion's shoulder. Mion is nervous and her heart is racing.@e"
 	},
 	{
 		"type": "MSGSET",
@@ -599,7 +599,7 @@
 		"TextJPN": "「…ど……どうしたんすか梨花さん。……何かいつもと雰囲気違う…」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Mion",
-		"TextENG": "``...W-What's wrong, Rika-san...? ......You seem a little different from your usual mood...``"
+		"TextENG": "``...Wha...... What's gotten into you, Rika-san? ......You're not acting like your usual self...``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -609,7 +609,7 @@
 		"TextJPN": "「……行きましょう。……二人ならどこへだって行ける…」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Rika",
-		"TextENG": "``......Let's go. ......We can go anywhere together....``"
+		"TextENG": "``......Let's go. ......Together, we can go anywhere we like...``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -617,7 +617,7 @@
 		"PreTextTags": "@s70.",
 		"TextJPN": "舞台、徐々に暗転。",
 		"AfterTextTags": "@e",
-		"TextENG": "The stage gradually turns dark."
+		"TextENG": "The stage gradually fades to black.@e"
 	},
 	{
 		"type": "MSGSET",
@@ -625,7 +625,7 @@
 		"PreTextTags": "@s70.",
 		"TextJPN": "しばらくしてピーピーという無線の呼び出し音。",
 		"AfterTextTags": "@e",
-		"TextENG": "A few moments later a radio is beeping."
+		"TextENG": "After a moment, there's a beep signaling a radio call.@e"
 	},
 	{
 		"type": "MSGSET",
@@ -635,7 +635,7 @@
 		"TextJPN": "「３号車です」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Voice",
-		"TextENG": "``This is Car-3.``"
+		"TextENG": "``This is car number three.``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -645,7 +645,7 @@
 		"TextJPN": "「…本部より待機中の全車へ。…目標はバスに乗車せず。繰り返す。目標はバスに乗車せず」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Voice",
-		"TextENG": "``...To all cars waiting for orders from headquarters. ...The target did not take the bus. I repeat. The target did not take the bus.``"
+		"TextENG": "``...Headquarter to all cars on standby. ...The target did not board the bus. Repeat. The target did not board the bus.``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -655,7 +655,7 @@
 		"TextJPN": "「偵察班より本部へ！　…停留所、もぬけのからです。失探しました」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Voice",
-		"TextENG": "``Reconnaissance team to headquarters! ...Their tracks have come to a stop. We lost them.``"
+		"TextENG": "``Recon team to headquarters! ...The bus stop is completely empty. We've lost visual!``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -665,6 +665,6 @@
 		"TextJPN": "「……街道を全て封鎖しろ。…繰り返す、街道を全て封鎖。…市内へ逃がすなッ！　…生かしたまま捕らえろッ！」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Voice",
-		"TextENG": "``......Blockade all the highways. ...I repeat, blockade all the highways. ...Don't let them escape to the city! ...Capture them, but keep them alive!``"
+		"TextENG": "``......Seal off all the main roads. ...Repeat, seal off all the main roads. ...Don't let them escape to the city! ...Capture them alive!``@e"
 	}
 ]

--- a/kamikashimashi_1.json
+++ b/kamikashimashi_1.json
@@ -15,19 +15,19 @@
 		"type": "MSGSET",
 		"MessageID": 154028,
 		"TextJPN": "彼方に見える興宮の街からは、火事のような煙があちこちから立ち上っている。",
-		"TextENG": "From the town of Okinomiya and beyond in sight, smoke from fires can be seen rising up everywhere."
+		"TextENG": "In the distant town of Okinomiya we saw smoke rising from fires here and there."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154029,
 		"TextJPN": "それらが煙り、街全体を不穏に覆っているのが一望できる。",
-		"TextENG": "The smoke, and unrest disturbingly covers the entire town."
+		"TextENG": "We had a very clear view of it as it hung ominously over the whole town."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154030,
 		"TextJPN": "風は時折、静寂な街に木霊する奇声や怒声、あるいは見当もつかない不気味な音を運んでくる。",
-		"TextENG": "The wind occasionally echoes across the silent town with an angry and strange voice, carrying an eerie sound nobody understands."
+		"TextENG": "Occasionally the wind carried the sound of screams, raging, and unidentifiable, these portentous noises echoing in the quiet town."
 	},
 	{
 		"type": "MSGSET",
@@ -36,7 +36,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0770.",
 		"TextJPN": "「……まるで、街の断末魔が聞こえるようだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``......It's as if we can hear the town's death agony.``"
+		"TextENG": "``......It sounds like something's dying cry.``"
 	},
 	{
 		"type": "MSGSET",
@@ -45,7 +45,7 @@
 		"PreTextTags": "@vS25/02/NREN_0600.",
 		"TextJPN": "「このおかしな騒ぎは雛見沢だけじゃないんだね……」",
 		"NamesENG": "Rena",
-		"TextENG": "``So this strange disturbance isn't only in Hinamizawa......``"
+		"TextENG": "``This isn't just in Hinamizawa, huh...``"
 	},
 	{
 		"type": "MSGSET",
@@ -54,7 +54,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0730.",
 		"TextJPN": "「ウィルスがとうとう、興宮にまで広がった、……ということなのか……？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``It seems this virus has finally spread itself to Okinomiya...... I am right......?``"
+		"TextENG": "``Does this mean... the virus has finally spread to Okinomiya...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -69,31 +69,31 @@
 		"type": "MSGSET",
 		"MessageID": 154035,
 		"TextJPN": "雛見沢に残ると言って、ひとり残った梨花。",
-		"TextENG": "Remaining in Hinamizawa, Rika stayed there alone."
+		"TextENG": "Rika had stayed behind in Hinamizawa of her own volition."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154036,
 		"TextJPN": "それは危険ではないかと止めたが、この光景を見ては、勝手の知れた雛見沢の方がまだマシかもしれない。",
-		"TextENG": "She stopped us when we told her it was dangerous, but to see this scene, and arbitrary to what one may think, the state of things in Hinamizawa will improve."
+		"TextENG": "We tried to stop her since it was dangerous, but seeing this sight, maybe it really was better to stay in Hinamizawa where we knew our way around."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154037,
 		"TextJPN": "怪我をしている魅音だが、ひとまずは落ち着いているように見える。",
-		"TextENG": "Mion is also injured, but it seems she has calmed down for the time being."
+		"TextENG": "Mion was still injured, but for the time being she seemed stable."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154038,
 		"TextJPN": "しかし、所詮は応急手当だ。医者に見せる必要がある。",
-		"TextENG": "However, first aid treatment is needed after all. So it's necessary for her to see a doctor."
+		"TextENG": "Still, she'd only been given first-aid. She still needed to see a doctor."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154039,
 		"TextJPN": "入江診療所は暴徒に荒らされ、すでに無人で、入江は消息不明だ。",
-		"TextENG": "Although the Irie Clinic was invaded by a mob, and is currently unmanned, Irie's whereabouts are also unknown."
+		"TextENG": "The rioters had broken into the Irie Clinic, so it was abandoned, and Irie was nowhere to be found."
 	},
 	{
 		"type": "MSGSET",
@@ -102,7 +102,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0740.",
 		"TextJPN": "「とにかく、医者を見つけないとな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``At any rate, we have to find you a doctor.``"
+		"TextENG": "``Anyway, we need to find you a doctor.``"
 	},
 	{
 		"type": "MSGSET",
@@ -111,7 +111,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0780.",
 		"TextJPN": "「おじさんは平気だよ。痛いには痛いけど、だいぶ落ち着いてきた」",
 		"NamesENG": "Mion",
-		"TextENG": "``This old man is fine. Though it was painful and hurt, it's calmed down alot.``"
+		"TextENG": "``I'm doing fine. Sure, it hurts, but it's settled down a lot.``"
 	},
 	{
 		"type": "MSGSET",
@@ -120,7 +120,7 @@
 		"PreTextTags": "@vS25/02/NREN_0610.",
 		"TextJPN": "「駄目。ちゃんとした手当てを受けないと、あとから膿んでくることもあるんだから」",
 		"NamesENG": "Rena",
-		"TextENG": "``No. If you don't receive proper treatment, it will come to fester soon enough.``"
+		"TextENG": "``No. If you don't get proper treatment, then it could fester later.``"
 	},
 	{
 		"type": "MSGSET",
@@ -129,7 +129,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0070.",
 		"TextJPN": "「お医者を探す他ありませんですわ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``I don't think we'll find a doctor.``"
+		"TextENG": "``We'll just have to search for a doctor.``"
 	},
 	{
 		"type": "MSGSET",
@@ -138,7 +138,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0750.",
 		"TextJPN": "「この状況で、医者が開いてるとは思い難いけどな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``In this situation, it's hard to think a doctor would even be open.``"
+		"TextENG": "``It's hard to imagine any doctors are open for business with things like this.``"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0790.",
 		"TextJPN": "「……園崎組の事務所を目指そう。母さんたちなら、きっと何とかしてくれるはず……」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Let's head for the office of the Sonozaki family. If my mom's there, I'm sure she'll be able to do something......``"
+		"TextENG": "``......Let's head for the office of the Sonozaki Group. My mother and the others there should be able to do something...``"
 	},
 	{
 		"type": "MSGSET",
@@ -156,7 +156,7 @@
 		"PreTextTags": "@vS25/02/NREN_0620.",
 		"TextJPN": "「詩ぃちゃんもそこかな」",
 		"NamesENG": "Rena",
-		"TextENG": "``I wonder if Shii-chan will be there.``"
+		"TextENG": "``You think Shii-chan's there too?``"
 	},
 	{
 		"type": "MSGSET",
@@ -165,7 +165,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0800.",
 		"TextJPN": "「こんな事態になったら、あそこが一番安全だろうからね」",
 		"NamesENG": "Mion",
-		"TextENG": "``In these circumstances, she's probably there and safe.``"
+		"TextENG": "``Given what's happened, that's the safest place to be.``"
 	},
 	{
 		"type": "MSGSET",
@@ -174,7 +174,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0080.",
 		"TextJPN": "「……魅音さんのお母さんたちが、冷静でいてくれればいいんですけれど……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``......I hope Mion's mom will be able to help......``"
+		"TextENG": "``......I just hope those people are still reasonable......``"
 	},
 	{
 		"type": "MSGSET",
@@ -183,7 +183,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0760.",
 		"TextJPN": "「とにかく、街の様子を見てみよう。いつまでもここにはいられない」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Anyway, let's look at the state of the town. We can't wait up here forever.``"
+		"TextENG": "``Anyway, let's check out the town. We can't stay up here forever.``"
 	},
 	{
 		"type": "MSGSET",
@@ -192,7 +192,7 @@
 		"PreTextTags": "@vS25/02/NREN_0630.",
 		"TextJPN": "「……そうだね。この騒ぎが、ここだけなのか。それとも日本中にまで及ぶのか、……雛見沢じゃ何もわからない」",
 		"NamesENG": "Rena",
-		"TextENG": "``......You're right. This uproar is not something we can check on from here. ......It may have spread to the rest of Japan...... although, we'll understand nothing if we stay in Hinamizawa.``"
+		"TextENG": "``......Right. Is this disaster only happening here? Or has it expanded out to the rest of Japan? ......We don't know anything here in Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -201,7 +201,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0090.",
 		"TextJPN": "「こんなのが、世界中で起こっていたらなんて……。考えたくもありませんわ……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``What if this is happening all over the world...... I don't want to think about it......``"
+		"TextENG": "``The idea that this could be happening all over the world... I don't want to think about it......``"
 	},
 	{
 		"type": "MSGSET",
@@ -210,66 +210,66 @@
 		"PreTextTags": "@vS25/03/NMIO_0810.",
 		"TextJPN": "「行こう。……大丈夫、自分の足で歩けるよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Let's go. ......We'll be fine, we can walk on foot.``"
+		"TextENG": "``Let's go. ......I'm all right. I can walk by myself.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154053,
 		"TextJPN": "普段なら、興宮までは自転車でいく。",
-		"TextENG": "Usually, we'd go by bicycle to Okinomiya."
+		"TextENG": "Normally we'd go to Okinomiya by bicycle."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154054,
 		"TextJPN": "しかし、雛見沢同様に興宮にも自警団気取りの暴徒がいるだろうことは想像がつく。",
-		"TextENG": "However, it's easy to imagine that the panache mobs of the vigilance committee have similarly headed to Okinomiya."
+		"TextENG": "But it was easy to imagine that rioters would be acting like the neighborhood watch here in Okinomiya, just like they were in Hinamizawa."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154055,
 		"TextJPN": "例のウィルス騒ぎは、雛見沢が発信源なのだ。興宮の人間からしてみれば、雛見沢から来る人間は全て敵も同然のはずだ。",
-		"TextENG": "It is also said that the source of this virus uproar is none other than Hinamizawa. So all the people in Okinomiya will be considering anyone coming from Hinamizawa their enemy."
+		"TextENG": "The whole virus commotion originated in Hinamizawa. So the people in Okinomiya should, naturally, view everyone coming from Hinamizawa as an enemy."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154056,
 		"TextJPN": "そんな連中が待ち受けているだろう普通の道では危険だと判断し、徒歩で裏道から向かうことに決める。",
-		"TextENG": "Taking this into consideration, I judged it dangerous for us to head our usual way as such people would be waiting for us, so we decided to use a secret path on foot."
+		"TextENG": "We decided it was too dangerous to move on roads likely with a watch on them, so we headed there on foot using back paths instead."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154057,
 		"TextJPN": "山菜取りの年寄りか、野原を駆け回る雛見沢の子供たちしか知らないようなルートが、もっとも安全だろう。",
-		"TextENG": "Only old people who collect edible wild plants, and children running around the fields know about this route, so it should be safe."
+		"TextENG": "The kind of routes used by gatherers, the elderly, and the children that ran around in the fields of Hinamizawa were the safest ones."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154058,
 		"TextJPN": "圭一たちは、興宮を目指す……。",
-		"TextENG": "Keiichi and company now aim for Okinomiya......"
+		"TextENG": "While Keiichi and the others headed to Okinomiya......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154059,
 		"TextJPN": "圭一の両親には、園崎家の秘密の地下道に避難してもらっている。",
-		"TextENG": "Keiichi's parents were asked to take refuge in the secret underpass owned by the Sonozaki family."
+		"TextENG": "Keiichi's parents had evacuated themselves to the Sonozakis' secret underground tunnels."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154060,
 		"TextJPN": "そこには多少の蓄えもあるので、しばらくは安全だろう。",
-		"TextENG": "Also, because there is some stock there, they will be safe for the time being."
+		"TextENG": "There were already some resources stored down there, so they'd be safe for a while."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154061,
 		"TextJPN": "しかし、より安全でより医療や食料の充実した場所が必要だ。",
-		"TextENG": "However, it is necessary to find a location with substantial medical care and food than security."
+		"TextENG": "Still, they needed to reach a place that was even safer, one with plenty of food and medical treatment."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154062,
 		"TextJPN": "そのような安全地帯が存在するかどうかを確認するのが、興宮探索の最大の目的だった……。",
-		"TextENG": "So, to confirm whether such safety zones exist, searching Okinomiya has become their greatest objective......"
+		"TextENG": "Confirming whether or not such a safe space even existed was their biggest objective behind scouting out Okinomiya......"
 	}
 ]

--- a/kamikashimashi_2.json
+++ b/kamikashimashi_2.json
@@ -12,7 +12,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0060.",
 		"TextJPN": "「………死屍、累々ね」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........Corpses, in heaps.``"
+		"TextENG": "``.........There's mounds of corpses.``"
 	},
 	{
 		"type": "MSGSET",
@@ -21,19 +21,19 @@
 		"PreTextTags": "@vS25/12/NHAN_0000.",
 		"TextJPN": "「酷い光景なのです……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``What an awful sight......``"
+		"TextENG": "``It's an awful sight......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154065,
 		"TextJPN": "暴徒に襲われたらしい無残な骸が、時折、路肩に転がっている。",
-		"TextENG": "Cold-blooded corpses which seemed to have been ganged up on by a mob are seen, sometimes, even on the shoulder of a road."
+		"TextENG": "The miserable remains of those beaten to death by the rioters lay here and there on the shoulders of the streets."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154066,
 		"TextJPN": "溢れ出る死臭と群がるハエの群に、羽入でさえ首を小さく横に振る……。",
-		"TextENG": "Swarms of flies gather round the overflowing stench of death, even Hanyuu has shivers down her spine."
+		"TextENG": "Even Hanyuu shook her head at the swarm of flies and the pervasive stench of death......"
 	},
 	{
 		"type": "MSGSET",
@@ -42,7 +42,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0070.",
 		"TextJPN": "「……でも、静かになったわね」",
 		"NamesENG": "Rika",
-		"TextENG": "``......But, it became quiet.``"
+		"TextENG": "``......But it's grown quieter.``"
 	},
 	{
 		"type": "MSGSET",
@@ -60,7 +60,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0080.",
 		"TextJPN": "「疑心暗鬼の鬼に心を許した連中は、もうあらかた殺し合って、死に絶えた頃なのかもね」",
 		"NamesENG": "Rika",
-		"TextENG": "``The people who surrendered their hearts to the suspicious demons have mostly killed one another. It shouldn't be long before they die out.``"
+		"TextENG": "``This is about the time when nearly all of those who let the demons of paranoia into their hearts die off, after trying to kill each other.``"
 	},
 	{
 		"type": "MSGSET",
@@ -69,25 +69,25 @@
 		"PreTextTags": "@vS25/12/NHAN_0020.",
 		"TextJPN": "「……………………」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``........................``"
+		"TextENG": "``...............``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154071,
 		"TextJPN": "不気味な竜が呻くような、……あの唸るような風の音が、いつの間にか聞こえなくなっていた。",
-		"TextENG": "An eerie dragon like moan is heard...... it growls alongside the sound of the wind, unaware that no one can hear it."
+		"TextENG": "That roaring wind that was like the ominous groan of a dragon... could no longer be heard."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154072,
 		"TextJPN": "代わって、雛見沢を包むのは死の静寂。",
-		"TextENG": "It is soon replaced by the silence of death which now envelops Hinamizawa."
+		"TextENG": "All that enveloped Hinamizawa in its place was the silence of death."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154073,
 		"TextJPN": "鬼に心を許し、殺し合いに身を委ねた者たちの叫びは、もう、聞こえない……。",
-		"TextENG": "The people, who surrendered their hearts to the demon, cried as they were entrusted to kill one another, but no longer can it be heard......"
+		"TextENG": "The screams of those who allowed the demons into their hearts and began killing each other could no longer be heard either..."
 	},
 	{
 		"type": "MSGSET",
@@ -96,7 +96,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0030.",
 		"TextJPN": "「でも、用心に越したことはないのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``However, it never hurts to be cautious.``"
+		"TextENG": "``But it doesn't hurt to be cautious.``"
 	},
 	{
 		"type": "MSGSET",
@@ -105,7 +105,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0090.",
 		"TextJPN": "「そうね。このおかしな世界がどうなるのか、見届けずには死ねないわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``You're right. Whatever happens to this strange world, we cannot die without seeing it with our own eyes.``"
+		"TextENG": "``True. I can't die before I see how this crazy world ends.``"
 	},
 	{
 		"type": "MSGSET",
@@ -123,19 +123,19 @@
 		"PreTextTags": "@vS25/05/NRIK_0100.",
 		"TextJPN": "「入江診療所の地下よ。とりあえず、今の雛見沢で一番安全なところだとは思わない？」",
 		"NamesENG": "Rika",
-		"TextENG": "``To the basement of the Irie Clinic. First of all, don't you think that would be the safest place in Hinamizawa?``"
+		"TextENG": "``The Irie Clinic's basement. That should be the safest place in Hinamizawa right now, don't you think?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154078,
 		"TextJPN": "地下研究区画はすでに死の静寂に包まれている。",
-		"TextENG": "The underground research section has already been wrapped in the silence of death."
+		"TextENG": "The underground research ward was filled with the silence of death as well."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154079,
 		"TextJPN": "死体と、白い壁に走る真っ赤な飛沫の跡さえ気にならないなら、当面は最高の場所だろう。",
-		"TextENG": "Corpses, and bright red splashes of blood run along the walls, but that is nothing to worry about. It should be the best place for the time being."
+		"TextENG": "So as long as she didn't mind the corpses and the trails of bright red blood splatter staining the pale white walls, it was the perfect place to hide out for a while."
 	},
 	{
 		"type": "MSGSET",
@@ -144,7 +144,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0110.",
 		"TextJPN": "「……まだ、村の中には荒ぶってる子もいるんでしょう？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Still, do you think there's anyone left in this wild village?``"
+		"TextENG": "``......Are there still violent ones in the village?``"
 	},
 	{
 		"type": "MSGSET",
@@ -153,7 +153,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0050.",
 		"TextJPN": "「はい……。もうじき落ち着くとは思いますですが、まだ……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Yes...... Although, I think things will settle down soon, but still......``"
+		"TextENG": "``Yes...... I think it should quiet down soon, but for now...``"
 	},
 	{
 		"type": "MSGSET",
@@ -162,55 +162,55 @@
 		"PreTextTags": "@vS25/05/NRIK_0120.",
 		"TextJPN": "「決まりね。ほとぼりを冷ましましょ。あそこなら、誰かの飲み物やお菓子もあるだろうし、お手洗いも綺麗だしね」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's been decided. The residual excitement will cool down. And at that time, everybody will be there with drinks and candy, even the bathroom will be beautiful.``"
+		"TextENG": "``Then it's settled. Let's wait for the heat to die down. We should be able to find someone's drinks and snacks down there, plus the bathrooms are nice.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154083,
 		"TextJPN": "梨花たちは入江診療所を目指す。",
-		"TextENG": "Rika and Hanyuu aim for the Irie Clinic."
+		"TextENG": "Rika and Hanyuu made their way to the Irie Clinic."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154084,
 		"TextJPN": "あれだけの時間をかけて研究を重ねてきたのに、……何も手を打てなかった無能たちの巣へ。",
-		"TextENG": "They spend much time looking over their repeated research...... but nothing except incompetence was found in that hive, as no progress was made."
+		"TextENG": "After all that time they spent researching the disease... ...it turned out they were just a den of incompetents, unable to do anything at all."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154085,
 		"TextJPN": "山の中の獣道を抜け、田んぼのあぜ道を駆け抜ける。",
-		"TextENG": "They pass through the animal trail in the mountains, and run through the rice fields near the footpath."
+		"TextENG": "They passed through animal trails in the mountains and through footpaths between the fields."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154086,
 		"TextJPN": "時に息を殺し、何者かの気配を探り、時には兎のように駆け抜けた。",
-		"TextENG": "They suppress their breath, and probe for signs of life, running through like a rabbit."
+		"TextENG": "Sometimes they held their breath and tried to sense the presence of nearby people, while other times they ran like rabbits."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154087,
 		"TextJPN": "そして、一気にガードレールを乗り越えると、……そこは興宮の街だった。",
-		"TextENG": "And then, they climb over the guardrail all at once...... and see the town of Okinomiya."
+		"TextENG": "Then once they jumped right over the guardrails... they were in Okinomiya."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154088,
 		"TextJPN": "何かが焦げるような臭いが煙り、風が遠くから時折、怒号を運ぶ。",
-		"TextENG": "The odor of smoke and something burning can be smelt, as the wind blowing in from a distance occasionally carries an angry roar."
+		"TextENG": "Every now and then the wind would carry a roar from the distance, along with smoke and the smell of something burning."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154089,
 		"TextJPN": "街は死んだように静まり返っているが、死んではいない。",
-		"TextENG": "The town has fallen into a deadly silence, but it is still not dead."
+		"TextENG": "The town was deathly quiet, but it wasn't dead."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154090,
 		"TextJPN": "疑心暗鬼に心を許し、怒りに身を任せる暴徒たちから身を潜めているだけだ。",
-		"TextENG": "Suspicion enters their hearts, they hide themselves from the mobs who have given themselves into the rage."
+		"TextENG": "The rioters who allowed paranoia into their hearts were only lying in wait as they teemed with rage."
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS25/02/NREN_0640.",
 		"TextJPN": "「……雛見沢より、危険かも」",
 		"NamesENG": "Rena",
-		"TextENG": "``......This may be more dangerous than Hinamizawa.``"
+		"TextENG": "``......It might be more dangerous here than in Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,7 +228,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0770.",
 		"TextJPN": "「同感だぜ……。嫌な予感がビンビンすらぁ……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I agree...... I've got a bad feeling about this......``"
+		"TextENG": "``Agreed...... I've got nothing but bad feelings about this...``"
 	},
 	{
 		"type": "MSGSET",
@@ -237,7 +237,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0100.",
 		"TextJPN": "「ここも、ウィルスパニックで暴動になっているってことなんですの……？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``It must have happened here too, do you think there were riots after the virus panic......?``"
+		"TextENG": "``Are there riots here because of fear about the virus as well......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -246,7 +246,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0820.",
 		"TextJPN": "「これはおじさんの仮説だけど。やっぱり、これがウィルスの症状なのかもしれない」",
 		"NamesENG": "Mion",
-		"TextENG": "``This is the hypothesis of Old Man. After all, these might be symptoms of the virus.``"
+		"TextENG": "``This is just my theory, but... I think this might be a symptom of the virus, actually.``"
 	},
 	{
 		"type": "MSGSET",
@@ -255,7 +255,7 @@
 		"PreTextTags": "@vS25/02/NREN_0650.",
 		"TextJPN": "「そうかもしれないね」",
 		"NamesENG": "Rena",
-		"TextENG": "``That may be so.``"
+		"TextENG": "``Maybe so.``"
 	},
 	{
 		"type": "MSGSET",
@@ -264,7 +264,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0110.",
 		"TextJPN": "「どういうことですの……？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``What kind of thing is this......?``"
+		"TextENG": "``What do you mean......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -273,7 +273,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0780.",
 		"TextJPN": "「ウィルスが脳に悪さをしてる、ってわけか……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``It's like rabies, except a human version, probably something like that......``"
+		"TextENG": "``So it's like a human version of rabies......``"
 	},
 	{
 		"type": "MSGSET",
@@ -282,7 +282,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0830.",
 		"TextJPN": "「殺人ウィルスの恐怖でみんなおかしくなってるって思ってたけど、……それだけじゃ説明がつかないんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``I thought that everyone had become strange in fear of this killer virus...... Although, we need a real explanation.``"
+		"TextENG": "``I thought everyone was going crazy out of fear of this killer virus, ......but that's not enough to explain everything.``"
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@vS25/02/NREN_0660.",
 		"TextJPN": "「人を濫りに恐れ、疑い、それに振り回されてしまう病気……」",
 		"NamesENG": "Rena",
-		"TextENG": "``A disease that causes people to be overly fearful, suspicious, and driven by it.......``"
+		"TextENG": "``An illness that stokes unfounded fears and suspicions until the victim is driven by nothing else...``"
 	},
 	{
 		"type": "MSGSET",
@@ -300,7 +300,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0120.",
 		"TextJPN": "「そんな病気が、本当にありますの？　だってテレビではそんなことは一言も……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Can such a disease be real? I mean, I've never even heard a word about such a thing on TV......``"
+		"TextENG": "``Does a disease like that really exist? I mean, they never mentioned any of that on TV......``"
 	},
 	{
 		"type": "MSGSET",
@@ -309,7 +309,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0840.",
 		"TextJPN": "「テレビが常に真実を言うとは限らない。それに、その殺人ウィルスはただの勘違いの可能性だってある」",
 		"NamesENG": "Mion",
-		"TextENG": "``The TV doesn't always tell the truth. Besides, the possibility of such a killer virus could just be a misunderstanding.``"
+		"TextENG": "``TV doesn't always tell the truth. Besides, there's a possibility the killer virus part was just a wrong guess.``"
 	},
 	{
 		"type": "MSGSET",
@@ -318,7 +318,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0790.",
 		"TextJPN": "「……どっちも負けないくらい恐ろしいウィルスだってことは、間違いないさ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......Which means we also can't lose to this terrifying virus if it isn't, no doubt about that.``"
+		"TextENG": "``......They're both equally frightening, that's for sure.``"
 	},
 	{
 		"type": "MSGSET",
@@ -327,7 +327,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0130.",
 		"TextJPN": "「でも、どうして私たちは平気なんですの？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``But, why are we okay?``"
+		"TextENG": "``But why are we fine, then?``"
 	},
 	{
 		"type": "MSGSET",
@@ -336,7 +336,7 @@
 		"PreTextTags": "@vS25/02/NREN_0670.",
 		"TextJPN": "「……耐性とか、あるのかもしれないね」",
 		"NamesENG": "Rena",
-		"TextENG": "``......We just may have a higher resistance.``"
+		"TextENG": "``......Maybe we're resistant?``"
 	},
 	{
 		"type": "MSGSET",
@@ -345,7 +345,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0850.",
 		"TextJPN": "「まぁ、症状が出てなくとも、おじさんたちが保菌者である可能性は否定できないねぇ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Well, even if we don't show symptoms, we can't deny the possibility that this Old Man and the rest of us are carriers.``"
+		"TextENG": "``Well, even if we're not showing any symptoms, we can't rule out the possibility that we're still carrying the disease.``"
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0800.",
 		"TextJPN": "「いいのかよ。その俺たちがこうして街に来ちまって」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``That's just great. Even if not, we could easily get it just by entering the town.``"
+		"TextENG": "``Is it really okay? For us to go into the city like this?``"
 	},
 	{
 		"type": "MSGSET",
@@ -363,31 +363,31 @@
 		"PreTextTags": "@vS25/03/NMIO_0860.",
 		"TextJPN": "「問題ないでしょ。この有様を見る限りはね」",
 		"NamesENG": "Mion",
-		"TextENG": "``That won't be a problem. We'll just keep our distance and assess the situation.``"
+		"TextENG": "``It shouldn't be a problem. Not judging by this state of affairs.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154108,
 		"TextJPN": "往来の無人を確かめながら、慎重に進む。",
-		"TextENG": "While checking the uninhabited street traffic, they advance carefully."
+		"TextENG": "We advanced carefully, checking to make sure the roads were clear."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154109,
 		"TextJPN": "街道は乗り捨てられた車が列を為していた。",
-		"TextENG": "The main roads are abandoned, and the cars are stacked in rows."
+		"TextENG": "Abandoned cars formed lines on the city streets."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154110,
 		"TextJPN": "あちこちの交差点で衝突した車がくすぶっている。",
-		"TextENG": "Several smoldering cars are found collided at every intersection."
+		"TextENG": "Some cars had crashed into each other and were still smoking at various intersections."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154111,
 		"TextJPN": "歩道にも、感染を疑われて殺されたに違いない人々の無残な姿が散見された……。",
-		"TextENG": "Also, on the sidewalks, the tragic appearance of individuals, who are suspected to have been killed by the infected, are seen from time to time......"
+		"TextENG": "Even on the sidewalks we saw the scattered remains of people murdered under suspicion of being infected......"
 	},
 	{
 		"type": "MSGSET",
@@ -396,7 +396,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0810.",
 		"TextJPN": "「詩音たちや、魅音の親たちが冷静でいてくれるといいんだけどな……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I hope Shion and your parents are cool headed, Mion......``"
+		"TextENG": "``I just hope Shion and Mion's parents are still sane......``"
 	},
 	{
 		"type": "MSGSET",
@@ -405,7 +405,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0870.",
 		"TextJPN": "「……父さんと母さんが、しっかりとみんなを律してくれてればいいんだけど」",
 		"NamesENG": "Mion",
-		"TextENG": "``......I hope my dad and mom are, they need to be strong and firm to regulate everyone.``"
+		"TextENG": "``......Mom and Dad are keeping everyone in line, I'm sure.``"
 	},
 	{
 		"type": "MSGSET",
@@ -414,7 +414,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0140.",
 		"TextJPN": "「詩音さんは、頭に血が上りやすい方だから……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Shion-san's someone whose blood easily climbs into her head......``"
+		"TextENG": "``Shion-san does have a quick temper......``"
 	},
 	{
 		"type": "MSGSET",
@@ -423,7 +423,7 @@
 		"PreTextTags": "@vS25/02/NREN_0680.",
 		"TextJPN": "「詩ぃちゃんは冷静な時とそうでない時の差が激しいからね……。私もちょっとだけ不安」",
 		"NamesENG": "Rena",
-		"TextENG": "``Shii-chan does change from calm to intense from time to time...... So I'm feeling a little uneasy, too.``"
+		"TextENG": "``There's a huge gap between how Shii-chan acts when she's calm and when she isn't...... I'm a little worried about her.``"
 	},
 	{
 		"type": "MSGSET",
@@ -432,19 +432,19 @@
 		"PreTextTags": "@vS25/03/NMIO_0880.",
 		"TextJPN": "「大丈夫だよ。こういう時の母さんには、詩音はぐぅの音も出ないから。……きっと母さんたちが、みんなをしっかりまとめてくれているはず」",
 		"NamesENG": "Mion",
-		"TextENG": "``She'll be fine. She's with my mom after all, so I'm sure Shion will come out with a quiet hug. ......Anyway, my mom and everyone is most likely level-headed and has everything in order.``"
+		"TextENG": "``She'll be fine. Shion won't talk back to Mom at times like this. ......I'm sure Mom will be keeping everyone organized.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154117,
 		"TextJPN": "雛見沢の町会も、お魎さえ元気だったなら冷静を失わなかったはずなのだ。",
-		"TextENG": "Even the neighborhood association of Hinamizawa should have stayed healthy and never lost their composure."
+		"TextENG": "If Oryou had been healthy, even the Hinamizawa town council wouldn't have lost its cool."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154118,
 		"TextJPN": "強いリーダーシップが混乱を未然に防げることを、魅音はすでに感じ取っていた。",
-		"TextENG": "They needed a strong leadership in advance to prevent confusion, even Mion had already grasped this."
+		"TextENG": "Mion had already gotten a taste of how strong leadership could prevent chaos ahead of time."
 	},
 	{
 		"type": "MSGSET",
@@ -453,7 +453,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0890.",
 		"TextJPN": "「多分、このウィルスは人を不安や恐怖から攻撃に駆り立てるんだ。……だから、強いリーダーシップや連帯、信頼があれば、きっと冷静を保てると思うんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Perhaps this virus drives people to attack others out of fear and anxiety. ......Therefore, strong leadership, solidarity and trust are needed, I think that would have certainly kept everyone calm.``"
+		"TextENG": "``This virus probably drives people to attack others out of fear and anxiety. ......So with strong leadership, teamwork, and trust, they should be able to maintain their senses.``"
 	},
 	{
 		"type": "MSGSET",
@@ -462,7 +462,7 @@
 		"PreTextTags": "@vS25/02/NREN_0690.",
 		"TextJPN": "「ウィルス騒ぎの恐怖が助長し、……恐怖心を暴走させてしまった？」",
 		"NamesENG": "Rena",
-		"TextENG": "``So fear of this virus promoted the uproar...... Have you let a sense of fear take charge?``"
+		"TextENG": "``You think the virus commotion fostered fear... and their terror ran rampant?``"
 	},
 	{
 		"type": "MSGSET",
@@ -471,7 +471,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0820.",
 		"TextJPN": "「そう考えるとしっくり来るな。少なくとも、自衛隊が来て、しっかりやってくれてる内は、雛見沢でも変なことはなかった」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``You shouldn't think like that. At least, if the Self-Defense Forces are to come, they should be be among those who are calm, as they didn't even act strange when they were in Hinamizawa.``"
+		"TextENG": "``That idea feels right to me. At the very least, even Hinamizawa didn't start acting weird up until the JSDF left and stopped doing their jobs.``"
 	},
 	{
 		"type": "MSGSET",
@@ -480,13 +480,13 @@
 		"PreTextTags": "@vS25/04/NSAT_0150.",
 		"TextJPN": "「そうですわね。……自衛隊の方がいなくなってから、一気にみんな不安になって、おかしくなっていきましたもの……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``You're right. ......After the Self-Defense Forces disappeared, everyone immediately felt uneasy, and then they all became strange......``"
+		"TextENG": "``That is true. ......Once the JSDF left, everyone grew frightened all at once, and the world went mad......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154123,
 		"TextJPN": "沙都子は、あっと思い出したように声を上げる。",
-		"TextENG": "Satoko raises her voice after having remembered."
+		"TextENG": "Satoko raised her voice to note that sudden memory."
 	},
 	{
 		"type": "MSGSET",
@@ -495,7 +495,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0160.",
 		"TextJPN": "「そう言えば、梨花も言ってましたですのっ。……心を鬼に明け渡さない、心の強さを持った人間なら大丈夫、って……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Come to think of it, Rika was saying that, too. ......'Don't surrender your heart to the demon, any human being with the strength of heart will be alright', she said......``"
+		"TextENG": "``That reminds me, Rika said something too. ......She said that people with strong hearts will be fine, since you won't hand them over to the demons.``"
 	},
 	{
 		"type": "MSGSET",
@@ -504,7 +504,7 @@
 		"PreTextTags": "@vS25/02/NREN_0700.",
 		"TextJPN": "「梨花ちゃんがそう言ったの？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Did Rika-chan say that?``"
+		"TextENG": "``Rika-chan said that?``"
 	},
 	{
 		"type": "MSGSET",
@@ -513,7 +513,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0170.",
 		"TextJPN": "「えぇ。……私、てっきり、病は気から、みたいな意味なのかと思ってましたのですけれど……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Yeah. ......I certainly thought, curiosity killed the cat, was the meaning of it......``"
+		"TextENG": "``Yes. ...I just assumed she meant something along the lines of 'illness starts in the mind' but......``"
 	},
 	{
 		"type": "MSGSET",
@@ -522,7 +522,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0900.",
 		"TextJPN": "「ひょっとすると……、それは言葉通りの意味だったのかもしれないねぇ……」",
 		"NamesENG": "Mion",
-		"TextENG": "``Possibly...... the meaning of those words could have meant the streets, right......``"
+		"TextENG": "``Maybe there is a chance...... she meant exactly what she said...``"
 	},
 	{
 		"type": "MSGSET",
@@ -531,7 +531,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0830.",
 		"TextJPN": "「……俺とレナが、沙都子を助け出す為に頭に血を上らせた時。……ひょっとしたら、俺たち、ヤバかったのかもな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......Rena and I let the blood climb to our heads in order to rescue Satoko. ......So perhaps, we're dangerous to be around.``"
+		"TextENG": "``......There was that moment when the blood rushed to our heads when Rena and I went to rescue Satoko. ......Maybe that was really risky for the two of us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -540,7 +540,7 @@
 		"PreTextTags": "@vS25/02/NREN_0710.",
 		"TextJPN": "「かもね。……でも、私たちは激しく心を燃え盛らせながらも、冷静を保ってたよ」",
 		"NamesENG": "Rena",
-		"TextENG": "``Maybe you're right. ......But, even though we let our hearts blaze intensely, we kept our composure.``"
+		"TextENG": "``Maybe so. But we managed to stay calm even as that fire burned strong in our hearts.``"
 	},
 	{
 		"type": "MSGSET",
@@ -549,7 +549,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0840.",
 		"TextJPN": "「ハートは熱く、思考はクールに。……ひょっとすると、俺たちが他の連中みたいにならずに済んだのは、普段から魅音の部活に鍛えられてたお陰かもしれないな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Our hearts were hot, but we thought coolly. ......So perhaps, we didn't become like those other people thanks to that and the training we received everyday in Mion's club activities.``"
+		"TextENG": "``Let your heart run hot, and keep your thoughts cool. ......Maybe the reason we didn't end up like the others is because we've been training ourselves for these kind of situations in Mion's club.``"
 	},
 	{
 		"type": "MSGSET",
@@ -558,7 +558,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0910.",
 		"TextJPN": "「冷静を保てず、激情に心を明け渡してしまうと、暴走してしまう。……それを鬼と呼んだなら、鬼ヶ淵村の昔から言い伝えられる伝承は、それを指すのかもしれないよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``You can never keep your cool, if you surrender your heart in passion, it would result in a rampage. ......Then you'll be called a demon, just like in the old legends of Onigafuchi village handed down since ancient times. It specifically points that out.``"
+		"TextENG": "``If you lose your cool and hand your heart over to primal emotions, then you go crazy. ......If you call the result of that process a demon, then it fits with the legends passed down from long ago about Onigafuchi Village.``"
 	},
 	{
 		"type": "MSGSET",
@@ -567,7 +567,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0180.",
 		"TextJPN": "「沼から鬼が湧き出して、という話でしたかしら」",
 		"NamesENG": "Satoko",
-		"TextENG": "``And then the demons surged from the swamp... I wonder if that story could happen again.``"
+		"TextENG": "``You mean that legend about demons coming up out of the swamp?``"
 	},
 	{
 		"type": "MSGSET",
@@ -576,7 +576,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0920.",
 		"TextJPN": "「きっと、その昔も同じことがあったんだよ。……そして、疑心暗鬼に取り憑かれて暴走した人々が、鬼と呼ばれたに違いないよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Surely, they said the same thing a long time ago. ......And then, the people became obsessed with suspicion and went on a rampage. It's very likely they referred to them as demons.``"
+		"TextENG": "``I'm sure something similar to this happened long ago. ......And I'm positive the people thrown into paranoia and running around out of control were called demons.``"
 	},
 	{
 		"type": "MSGSET",
@@ -585,7 +585,7 @@
 		"PreTextTags": "@vS25/02/NREN_0720.",
 		"TextJPN": "「……なるほど。何となく状況が飲み込めて来たかな」",
 		"NamesENG": "Rena",
-		"TextENG": "``......I see. I wonder how everyone somehow came to swallow that situation.``"
+		"TextENG": "``...Makes sense. I think we're getting a grasp of what's going on.``"
 	},
 	{
 		"type": "MSGSET",
@@ -594,7 +594,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0850.",
 		"TextJPN": "「しかし、伝承が残ってるってことは、事態は収まり、人々は生き残ったってわけだ。……なら、これは絶望じゃない。希望だ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``However, this thing still remains in the legends, and the situation fits, although some people survived. ......Then if that's the case, we aren't in despair at all. There is a hope.``"
+		"TextENG": "``Still, if there were legends left about it, then that means the whole thing was settled, and people survived. ......So this isn't hopeless. We have hope.``"
 	},
 	{
 		"type": "MSGSET",
@@ -603,7 +603,7 @@
 		"PreTextTags": "@vS25/02/NREN_0730.",
 		"TextJPN": "「そうだね。この騒ぎが世界を滅ぼすわけじゃない。必ず終わりがあるってことなんだから」",
 		"NamesENG": "Rena",
-		"TextENG": "``You're right. This uproar won't destroy the world. Because something must always come to an end.``"
+		"TextENG": "``Right. This commotion isn't going to destroy the world. There's guaranteed to be a way to end it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -612,7 +612,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0190.",
 		"TextJPN": "「オヤシロさまが降臨して下さるのを、待つ他ないんですの……？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Then Oyashiro-sama will descend, does that mean we just have to wait......?``"
+		"TextENG": "``Is waiting for Oyashiro-sama to descend the only option we have......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -621,7 +621,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0930.",
 		"TextJPN": "「伝承ではそういうことになってるね。……人々には何も出来ず、オヤシロさまの降臨を待つ他なかった」",
 		"NamesENG": "Mion",
-		"TextENG": "``According to the legend, such a thing should happen. ......Nothing could be done by man, they could only wait for the descent of Oyashiro-sama.``"
+		"TextENG": "``That's how it ended back then, according to the legends. ......The people were unable to do anything except wait for Oyashiro-sama's descent.``"
 	},
 	{
 		"type": "MSGSET",
@@ -630,7 +630,7 @@
 		"PreTextTags": "@vS25/02/NREN_0740.",
 		"TextJPN": "「……これほどの騒ぎなのに、私たちには待つことしか出来ないってこと……？」",
 		"NamesENG": "Rena",
-		"TextENG": "``......So, even though such an uproar has happened, the only thing we can do is wait......?``"
+		"TextENG": "``......Are you saying all we can do is wait, even with all this going on...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -639,7 +639,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0940.",
 		"TextJPN": "「伝承の通りなら、ね」",
 		"NamesENG": "Mion",
-		"TextENG": "``According to the legend, yes.``"
+		"TextENG": "``If we're to follow the legends.``"
 	},
 	{
 		"type": "MSGSET",
@@ -648,7 +648,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0860.",
 		"TextJPN": "「あぁ、まったくっ。オヤシロさまよ！　どこかにいてこの騒ぎを見てるんなら、早く降臨してこの騒ぎを終わらせてくれ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Oh, indeed. Oyashiro-sama! No matter where you are, I know you're watching this uproar, so you should descend soon, and end it!!``"
+		"TextENG": "``Yeah, come on already! Oyashiro-sama! If you're out there watching this, then make with the descent and put a stop to this!!``"
 	},
 	{
 		"type": "LOGSET",
@@ -665,7 +665,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0130.",
 		"TextJPN": "「神様のくせに風邪を引くの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Did you catch a cold, in spite of being God?``"
+		"TextENG": "``Can Gods catch colds?``"
 	},
 	{
 		"type": "MSGSET",
@@ -674,25 +674,25 @@
 		"PreTextTags": "@vS25/12/NHAN_0070.",
 		"TextJPN": "「あぅあぅ。くしゃみは人間だけの特権ではないのですよ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Au au. Sneezing isn't a privilege only for human beings.``"
+		"TextENG": "``Au, au. Humans aren't the only ones that can sneeze, you know.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154144,
 		"TextJPN": "入江診療所の中は、暴徒たちによって荒らし尽くされていた。",
-		"TextENG": "The inside of the Irie Clinic has been exhaustively layed waste to by mobs."
+		"TextENG": "The Irie Clinic had been ransacked by rioters."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154145,
 		"TextJPN": "ここに治療薬が隠されているというデマを信じた暴徒たちが、大挙して押し寄せたのだ。",
-		"TextENG": "The mobs who believed a false rumor that a therapeutic drug was hidden here, overwhelmed the building in great numbers."
+		"TextENG": "Believing the rumors that a cure was hidden here, they had swarmed it en masse."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154146,
 		"TextJPN": "しかし、それは地上部分の話だ。地下の秘密研究区画にそれは及ばない。",
-		"TextENG": "However, this is the story for the above ground parts. As the violence never reached the secret underground research area."
+		"TextENG": "But that only applied to the sections on the surface. Their riot hadn't extended to the secret research ward underground."
 	},
 	{
 		"type": "MSGSET",
@@ -701,7 +701,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0140.",
 		"TextJPN": "「ここには何もないのに。……あればとっくに入江が手を打っていたわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``There is nothing here. ......Even if there was, Irie took with him long ago.``"
+		"TextENG": "``There's nothing here, though. ......If Irie were around, he would've taken action long ago.``"
 	},
 	{
 		"type": "MSGSET",
@@ -710,61 +710,61 @@
 		"PreTextTags": "@vS25/12/NHAN_0080.",
 		"TextJPN": "「……目を背けずにはいられないのです……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......I can't help but look away......``"
+		"TextENG": "``......We mustn't avert our eyes...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154149,
 		"TextJPN": "荒れ果てた診療所内には、幾人もの骸が転がっている。",
-		"TextENG": "In this desolate clinic, many corpses came to visit, allowing flies to gather."
+		"TextENG": "There were several corpses gathering flies there in the plundered clinic."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154150,
 		"TextJPN": "ここに治療薬があると信じ込んだ人々は、最後には、誰かが治療薬を隠し持っていると信じ込み、殺し合ったのだろう……。",
-		"TextENG": "Many people who came here were convinced there was a remedy, but in the end, they firmly believed someone had hidden the remedy, and killed to find it......"
+		"TextENG": "Those who believed in the cure ultimately became convinced that someone there was hiding it, and began to kill each other......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154151,
 		"TextJPN": "羽入は目を塞ぐが、梨花は気にすることなく足を進める。",
-		"TextENG": "Hanyuu closes her eyes, but Rika not minding it, steps over the corpses."
+		"TextENG": "Hanyuu covered her eyes after all, but Rika stepped over the corpses without any concern."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154152,
 		"TextJPN": "その中には見知った顔もあったが、梨花は気にする様子もなかった。",
-		"TextENG": "There are also many faces she had become acquainted with, but Rika isn't in any state to care."
+		"TextENG": "Some of the corpses were even familiar faces to her, but Rika didn't seem to care."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154153,
 		"TextJPN": "秘密の扉を抜け、地下へ向かう。",
-		"TextENG": "She opens the secret door, and enters the basement."
+		"TextENG": "She passed through the secret door and headed underground."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154154,
 		"TextJPN": "セキュリティのある機密ドアの向こうに留まれば、地上のどこよりも安全だ。",
-		"TextENG": "Staying on the other side of that secret door with security, is safer than anywhere else above ground."
+		"TextENG": "It was far safer to stay behind the secret security door than on the surface."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154155,
 		"TextJPN": "何しろ、研究員たちは全て殺し合ったか自殺したかした。完全な無人を上回る安全は、存在しないのだから……。",
-		"TextENG": "At any rate, all the researchers either came together and committed suicide or killed one another. So security is fully unmanned, because they no longer exist......"
+		"TextENG": "After all, all the researchers here were either murdered or committed suicide. There was nothing safer than a place completely devoid of others......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154156,
 		"TextJPN": "セキュリティが、古手梨花であることを確認し、ドアを開ける。",
-		"TextENG": "``Security``. Rika Furude confirmed it's the correct room and opens the door."
+		"TextENG": "The security system confirmed it was Rika Furude, and then the door opened."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154157,
 		"TextJPN": "それが後で閉まるのを確認すると、骸に顔色一つ変えなかった梨花であっても、少し安堵した。",
-		"TextENG": "After confirming that it locks some time later, and even after seeing a single corpse, Rika doesn't change her expression, but feels only slightly relieved."
+		"TextENG": "Even though her expression never changed at the sight of the corpses, she heaved a sigh of relief once she confirmed the door was shut behind her."
 	},
 	{
 		"type": "MSGSET",
@@ -773,7 +773,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0150.",
 		"TextJPN": "「あとは、寝て過ごすも、誰かの溜め込んだおやつをつまみ食いするも自由ってわけだわ。何しろ、もう誰もいないのだから」",
 		"NamesENG": "Rika",
-		"TextENG": "``Afterwards, we can pass time by sleeping, but meanwhile, we should freely go around and pick up snacks to create a stockpile so we'll have something to eat. Anyway, there's nobody here anymore.``"
+		"TextENG": "``Now we can do as we please, be that sleep through this, or snack on the treats someone stored down here. There's no one else here, after all.``"
 	},
 	{
 		"type": "MSGSET",
@@ -782,7 +782,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0090.",
 		"TextJPN": "「これだけの惨状の中、よくもそれだけの余裕を保てるものなのです……。たくましいというか、図太いというか……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``What a terrible sight, how dare they allow such a place to be maintained...... Did I speak too strongly, or should I have been bold......``"
+		"TextENG": "``I'm surprised you're able to stay so calm amidst that dreadful sight...... I don't know if that's you being strong, or shameless......``"
 	},
 	{
 		"type": "MSGSET",
@@ -791,7 +791,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0160.",
 		"TextJPN": "「人の死どころか、自分の死だって、足の指を使っても数え切れないくらい経験してきたのよ。今更、どこぞの誰かの死体なんかで私が驚くと思う？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Let alone the death of these people, we should think about our own, even though we have already experienced it countless times from our toes. Now, do you think I'm surprised at the body of some somebody's corpse?``"
+		"TextENG": "``I've experienced death, even my own, more times than I can count. So why should some stranger's corpse faze me at this point?``"
 	},
 	{
 		"type": "MSGSET",
@@ -800,7 +800,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0100.",
 		"TextJPN": "「……はぁ。昔の梨花は、もう少し歳相応に臆病で可愛かったのに……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......Huh. Old Rika was a little more cute and appropriate for her actual age......``"
+		"TextENG": "``......Hahh. The old Rika was cuter. She was as scared as one should be for your age......``"
 	},
 	{
 		"type": "MSGSET",
@@ -809,7 +809,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0170.",
 		"TextJPN": "「今更、この私が何を怖がると？　……そうね、ならオバケでも連れて来なさいよ。そうしたら、少しは驚いてあげてもいいわよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``Now, is this what you're afraid of? ......Well, bring on the ghost then. If you do, maybe it'll give them a little surprise.``"
+		"TextENG": "``What should I fear at this point? ......Well, I suppose you could summon up a ghost. I'd be a little surprised if you did that!``"
 	},
 	{
 		"type": "MSGSET",
@@ -818,7 +818,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0180.",
 		"TextJPN": "「……え？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Eh?``"
+		"TextENG": "``......Huh?``"
 	},
 	{
 		"type": "MSGSET",
@@ -827,31 +827,31 @@
 		"PreTextTags": "@vS25/12/NHAN_0110.",
 		"TextJPN": "「なっ、何ですか梨花っ、お、脅かしっこはなしなのですっ……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Wh-What is it, Rika?! D-do you want me to scare people......``"
+		"TextENG": "``W-What is it, Rika?! D-Don't start scaring me, okay...?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154165,
 		"TextJPN": "無人のはずの地下区画で、……今、何かが聞こえた気がしたのだ。",
-		"TextENG": "The basement is supposed to be uninhabited...... Now, they have a feeling they just heard something."
+		"TextENG": "The underground ward was supposed to be empty... but she thought she heard something just then."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154166,
 		"TextJPN": "気のせい……？",
-		"TextENG": "Is it their imagination......?"
+		"TextENG": "Was it her imagination......?"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154167,
 		"TextJPN": "二人は顔を見合わせてから、息を殺し、耳を澄ます……。",
-		"TextENG": "Two of them look at each other, supress their breath, and listen carefully......"
+		"TextENG": "They both glanced at each other, held their breath, and strained their ears......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154168,
 		"TextJPN": "………………………。",
-		"TextENG": "..........................."
+		"TextENG": "........................"
 	},
 	{
 		"type": "MSGSET",
@@ -860,7 +860,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0190.",
 		"TextJPN": "「……聞こえる……、わよね……？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......I heard something...... did you hear it......?``"
+		"TextENG": "``......You hear that...... right......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -869,7 +869,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0120.",
 		"TextJPN": "「オ、オバケなのですか？！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Is it a g-ghost?!``"
+		"TextENG": "``I-Is it a ghost?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -878,19 +878,19 @@
 		"PreTextTags": "@vS25/05/NRIK_0200.",
 		"TextJPN": "「……半分オバケみたいなあんたが怯えてどうすんのよ。しかしこれは、何の音……？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......I never knew you would be scared of a ghost, seeing you're half one yourself. However, what is that sound......?``"
+		"TextENG": "``...You're practically a ghost yourself, so why are you afraid? Still, what is this sound......?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154172,
 		"TextJPN": "どこか遠くから、ズン……ズン……と、鈍い音のようなものが繰り返し聞こえるのだ。",
-		"TextENG": "From a distance... *thud*...... *thud*...... A dull sound can be heard repeatedly."
+		"TextENG": "Far off in the distance there was a thnn....... thnn..... They could hear that dull sort of sound repeating over and over."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154173,
 		"TextJPN": "梨花たちは、音の正体を確かめる為、頷き合ってから、音の聞こえる方向に耳を澄ます……。",
-		"TextENG": "Rika and Hanyuu want to check out the identity of the sound, and after nodding, listen carefully in it's direction to hear the sound......"
+		"TextENG": "They both nodded to each other and strained their ears, trying to identify the source of the sound......"
 	},
 	{
 		"type": "MSGSET",
@@ -899,25 +899,25 @@
 		"PreTextTags": "@o65.@vS25/00/NBOA_0000|S25/00/NBOB_0000|S25/00/NBOC_0000.",
 		"TextJPN": "「「ぶっ殺せッぶっ殺せ！！　感染野郎は殺せ！！　殺して死体を焼き払えッ！！」」",
 		"NamesENG": "Mobs",
-		"TextENG": "``Kill them, kill them!! Kill the infected people!! Kill them and burn the bodies!!``"
+		"TextENG": "``Kill them! Kill them! Kill the infected!! Kill them and burn their corpses!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154175,
 		"TextJPN": "暴徒の若者たち１０人ほどのグループが、大通りを駆け抜けていく。",
-		"TextENG": "A group of approximately ten youths in a mob, run through the main street."
+		"TextENG": "A group of ten young rioters dashed down the main street."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154176,
 		"TextJPN": "彼らの服は返り血で染まり、目は真っ赤に血走っている。",
-		"TextENG": "Their clothes dyed with their victim's blood, their eyes bloodshot red."
+		"TextENG": "Their clothes were stained with the spray of blood, and their eyes were bloodshot."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154177,
 		"TextJPN": "手にしている、バットやら鉄パイプやらも血を滴らせ、不気味に歪んでいた。",
-		"TextENG": "They have in hands bloody bats and iron pipes, all creepily distorted."
+		"TextENG": "The bats and metal pipes in their hands were dripping with blood, and were bent in unsettling directions."
 	},
 	{
 		"type": "MSGSET",
@@ -926,7 +926,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0870.",
 		"TextJPN": "「あんなのに見つかったら……、本当にヤバいな……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``We'll be found if we stay here...... it's really dangerous......``"
+		"TextENG": "``If those people find us... then we're really in trouble......``"
 	},
 	{
 		"type": "MSGSET",
@@ -935,7 +935,7 @@
 		"PreTextTags": "@vS25/02/NREN_0750.",
 		"TextJPN": "「大学生かな。……雛見沢のお年寄りたちのようには行かないね」",
 		"NamesENG": "Rena",
-		"TextENG": "``I wonder if they are university students. ......Let's not go in like the elderly of Hinamizawa.``"
+		"TextENG": "``Were they college students? ......I guess this won't be as easy as facing Hinamizawa's elderly.``"
 	},
 	{
 		"type": "MSGSET",
@@ -944,7 +944,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0200.",
 		"TextJPN": "「大丈夫。見つかってはいませんわ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``It's alright. We won't be found.``"
+		"TextENG": "``We are fine, I think. They haven't found us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -953,37 +953,37 @@
 		"PreTextTags": "@vS25/03/NMIO_0950.",
 		"TextJPN": "「……ふーっ。……こりゃあ、参ったねぇ……」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Heh. ......Wha now......``"
+		"TextENG": "``...Phew. ......This is a real pickle...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154182,
 		"TextJPN": "正気を失った若者たちは、何かが聞こえたと騒いでは駆けて行く。",
-		"TextENG": "The youth who have lost their sanity run over and make a racket after they hear something."
+		"TextENG": "The insane youths were dashing whenever they heard some commotion."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154183,
 		"TextJPN": "そうして、逃げる者はどこまでも追って襲いかかり、",
-		"TextENG": "Then, they kill the escaping person,"
+		"TextENG": "Then they killed those who fled..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154184,
 		"TextJPN": "命乞いする者も襲い、立ち向かわれれば、時に自らが命を落とした。",
-		"TextENG": "however, before this person was murdered, he begged for his life, but was confronted, and killed."
+		"TextENG": "Those who begged for their lives, and occasionally those who stood against them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154185,
 		"TextJPN": "まさに、血に飢えた鬼の所業。",
-		"TextENG": "Their act is exactly like that of a bloodthirsty demon."
+		"TextENG": "They truly were acting like bloodthirsty demons."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154186,
 		"TextJPN": "……恐らくこの光景が、伝承が伝える鬼ヶ淵村の惨劇そのものなのだ。",
-		"TextENG": "......Perhaps this scene is the legend of Onigafuchi village conveying itself as these tragic events."
+		"TextENG": "......That very sight was most likely what the legends of Onigafuchi Village were passing down."
 	},
 	{
 		"type": "MSGSET",
@@ -992,7 +992,7 @@
 		"PreTextTags": "@vS25/02/NREN_0760.",
 		"TextJPN": "「事務所って遠いの？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Is the office far?``"
+		"TextENG": "``Is the office far from here?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1001,7 +1001,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0960.",
 		"TextJPN": "「……距離的には遠くないんだけど、大通りを避けるようにすると、意外と面倒だねぇ……」",
 		"NamesENG": "Mion",
-		"TextENG": "``......It's not too far away, but we should avoid the main street. It's unexpectedly troublesome......``"
+		"TextENG": "``......In terms of distance, no, but if we're trying to avoid the main street, then it's surprisingly hard to get to......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1010,7 +1010,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0880.",
 		"TextJPN": "「大通りは、どこもかしこもイカレた連中が走り回ってるか殺し合ってるかのどちらかだからな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``The main street, mostly because those crazy guys are running around everywhere trying to kill everyone.``"
+		"TextENG": "``The main street is full of crazies either running around everywhere or killing each other.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1019,31 +1019,31 @@
 		"PreTextTags": "@vS25/04/NSAT_0210.",
 		"TextJPN": "「安全第一が一番ですわ。………ッ？！　静かに！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Safety first is always the best option. .........?! Quiet!``"
+		"TextENG": "``Then let us practice safety first. ......?! Quiet!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154191,
 		"TextJPN": "後ろの彼方から、カランカラーンと空き缶が転げる音が聞こえる。",
-		"TextENG": "From a short distance behind them, *clang clang*, the sound of empty cans rolling can be heard."
+		"TextENG": "We heard the rattling of an empty can rolling around somewhere behind us."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154192,
 		"TextJPN": "さっき、沙都子が仕掛けた空き缶トラップを、誰かが蹴飛ばしたのだ。",
-		"TextENG": "Some time ago, Satoko used a bunch of empty cans to set a trap, but now, somebody has kicked it."
+		"TextENG": "Someone had kicked the empty can trap Satoko set up earlier."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154193,
 		"TextJPN": "息を潜めるまでもなく、暴徒たちの物騒な声が迫ってくるのが聞こえる。",
-		"TextENG": "They didn't bother to hide their breaths, we can hear the dangerous voices of a mob imminently approaching."
+		"TextENG": "They weren't keeping quiet, either. We could hear the loud voices of the rioters drawing close."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154194,
 		"TextJPN": "殺す対象を探し回る彼らは、路地裏に至るまで徹底的に探し回っているのだ。",
-		"TextENG": "They search around for a target to kill, hunting thoroughly as they approach the back alley."
+		"TextENG": "They had finally started searching the back alleys too in their search for more to kill."
 	},
 	{
 		"type": "MSGSET",
@@ -1052,7 +1052,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0890.",
 		"TextJPN": "「まずいぞ、追いつかれる……！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``This is bad, they're gonna catch up with us......!``"
+		"TextENG": "``This is bad. They'll catch up to us......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1061,7 +1061,7 @@
 		"PreTextTags": "@vS25/02/NREN_0770.",
 		"TextJPN": "「でも、走る訳にはいかないよッ、バレちゃう！　隠れてやり過ごすの！」",
 		"NamesENG": "Rena",
-		"TextENG": "``But, we cannot afford to run, they'd find us! We have hide and wait it out!``"
+		"TextENG": "``But we can't exactly run, either! They'll find us! We have to hide and wait them out!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1070,7 +1070,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0220.",
 		"TextJPN": "「そこのゴミ箱を寄せて物陰を作るんですの！！　急いでッ！！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Use those trash cans over there and make some cover!! Hurry!!``"
+		"TextENG": "``Bring those trash cans over here! Create cover!! Hurry!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1079,7 +1079,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0970.",
 		"TextJPN": "「圭ちゃん、そっちのを持ってきて！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Kei-chan, grab that one over there for me!!``"
+		"TextENG": "``Kei-chan, grab that one!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1088,19 +1088,19 @@
 		"PreTextTags": "@vS25/01/NKEI_0900.",
 		"TextJPN": "「お、おう……！！　……うわッ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Y-Yeah......!! ......Uwa!``"
+		"TextENG": "``Y-Yeah...!! ......Uwah!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154200,
 		"TextJPN": "痛恨のミス。ゴミ箱の周りに散乱していた何かに足を滑らせ、圭一は抱えていたゴミ箱ごと転ぶ。",
-		"TextENG": "A fatal mistake. Slipping on something scattered around the trash cans, Keiichi falls down together with the trash cans which he held."
+		"TextENG": "It was an unfortunate mistake. Keiichi's foot slipped on some of the garbage scattered around the trash can, and he went down, can and all."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154201,
 		"TextJPN": "ガランガランと大きな音が路地に響き渡る……。",
-		"TextENG": "A loud *clatter clatter* sound echoes across the alley......"
+		"TextENG": "The loud clatter echoed throughout the back alley......"
 	},
 	{
 		"type": "MSGSET",
@@ -1109,19 +1109,19 @@
 		"PreTextTags": "@vS25/00/NBOA_0010.",
 		"TextJPN": "「おいッ、何か聞こえたぞッ！！　感染野郎に違いねえぇッ！！」",
 		"NamesENG": "Mob",
-		"TextENG": "``Hey! I heard something!! It must be some infected bastards!!``"
+		"TextENG": "``Hey! I heard something!! It must be another infected!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154203,
 		"TextJPN": "それに呼応して、狂喜とも憤怒ともつかぬ雄叫びが遠くから複数、轟く。",
-		"TextENG": "In response to it, an untold number of courageous shouts in wild joy are heard far away, roaring."
+		"TextENG": "Others responded to that call, their war cries full of madness and rage roaring in the distance."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154204,
 		"TextJPN": "その雄叫びは、背後だけではなく、前方からも聞こえた。",
-		"TextENG": "Roars, not only from behind, but also from the front can be heard."
+		"TextENG": "The cries came from both behind and in front of them."
 	},
 	{
 		"type": "MSGSET",
@@ -1130,7 +1130,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0230.",
 		"TextJPN": "「挟まれてますわ！！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``We're sandwiched!!``"
+		"TextENG": "``It's a pincer attack!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1139,7 +1139,7 @@
 		"PreTextTags": "@vS25/02/NREN_0780.",
 		"TextJPN": "「戦えない！　敵をどんどん誘き寄せちゃう！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``We can't fight like this! We need to lure the enemy steadily!!``"
+		"TextENG": "``We can't fight here! That'll only draw in even more of them!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1148,7 +1148,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0980.",
 		"TextJPN": "「正面突破で行くよッ。事務所まで駆け抜けよう！」",
 		"NamesENG": "Mion",
-		"TextENG": "``I'll breakthrough the front. Let's run them through until we reach the office!``"
+		"TextENG": "``We'll have to break through the front! Let's push through to the office!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1157,7 +1157,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0910.",
 		"TextJPN": "「あ痛！　テテテテッ？！　マ、マジかよ…？！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Oww! Owowowow! Ar-Are you serious...?!``"
+		"TextENG": "``Ah, ow! Owwww?! S-Seriously...?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1166,19 +1166,19 @@
 		"PreTextTags": "@vS25/02/NREN_0790.",
 		"TextJPN": "「圭一くん？！　挫いちゃったの？！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Keiichi-kun?! Did you sprain something?!``"
+		"TextENG": "``Keiichi-kun?! Did you sprain your leg?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154210,
 		"TextJPN": "全員の血が一瞬で凍りつく。最善にして唯一の手段が失われたからだ。",
-		"TextENG": "Everyone's blood freezes in an instant. Because their best and only means has been lost."
+		"TextENG": "Everyone's blood froze in an instant. Because that meant they just lost their one and only best option."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154211,
 		"TextJPN": "魅音は圭一に肩を貸しながら、素早く指示を出す。",
-		"TextENG": "Mion, while lending a shoulder to Keiichi, gives quick and fast instructions."
+		"TextENG": "Mion lent Keiichi her shoulder and quickly issued orders."
 	},
 	{
 		"type": "MSGSET",
@@ -1187,7 +1187,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0990.",
 		"TextJPN": "「沙都子ッ、退路を探して！！　レナは武器を！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Satoko, look for a way to retreat!! Rena, get a weapon!!``"
+		"TextENG": "``Satoko, find our way out!! Rena, weapons!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1196,7 +1196,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0240.",
 		"TextJPN": "「もうやってますわ！！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``One step ahead of you!!``"
+		"TextENG": "``I'm already on it!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1205,49 +1205,49 @@
 		"PreTextTags": "@vS25/02/NREN_0800.",
 		"TextJPN": "「こんなものしかないけど…！」",
 		"NamesENG": "Rena",
-		"TextENG": "``I know what to do...!``"
+		"TextENG": "``This is all I could find...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154215,
 		"TextJPN": "レナは駐輪禁止の立て看板を抱える。投げつけるなりすれば、怯ませる程度のことは出来るだろう。",
-		"TextENG": "Rena grabs a bicycle parking prohibited billboard. And hurls it, dealing a certain degree of damage."
+		"TextENG": "Rena held up a sign prohibiting bicycle parking. It would at least serve to frighten others if she swung it at them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154216,
 		"TextJPN": "だが、何よりも一番の武器は、仲間を守る為に覚悟を決めた、レナの目の色だ。",
-		"TextENG": "However, above everything else is to first make a weapon, and preparing herself in order to protect her friends, Rena's eyes light up."
+		"TextENG": "But their greatest weapon of all was the look in Rena's eyes, filled with her resolve to protect her friends."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154217,
 		"TextJPN": "レナは、大切なものを守る為に覚悟を決めた時は、一切の躊躇も容赦もない。",
-		"TextENG": "Rena has prepared herself in order to protect such important things, and thus will show no hesitation or mercy."
+		"TextENG": "Whenever Rena was prepared to defend something precious to her, she showed no mercy or hesitation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154218,
 		"TextJPN": "沙都子はトラップを仕掛ける時の天才的観察眼で状況を瞬時に計算する。",
-		"TextENG": "Satoko calculates the situation with an observing eye and instantly sets a genius trap."
+		"TextENG": "Satoko used the talented observation skills she had when setting traps to rapidly calculate what to do."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154219,
 		"TextJPN": "前後が塞がれたなら、逃れるのは上しかない。",
-		"TextENG": "And if the front and back is blocked, then the only means of escape is up."
+		"TextENG": "If both forward and backward were blocked off, then they could only escape upward."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154220,
 		"TextJPN": "ゴミ箱を踏み台に、あそこのひさしに上ってそれから……。",
-		"TextENG": "We must use the trash cans as a stepping stone, and get up to a roof using its eaves......"
+		"TextENG": "If they used the trash cans as a stool and climbed up on those eaves, then..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154221,
 		"TextJPN": "ああ、でも駄目！　圭一は足を挫いているのだ。梯子でもなければ、到底、どうにもならない！！",
-		"TextENG": "Ah, but it's no use! Keiichi has sprained his foot. So without a ladder, we're absolutely helpless!!"
+		"TextENG": "Ahh, but they couldn't! Keiichi had sprained his leg. There wasn't anything they could do without a ladder!!"
 	},
 	{
 		"type": "MSGSET",
@@ -1256,19 +1256,19 @@
 		"PreTextTags": "@vS25/01/NKEI_0920.",
 		"TextJPN": "「だ、大丈夫！　一時的なものだぜ、この位、へっちゃらだ…！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I-I'm fine! It's only temporary, I can do this...!``"
+		"TextENG": "``I-I'm fine! It's only temporary! This is nothing...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154223,
 		"TextJPN": "確かに、まったく歩けないほどではない。休めばすぐに治る程度のものだろう。",
-		"TextENG": "Certainly, I can walk. Although, it is at an extent which needs to be healed immediately, so I have to rest."
+		"TextENG": "It certainly wasn't so bad that he couldn't walk. It probably would heal quickly once he got some rest."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154224,
 		"TextJPN": "しかしそれでも、今この場を凌ぐことを期待するにはあまりに心細い…！",
-		"TextENG": "However, I can't let this opportunity surpass me now, I can't lose hope...!"
+		"TextENG": "But that didn't mean he could hope to escape their current dire straits...!"
 	},
 	{
 		"type": "MSGSET",
@@ -1277,7 +1277,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0250.",
 		"TextJPN": "「何でこんな時に足を挫きますですの！！　本当におマヌケさんですわね、圭一さんは！！　ああ！！　梯子さえあれば……！！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Why did you have to sprain your foot at a time like this!! You're really an idiot, Keiichi-san!! Ah!! If only we had a ladder......!!``"
+		"TextENG": "``Why did you have to sprain your foot at a time like this?!! You really are a blockhead, Keiichi-san!! Aargh!! If only we had a ladder......!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1286,7 +1286,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0930.",
 		"TextJPN": "「俺ひとりなら何とでもなる！　だから気にせず上へあがれ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I can't do anything by myself! Go up top and forget about me!!``"
+		"TextENG": "``If you're just worried about me, I'll manage! So don't worry about me and climb up there!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1295,7 +1295,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0260.",
 		"TextJPN": "「寝言いってる暇があったら、梯子が見つかるようにお祈りあそばせ！！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``You can talk gibberish later, just pray that I find a ladder in time!!``"
+		"TextENG": "``If you've got time to spout nonsense, then start praying that I find a ladder!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1304,7 +1304,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0940.",
 		"TextJPN": "「うぉおおおぉおお、天の神様、オヤシロさま！！　どうか梯子をお恵み下さいぃいいぃ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Uh~ooooooo, God of Heaven, Oyashiro-sama!! Please bless us with a ladder!!``"
+		"TextENG": "``Ooooooooooh! God in Heaven! Oyashiro-sama!! Please bless us with a ladderrrrr!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1313,7 +1313,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1000.",
 		"TextJPN": "「ハハ！　祈って助かったら、おじさん、ヘソを出して踊ってあげるよ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ha ha! We may be saved if you pray, but this Old Man then will take out the navel and dance!``"
+		"TextENG": "``Haha! If praying'll save us, then I'll stick my belly button out and dance!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1322,7 +1322,7 @@
 		"PreTextTags": "@vS25/02/NREN_0810.",
 		"TextJPN": "「み、魅ぃちゃん…！！　は、梯子…！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Mi-Mii-chan...!! A l-ladder...!!``"
+		"TextENG": "``M-Mii-chan...!! A-A ladder...!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1331,25 +1331,25 @@
 		"PreTextTags": "@vS25/03/NMIO_1010.",
 		"TextJPN": "「ふぇッ？！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Heh?!``"
+		"TextENG": "``Hwah?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154232,
 		"TextJPN": "ひさしの上から、本当に梯子が降りてくる。",
-		"TextENG": "From the top of the eaves, a ladder truly comes down."
+		"TextENG": "There really was a ladder coming down from one of the eaves."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154233,
 		"TextJPN": "見れば、ひとりの少女が木製の梯子を、危なっかしい手付きでこちらへ差し出そうとしていた。",
-		"TextENG": "When I look, a single girl holding a wooden ladder is trying to offer it in an unsteady way using her hands."
+		"TextENG": "Looking up, there was a lone young girl lowering a stainless steel ladder with shaky hands."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154234,
 		"TextJPN": "本来なら軽量のそれも、小柄な少女には充分な重さがあるだろう。バランスを崩して転落しないとも限らない。",
-		"TextENG": "She looks naturally lightweight, so it seems this petite girl doesn't have enough. She may lose her balance and fall."
+		"TextENG": "They were usually pretty light, but it was plenty heavy for such a small girl. There was a pretty good chance she'd lose her balance and fall down."
 	},
 	{
 		"type": "MSGSET",
@@ -1358,13 +1358,13 @@
 		"PreTextTags": "@vS25/02/NREN_0820.",
 		"TextJPN": "「ありがとう！！　もう大丈夫、手を離して！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Thank you!! It's alright now, release your hands!``"
+		"TextENG": "``Thank you!! It's good now, so let go!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154236,
 		"TextJPN": "レナは梯子を受け取り、素早く立て掛ける。",
-		"TextENG": "Rena receives the ladder, and quickly leans it."
+		"TextENG": "Rena took the ladder and quickly moved it into place."
 	},
 	{
 		"type": "MSGSET",
@@ -1373,7 +1373,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1020.",
 		"TextJPN": "「圭ちゃん、登れそう？！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Kei-chan, will you be able to climb?!``"
+		"TextENG": "``Kei-chan, can you climb?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1382,7 +1382,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0950.",
 		"TextJPN": "「登らなきゃ、あいつらがレナにぶっ殺されちまうからな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I have to climb, or Rena will kill those guys.``"
+		"TextENG": "``If I don't climb, then those other people are dying at Rena's hands.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1391,25 +1391,25 @@
 		"PreTextTags": "@vS25/02/NREN_0830.",
 		"TextJPN": "「ありがと。圭一くんが登れるなら、無駄な犠牲者が出なくて済むかな、かな」",
 		"NamesENG": "Rena",
-		"TextENG": "``Thank you. Climb, Keiichi-kun, I wonder if I can finish this without creating any unnecessary victims, I wonder.``"
+		"TextENG": "``Thanks. We can avoid more needless deaths if you can climb. If you can.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154240,
 		"TextJPN": "レナは木製の枠の立て看板をへし折り、鋭く尖った槍にしていた。",
-		"TextENG": "Rena breaks off the wooden frame of the billboard, and creates a sharp and pointy spear."
+		"TextENG": "Rena had already broken off parts of the wooden sign's frame, turning it into a sharp, pointed spear."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154241,
 		"TextJPN": "立て看板を投げつけて怯ませる、などという次元とは発想が違うらしい。恐ろしくもあり、頼もしくもある。",
-		"TextENG": "She stands daunting, ready to throw the billboard. Anyhow, this way of thinking isn't any different from her regular perspective. Both terrifying, and reliable."
+		"TextENG": "Her idea was on a whole different level from just waving it around to scare people. It was both frightening and reassuring."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154242,
 		"TextJPN": "しかしそれでも、梯子に勝るものではない。",
-		"TextENG": "However, that thing is not superior to a ladder."
+		"TextENG": "Still, nothing was better than taking the ladder."
 	},
 	{
 		"type": "MSGSET",
@@ -1418,7 +1418,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0270.",
 		"TextJPN": "「ありがとうですわ！　どなたか存じませんけど、大感謝ですのよ！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Thank you! Although I don't know who you are, you have my gratitude!``"
+		"TextENG": "``Thank you! I don't know who you are, but thank you very much!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1427,7 +1427,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0000.",
 		"TextJPN": "「……それほどでも、ある」",
 		"NamesENG": "Girl",
-		"TextENG": "``......Even so, I had to.``"
+		"TextENG": "``......I suppose it is worth that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1436,7 +1436,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0960.",
 		"TextJPN": "「大丈夫だ、登れる……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......I'm fine, I can climb it......``"
+		"TextENG": "``I'm good, I can climb...``"
 	},
 	{
 		"type": "MSGSET",
@@ -1445,7 +1445,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1030.",
 		"TextJPN": "「悪いけど、急いで！　来たッ！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``I know it's hard, but hurry! They're coming!!``"
+		"TextENG": "``I know, but hurry! They're almost here!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1454,7 +1454,7 @@
 		"PreTextTags": "@vS25/00/NBOA_0020.",
 		"TextJPN": "「感染野郎どもがいやがったぞ！！　何人もいやがるッ！！」",
 		"NamesENG": "Mob",
-		"TextENG": "``The infected bastards are back! There's more of them!``"
+		"TextENG": "``There's more of those infected bastards!! A whole bunch, actually!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1463,7 +1463,7 @@
 		"PreTextTags": "@vS25/00/NBOB_0010.",
 		"TextJPN": "「ぶっ殺せぶっ殺せ！！　ヒャッハハハハハハハッ！！」",
 		"NamesENG": "Mob",
-		"TextENG": "``Kill them, kill them!! Hyah ha ha ha ha ha ha ha!!``"
+		"TextENG": "``Kill them! Kill them!! Hyahahahahahahahaha!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1472,7 +1472,7 @@
 		"PreTextTags": "@vS25/02/NREN_0840.",
 		"TextJPN": "「うるさいっ！　殺すってことは、自分が殺されることも覚悟するってことだよッ！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Shut up! If you want to kill somebody, you should be prepared to die yourself!``"
+		"TextENG": "``Shut up! If you're out to kill, then you're prepared to be killed too, right?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1481,25 +1481,25 @@
 		"PreTextTags": "@vS25/04/NSAT_0280.",
 		"TextJPN": "「レナさん、登って！！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Rena-san, climb!!``"
+		"TextENG": "``Rena-san, please climb!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154251,
 		"TextJPN": "レナが梯子を登ると、魅音はすぐに梯子を引き上げる。",
-		"TextENG": "After Rena climbs the ladder, Mion raises the ladder immediately."
+		"TextENG": "Once Rena climbed up, Mion quickly pulled up the ladder."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154252,
 		"TextJPN": "少女は、その梯子はここに置いていっていいと仕草で伝えると、ひさしから、２階の窓の中に入る。",
-		"TextENG": "The girl conveys to us that we can leave the ladder here via a gesture, then from the eaves, we enter through a window onto the second floor."
+		"TextENG": "The young girl gestured to say it was okay to leave the ladder here, before passing through the second-floor window via the eaves."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154253,
 		"TextJPN": "眼下では、暴徒の若者たちが口汚く罵りながら、ひさしの上によじ登る方法を探している。",
-		"TextENG": "While below, the mob of youths curse abusively, looking for a way to climb on top of the eaves."
+		"TextENG": "Below them, the young rioters were spouting filthy curses as they searched for a way to climb."
 	},
 	{
 		"type": "MSGSET",
@@ -1508,7 +1508,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0010.",
 		"TextJPN": "「こっち。……ここもいつまでも安全、……なわけない」",
 		"NamesENG": "Girl",
-		"TextENG": "``Here. ......Here you'll be safe forever...... There's no reason you shouldn't be.``"
+		"TextENG": "``This way. ......This place won't be safe forever, either.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1517,7 +1517,7 @@
 		"PreTextTags": "@vS25/02/NREN_0850.",
 		"TextJPN": "「本当にありがとう！　あなたは命の恩人！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Thank you very much! You're a life saver!``"
+		"TextENG": "``Seriously, thank you! You've saved our lives!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1526,7 +1526,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0970.",
 		"TextJPN": "「また窓から出るのかよ？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``What made you come out the window?``"
+		"TextENG": "``Are we going out through another window?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1535,37 +1535,37 @@
 		"PreTextTags": "@vS25/50/NUNE_0020.",
 		"TextJPN": "「……あの程度、連中はよじ登って来ない、……わけがない」",
 		"NamesENG": "Girl",
-		"TextENG": "``......If I didn't, you people wouldn't be able to climb up...... No other reason.``"
+		"TextENG": "``......There's no way those people won't, climb up here.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154258,
 		"TextJPN": "再び別の窓から出て、空調の室外機を踏み台に、さらに隣の建物の窓から入る。",
-		"TextENG": "We exit through another window, and use the outdoor units and air conditioning as a stepping stone, to enter through a window into the adjacent building."
+		"TextENG": "She exited through another window, then used an outdoor air conditioning unit as a stepping stone to climb into the neighboring building through its own window."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154259,
 		"TextJPN": "どうやら、彼女は商店街の２階伝いに移動して、危険な地上を避けているようだった。",
-		"TextENG": "It appears that this girl moved to the second floor along the walls of the shopping district, she seems to be avoiding the danger on the ground."
+		"TextENG": "Apparently she had been traveling along the second floor of the shopping district to avoid the dangerous streets below."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154260,
 		"TextJPN": "そうやって、建物から建物へ、屋根から屋根へ伝って移動し、安全圏まで逃げ切ったことを確信する……。",
-		"TextENG": "In that way, we moved from building to building, roof to roof, convinced that we will eventually succeed and escape to a safe zone......"
+		"TextENG": "They continued moving like that from building to building and roof to roof until they were certain they had managed to escape to a safe area......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154261,
 		"TextJPN": "辿り着いたのは、どこかの住宅兼店舗の２階。",
-		"TextENG": "Then we arrived, on the second floor of some house and shop."
+		"TextENG": "They eventually stopped at the second floor of a shop-slash-residence."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154262,
 		"TextJPN": "ここが彼女のシェルターらしかった。",
-		"TextENG": "Here seemed to be her shelter."
+		"TextENG": "Apparently that was her shelter."
 	},
 	{
 		"type": "MSGSET",
@@ -1574,7 +1574,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1040.",
 		"TextJPN": "「……大丈夫。完全に振り切ったみたいだね」",
 		"NamesENG": "Mion",
-		"TextENG": "``......We're alright. It seems we've completely shaken them off.``"
+		"TextENG": "``......We're okay. It looks like we shook them off.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1583,7 +1583,7 @@
 		"PreTextTags": "@vS25/02/NREN_0860.",
 		"TextJPN": "「また別の獲物を探しだしただけだよ。……あの人たちはただ、人殺しがしたいだけ」",
 		"NamesENG": "Rena",
-		"TextENG": "``They must have already started to look for another prey. ......Those people just want to be murderers.``"
+		"TextENG": "``They just started searching for other prey. ......Those people just want to kill.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1592,7 +1592,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0290.",
 		"TextJPN": "「まるで地面は、鮫の泳ぐ海に見えますわ……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``It's as if on the ground we were looking into a sea of swimming sharks......``"
+		"TextENG": "``It's like the streets are an ocean full of sharks......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1601,7 +1601,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0980.",
 		"TextJPN": "「……本当にありがとう。助かったぜ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......Thank you very much. You saved us.``"
+		"TextENG": "``......We're really thankful. You saved us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1610,7 +1610,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0030.",
 		"TextJPN": "「これで助かった……、かどうかは、誰にもわからないです」",
 		"NamesENG": "Girl",
-		"TextENG": "``I was saved by this...... But, I don't know whether anyone knows about here.``"
+		"TextENG": "``No one knows, if you're safe now or not.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1619,7 +1619,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1050.",
 		"TextJPN": "「ひとまずの難を逃れただけだからね。……でも、礼を言うよ。ありがとう」",
 		"NamesENG": "Mion",
-		"TextENG": "``We only escaped for the time being. ......But, we have to say thanks. Thank you.``"
+		"TextENG": "``Well, we managed to escape that particular crisis, if nothing else. ......But I should thank you. So, thanks.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1628,7 +1628,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0040.",
 		"TextJPN": "「礼を言われる……、ほどのこともある」",
 		"NamesENG": "Girl",
-		"TextENG": "``You said thanks...... I don't need it.``"
+		"TextENG": "``I guess, I did earn your thanks.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1637,19 +1637,19 @@
 		"PreTextTags": "@vS25/02/NREN_0870.",
 		"TextJPN": "「くす。……だね」",
 		"NamesENG": "Rena",
-		"TextENG": "``*Giggles*. ......Okay.``"
+		"TextENG": "``Heehee. ...Right.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154271,
 		"TextJPN": "危険を冒して誰かを助ける義理など、あるわけもない。",
-		"TextENG": "Well, it is one's social obligation to help someone when they're in danger, there's no reason not to."
+		"TextENG": "She had no obligation to risk herself to try and save someone else."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154272,
 		"TextJPN": "今の興宮では、戸締まりを厳重にした室内に閉じこもることが出来たなら、耳を塞いでうずくまっているのが最善なのだから。",
-		"TextENG": "But in the present Okinomiya, you should shut yourself up in a room and lock it severely, and best crouch down and cover your ears."
+		"TextENG": "If she was able to lock herself up tight indoors, then her best option would have been to curl up and shut out all other sounds."
 	},
 	{
 		"type": "MSGSET",
@@ -1658,7 +1658,7 @@
 		"PreTextTags": "@vS25/01/NKEI_0990.",
 		"TextJPN": "「俺は前原圭一。君は？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I'm Maebara Keiichi. You?``"
+		"TextENG": "``I'm Keiichi Maebara. You?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1667,7 +1667,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0050.",
 		"TextJPN": "「@bうね.@<采@>、……と呼ばれたりもする」",
 		"NamesENG": "Une",
-		"TextENG": "``Une...... that's what they call me.``"
+		"TextENG": "``Une..... is what people call me.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1676,7 +1676,7 @@
 		"PreTextTags": "@vS25/02/NREN_0880.",
 		"TextJPN": "「私はレナ。そっちは魅ぃちゃんと沙都子ちゃん」",
 		"NamesENG": "Rena",
-		"TextENG": "``I'm Rena. And this here is Mii-chan and Satoko-chan.``"
+		"TextENG": "``I'm Rena. This is Mii-chan and Satoko-chan.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1685,7 +1685,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0300.",
 		"TextJPN": "「よろしくですわ。本当に最高のタイミングで助けてくれましてよ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Nice to meet you. Your help really came in the best timing.``"
+		"TextENG": "``Nice to meet you. You really did save us at the perfect time.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1694,7 +1694,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0060.",
 		"TextJPN": "「運が良かった、……がいつもとは限らないのです」",
 		"NamesENG": "Une",
-		"TextENG": "``You were lucky...... I wasn't going to be there for long.``"
+		"TextENG": "``You were lucky, but that doesn't mean you always will be.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1703,7 +1703,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1060.",
 		"TextJPN": "「ま、運も実力のうちさね」",
 		"NamesENG": "Mion",
-		"TextENG": "``Well, you sure have the ability of luck.``"
+		"TextENG": "``Well, luck is another kind of strength.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1712,7 +1712,7 @@
 		"PreTextTags": "@vS25/02/NREN_0890.",
 		"TextJPN": "「ここには采ちゃんだけ？　他に人は？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Are you the only one here, UNE-chan? Is there anyone else?``"
+		"TextENG": "``Is it just you here, Une-chan? Any others?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1721,43 +1721,43 @@
 		"PreTextTags": "@vS25/50/NUNE_0070.",
 		"TextJPN": "「居た。……でも、帰ってこない」",
 		"NamesENG": "Une",
-		"TextENG": "``There was. ......But, they haven't come home.``"
+		"TextENG": "``There were. ......But they're not coming back.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154281,
 		"TextJPN": "ここで息を潜めていれば、安全だったろうに。",
-		"TextENG": "We all lower our breathing. As long as we are here, we're safe."
+		"TextENG": "If she stayed quiet, she would be safe here."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154282,
 		"TextJPN": "しかし、人間の悲しい性なのだ。安全を得ると、今度は逆に危険を冒したくなる……。",
-		"TextENG": "However, this is the sad nature of humans. Because upon obtaining safety, you always run the risk of reversing your situation......"
+		"TextENG": "Yet that's the sad nature of humanity. Once they gain safety, they want to risk danger......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154283,
 		"TextJPN": "家族の安否の確認、あるいは帰宅。安全を得ると、どうしてもその場には留まれなくなるのだ……。",
-		"TextENG": "As either if you confirm the safety of your family, or return home. Even if you attain safety, you can never stay in the one place......"
+		"TextENG": "Whether it's wanting to make sure your family is safe, or to return home, once a person finds safety, they can't just stay there......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154284,
 		"TextJPN": "確かにここはシェルターだったらしい。",
-		"TextENG": "Although, here certainly seems to be a shelter."
+		"TextENG": "The place certainly was a shelter."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154285,
 		"TextJPN": "飲料水のペットボトルが１ダースほども並べられ、菓子袋のつめ込まれたスーパーの袋が４つほども転がっている。",
-		"TextENG": "Approximately one dozen plastic bottles of drinking water are displayed, and also approximately four supermarket bags packed with confectionery are lying around."
+		"TextENG": "There were a dozen plastic bottles full of water lined up, and there were about four grocery bags stuffed full of candy bags laying there too."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154286,
 		"TextJPN": "何人がいたかは知らないが、贅沢さえ言わなければ、３日は籠城できただろう。",
-		"TextENG": "I don't know how many people were here, but it's kinda luxurious. This place could even hold out a three day siege."
+		"TextENG": "They didn't know how many had been here, but as long as they were frugal, they could hole up for three days."
 	},
 	{
 		"type": "MSGSET",
@@ -1766,7 +1766,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1070.",
 		"TextJPN": "「そういう安全な場所を築くとさ。……家族や友人を連れて来たくなるのさ」",
 		"NamesENG": "Mion",
-		"TextENG": "``It seems you built such a safe place. ......I'm tempted to bring all my family and friends.``"
+		"TextENG": "``When people manage to create a safe space... they want to bring their family and friends into it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1775,7 +1775,7 @@
 		"PreTextTags": "@vS25/02/NREN_0900.",
 		"TextJPN": "「そうだね。ここで耳を塞いでじっとしているのが正解。……でも、采ちゃんのお陰で、私たちは助かった」",
 		"NamesENG": "Rena",
-		"TextENG": "``You're right. Except the correct answer was to keep still and cover your ears. ......But, thanks to Une-chan, we were saved.``"
+		"TextENG": "``That's true. Staying put here and ignoring what you hear outside might be the right answer. ......But thanks to Une-chan, we're all safe.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1784,7 +1784,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0310.",
 		"TextJPN": "「命の恩人というだけでは、とても感謝がし切れませんわね……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``We should call you a lifesaver, we're very grateful......``"
+		"TextENG": "``I can't really thank you enough for saving our lives......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1793,7 +1793,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1000.",
 		"TextJPN": "「あの物騒な連中は、まだまだ大勢いるのか？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Those dangerous people, are they in great numbers?``"
+		"TextENG": "``Are there still many more violent groups like that one?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1802,7 +1802,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0080.",
 		"TextJPN": "「あまりいない、……わけがない」",
 		"NamesENG": "Une",
-		"TextENG": "``There's not that many...... there's no reason.``"
+		"TextENG": "``There's more than that, there's plenty.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1811,7 +1811,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1080.",
 		"TextJPN": "「だろうね。しかし、連中も真夜中まで駆け回ってるわけじゃないでしょ」",
 		"NamesENG": "Mion",
-		"TextENG": "``I guess so. However, those people will probably stop running at midnight.``"
+		"TextENG": "``Figures. Still, they're not running around in the middle of the night, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1820,7 +1820,7 @@
 		"PreTextTags": "@vS25/02/NREN_0910.",
 		"TextJPN": "「雛見沢の自警団は、夜も不寝番を立ててたね」",
 		"NamesENG": "Rena",
-		"TextENG": "``The vigilance committee of Hinamizawa put up a night watchman at night also.``"
+		"TextENG": "``The neighborhood watch in Hinamizawa set up patrols after dark.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1829,7 +1829,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0320.",
 		"TextJPN": "「彼らもまた、怯えているんですもの。……油断して大いびきとは思えませんわ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``They were just frightened, too. ......Although, I don't think you'd catch them off guard snoring out loud.``"
+		"TextENG": "``They're frightened too. ...I do doubt they'll let their guard down and start snoring.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1838,7 +1838,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1010.",
 		"TextJPN": "「それでも、真っ昼間よりは多少、安全になるはず。園崎組の事務所は遠くないんだろ？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Even so, it should be a little safer in the daytime. Is the Sonozaki family office close?``"
+		"TextENG": "``Even so, it should be a little safer than moving in the middle of the day. The Sonozaki group's office isn't far, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1847,7 +1847,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1090.",
 		"TextJPN": "「……まぁ、直線距離的には、ね」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Well, if its distance was in a straight line, then yeah.``"
+		"TextENG": "``...Well, not in terms of direct distance.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1856,7 +1856,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0330.",
 		"TextJPN": "「少し様子を見るべきですわ。焦るべきではありませんもの」",
 		"NamesENG": "Satoko",
-		"TextENG": "``You should look at our state. We shouldn't hurry.``"
+		"TextENG": "``We should wait and observe for a bit. There's no need to rush.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1865,7 +1865,7 @@
 		"PreTextTags": "@vS25/02/NREN_0920.",
 		"TextJPN": "「そうだね。采ちゃん。少し、街の様子を聞かせてもらってもいい？」",
 		"NamesENG": "Rena",
-		"TextENG": "``You're right. Une-chan. Could you tell us a little about the state of the town?``"
+		"TextENG": "``That's true. Une-chan? Could you tell us a bit about what's going on in the city?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1874,6 +1874,6 @@
 		"PreTextTags": "@vS25/50/NUNE_0090.",
 		"TextJPN": "「………話せば長い、……こともないのですが。……………」",
 		"NamesENG": "Une",
-		"TextENG": "``.........It will be long if I talk...... I hope it won't bother you. ...............``"
+		"TextENG": "``......Telling you, won't take that long...``"
 	}
 ]

--- a/kamikashimashi_2.json
+++ b/kamikashimashi_2.json
@@ -282,7 +282,7 @@
 		"PreTextTags": "@vS25/03/NMIO_0830.",
 		"TextJPN": "「殺人ウィルスの恐怖でみんなおかしくなってるって思ってたけど、……それだけじゃ説明がつかないんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``I thought everyone was going crazy out of fear of this killer virus, ......but that's not enough to explain everything.``"
+		"TextENG": "``I thought everyone was going crazy out of fear of this killer virus...... but that's not enough to explain everything.``"
 	},
 	{
 		"type": "MSGSET",

--- a/kamikashimashi_3.json
+++ b/kamikashimashi_3.json
@@ -405,7 +405,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0060.",
 		"TextJPN": "「……ぅぅ、………う…………」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``......Nnh ......nh.........``"
+		"TextENG": "``......Nnh......nh.........``"
 	},
 	{
 		"type": "MSGSET",

--- a/kamikashimashi_3.json
+++ b/kamikashimashi_3.json
@@ -12,7 +12,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0210.",
 		"TextJPN": "「あったわ。多分、これで開くわね」",
 		"NamesENG": "Rika",
-		"TextENG": "``There it is. Maybe now it will open.``"
+		"TextENG": "``Found it. It should open if I do this.``"
 	},
 	{
 		"type": "MSGSET",
@@ -21,7 +21,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0130.",
 		"TextJPN": "「あぅあぅ。恐ろしいオバケを閉じ込めているのだったら、どうしましょうなのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Au au. There could be a terrifying ghost trapped inside, what then?!``"
+		"TextENG": "``Au, au. What'll we do if there's a terrifying ghost trapped in there?``"
 	},
 	{
 		"type": "MSGSET",
@@ -30,7 +30,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0220.",
 		"TextJPN": "「あんたとどっちがバケモノか、にらめっこしてみなさいよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``Well, if there is a ghost, we'll play a staring game.``"
+		"TextENG": "``Then you two can have a staring contest to determine which one's the stronger apparition.``"
 	},
 	{
 		"type": "MSGSET",
@@ -45,13 +45,13 @@
 		"type": "MSGSET",
 		"MessageID": 154304,
 		"TextJPN": "繰り返し聞こえる怪音は、備蓄倉庫と書かれた頑丈な扉の内側からだった。",
-		"TextENG": "An unearthly sound is heard repeatedly, it comes from the inside of a sturdy door with the words ``Storage warehouse`` written on it."
+		"TextENG": "The strange, repetitive sound they heard was coming from the other side of a sturdy door, labeled the emergency storage room."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154305,
 		"TextJPN": "何者かが分厚い金属の扉に体当たりをしている。そう考えるのが妥当だった。",
-		"TextENG": "Someone must be throwing themselves against the thick metal door. That's probably the right explanation."
+		"TextENG": "Someone was slamming themselves against the thick metal door. That idea made the most sense, at least."
 	},
 	{
 		"type": "MSGSET",
@@ -60,7 +60,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0230.",
 		"TextJPN": "「でも、どうして備蓄倉庫？」",
 		"NamesENG": "Rika",
-		"TextENG": "``But, why a storage warehouse?``"
+		"TextENG": "``But why the emergency storage room?``"
 	},
 	{
 		"type": "MSGSET",
@@ -69,7 +69,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0150.",
 		"TextJPN": "「誰かが、牢屋の代わりに使ったということでしょうか……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``They must be using it as a jail instead......``"
+		"TextENG": "``Maybe someone was using it as a jail cell...``"
 	},
 	{
 		"type": "MSGSET",
@@ -78,7 +78,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0240.",
 		"TextJPN": "「誰が？　いつ？　誰を？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Who? When? Who's in there?``"
+		"TextENG": "``Who? When? For whom?``"
 	},
 	{
 		"type": "MSGSET",
@@ -87,7 +87,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0160.",
 		"TextJPN": "「そんなことオヤシロさまだってわからないのですっ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Even Oyashiro-sama doesn't know the answer to such a thing.``"
+		"TextENG": "``Even I, Oyashiro-sama, don't know that!``"
 	},
 	{
 		"type": "MSGSET",
@@ -96,31 +96,31 @@
 		"PreTextTags": "@vS25/05/NRIK_0250.",
 		"TextJPN": "「それもそうね」",
 		"NamesENG": "Rika",
-		"TextENG": "``Is that so.``"
+		"TextENG": "``I suppose that's true.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154311,
 		"TextJPN": "備蓄倉庫は外側から施錠されるタイプの扉だ。",
-		"TextENG": "The storage warehouse door type tells us it was locked from the outside."
+		"TextENG": "The door to the emergency storage room was the type being locked from the outside."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154312,
 		"TextJPN": "内側から叩き続けている以上、施錠されると内側からは開けられないのだろう。",
-		"TextENG": "We continue to hear banging from the inside, although it can't be opened from the inside since it's locked."
+		"TextENG": "Given that something kept hitting it in there, there was probably no way to unlock it from inside."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154313,
 		"TextJPN": "マスターキーを手に戻ると、音は一旦止んでいた。",
-		"TextENG": "When I returned with the master key in hand, the sound stopped."
+		"TextENG": "Once she came back with the master key, the sound stopped for a moment."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154314,
 		"TextJPN": "叩くのに疲れたのか。それとも、梨花たちが踏み入ってくるのを、息を潜めて待ち構えているのか。",
-		"TextENG": "Maybe whoever got tired of banging. Or maybe they dropped their breath and wait for us to get inside."
+		"TextENG": "Maybe they were worn out from hitting it so much? Either that, or they had gone quiet as Rika and Hanyuu approached, and were lying in wait for them."
 	},
 	{
 		"type": "MSGSET",
@@ -138,25 +138,25 @@
 		"PreTextTags": "@vS25/12/NHAN_0170.",
 		"TextJPN": "「い、いつでもどうぞなのですよ……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``G-Go on whenever you want......``"
+		"TextENG": "``A-Anytime you're ready......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154317,
 		"TextJPN": "鍵を挿し入れ、ゆっくりと回す……。",
-		"TextENG": "I insert the key, and turn it slowly......"
+		"TextENG": "She inserted the key, and slowly turned it......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154318,
 		"TextJPN": "まさかとは思うが、Ｌ５発症者をこの中に隔離して閉じ込めたということはないだろうか？",
-		"TextENG": "I have thought about it, did the person imprisoned here develop L5 and got isolated?"
+		"TextENG": "There's no way that an L5 patient was being kept quarantined in here, right?"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154319,
 		"TextJPN": "だとしたら、開けた途端、中から飛び出してきて、襲い掛かってくることもありえる。",
-		"TextENG": "I hope that's not the case. However, as soon as we open the door, it is possible something could jump out from the inside, trying to attack us."
+		"TextENG": "If there was, then the moment she opened it they could leap out from inside and start attacking her."
 	},
 	{
 		"type": "MSGSET",
@@ -165,55 +165,55 @@
 		"PreTextTags": "@vS25/05/NRIK_0270.",
 		"TextJPN": "「それはないわね。……入江たちが、こんなところに閉じ込めるなんて、訳の分からないことをするわけがない」",
 		"NamesENG": "Rika",
-		"TextENG": "``Not possible. ......I can't believe Irie or anyone else would confine someone to such a place, they have no reason to do that.``"
+		"TextENG": "``That won't happen. ......There's no way Irie and the others would do something so senseless as locking a victim up in a place like this.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154321,
 		"TextJPN": "百年の魔女の梨花にとって、この扉の向こうを確かめるという好奇心に抗うのは難しいことのようだった。",
-		"TextENG": "For Rika, the witch of one hundred years, it is difficult for her to fight against her own curiosity to check what is on the other side of this door."
+		"TextENG": "Even for the hundred-year-old witch, Rika, it was hard to fight the curiosity of finding out what lay beyond that door."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154322,
 		"TextJPN": "このような滅茶苦茶な世界に興味はない。しかし、死ぬことはいつでも出来る。",
-		"TextENG": "I am not interested in such an unreasonable world. However, it is possible to die anytime."
+		"TextENG": "She didn't have any interest in this crazy world. But she could die at any time."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154323,
 		"TextJPN": "なら、ぎりぎりまでこの世界がどうなるのかを見てみたい。",
-		"TextENG": "Then, I want to see what happens to this world until the very last minute."
+		"TextENG": "So she wanted to see what happened to the world up until the very end."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154324,
 		"TextJPN": "見届けたいなどという高尚な気持ちでなく、怖いもの見たさのような、ちょっぴり邪な好奇心だ。",
-		"TextENG": "My noble feeling wants to make sure of it, so I shouldn't rubberneck, but indulge my wicked curiosity."
+		"TextENG": "It wasn't some noble desire to watch over its demise, but the slightly wicked curiosity of wanting to see something scary."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154325,
 		"TextJPN": "重い扉をゆっくりと開く……。",
-		"TextENG": "I slowly open the heavy door......"
+		"TextENG": "She slowly opened the heavy door......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154326,
 		"TextJPN": "するとわずかに開いた隙間から、ぶわっと汗と腐ったモノが入り混じったような、悪臭の熱気が噴き出してくる。",
-		"TextENG": "Then, from the slightly open gap, sweat and the smell of something rotten comes gushing out, alongside the heat of this stench."
+		"TextENG": "Through the slight crack came the foul, hot scent of sweat mixed with something rotten."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154327,
 		"TextJPN": "恐ろしい何かを予感するより、不潔な何かが予感させられた。",
-		"TextENG": "Rather than my premonition which was something terrible, it was something dirty."
+		"TextENG": "The smell made her imagine something more filthy than frightening."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154328,
 		"TextJPN": "そして、床に突っ伏していた汗だくの男が、ゆっくりと顔を上げる……。",
-		"TextENG": "And, see a sweaty man who fell with his face on the floor, slowly raise his head......"
+		"TextENG": "There was a light on inside...... And a sweaty man who was collapsed on the floor slowly raised his head......"
 	},
 	{
 		"type": "MSGSET",
@@ -231,7 +231,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0000.",
 		"TextJPN": "「やぁ……梨花ちゃん……。……助かったよ………」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Hey...... Rika-chan...... ......I'm saved.........``"
+		"TextENG": "``Hey...... Rika-chan...... ......You saved me.........``"
 	},
 	{
 		"type": "MSGSET",
@@ -240,7 +240,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0290.",
 		"TextJPN": "「こんなところで何をしていたのですか？」",
 		"NamesENG": "Rika",
-		"TextENG": "``What are you doing in a place like this?``"
+		"TextENG": "``What were you doing in a place like that?``"
 	},
 	{
 		"type": "MSGSET",
@@ -249,7 +249,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0010.",
 		"TextJPN": "「さぁねぇ。少なくとも、僕の意思じゃないことは確かさ」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``I don't know. At least, it certainly wasn't my intention.``"
+		"TextENG": "``Who knows. At the very least, it wasn't something I chose.``"
 	},
 	{
 		"type": "MSGSET",
@@ -258,7 +258,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0180.",
 		"TextJPN": "「梨花……、奥の配管を見るのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Rika...... look at the back of the plumbing.``"
+		"TextENG": "``Rika...... Look at the pipes in the back.``"
 	},
 	{
 		"type": "MSGSET",
@@ -273,37 +273,37 @@
 		"type": "MSGSET",
 		"MessageID": 154335,
 		"TextJPN": "倉庫の奥の配管に括りつけるように、壊れた手錠が掛けられていた。",
-		"TextENG": "Tied to the back pipe of the warehouse, are a pair of broken handcuffs."
+		"TextENG": "Fastened to the pipes at the back of the storage room were a pair of broken handcuffs."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154336,
 		"TextJPN": "恐らく、それに拘束されていたに違いない。",
-		"TextENG": "Probably he was restrained and placed here."
+		"TextENG": "He was almost certainly bound up in them before."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154337,
 		"TextJPN": "一体、彼はいつからここに閉じ込められていたのだろう。",
-		"TextENG": "Who on earth trapped him for so long."
+		"TextENG": "Just how long had he been held captive in there, though?"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154338,
 		"TextJPN": "様子を見る限り、ほんの一昼夜程度とは思えない。",
-		"TextENG": "Judging by his state, I doubt it's only been one whole day."
+		"TextENG": "Judging from his surroundings, it had to have been more than a day."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154339,
 		"TextJPN": "……まさか、この騒ぎの最中、ずっとここに閉じ込められていたというのだろうか？",
-		"TextENG": "......No way, in the middle of this uproar was he been trapped in here?"
+		"TextENG": "......It couldn't be. Had he been locked up in there since this whole commotion started?"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154340,
 		"TextJPN": "やつれ、疲労し切っているが、気力は辛うじて保っているようだった。",
-		"TextENG": "He looks worn out, and really tired. He seems to have barely kept hold of any energy."
+		"TextENG": "He was worn down and exhausted, but it looked like he had just barely held onto his mind."
 	},
 	{
 		"type": "MSGSET",
@@ -312,7 +312,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0020.",
 		"TextJPN": "「ところで。……外ではこの数日間、何かあったかい？」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``By the way...... The past several days, has anything happened?``"
+		"TextENG": "``By the way... has anything happened outside over the past few days?``"
 	},
 	{
 		"type": "MSGSET",
@@ -321,7 +321,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0310.",
 		"TextJPN": "「何も。……むしろ、ようやく静かになったというところなのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``Nothing...... Rather, this place has finally become quiet.``"
+		"TextENG": "``Not much. ......In fact, it's finally quieted down.``"
 	},
 	{
 		"type": "MSGSET",
@@ -339,7 +339,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0320.",
 		"TextJPN": "「村人が次々に末期発症を起こしたわ。今はそれが、村だけに留まらず、興宮にまで拡大してるみたい」",
 		"NamesENG": "Rika",
-		"TextENG": "``The villagers terminally developed one after another. But now, it's no longer just this village, it seems to have even spread to Okinomiya.``"
+		"TextENG": "``The villagers expressed terminal symptoms one after another. Now it's spread beyond the village and into Okinomiya as well.``"
 	},
 	{
 		"type": "MSGSET",
@@ -348,7 +348,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0030.",
 		"TextJPN": "「何てことだ……。た、鷹野さんは？！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``How could this have happened...... And Ta-Takano-san?!``"
+		"TextENG": "``That's terrible... W-What about Takano-san?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -357,7 +357,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0330.",
 		"TextJPN": "「……そういえば、この騒ぎが始まってから見かけないのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``......That reminds me, I haven't seen her since this uproar began.``"
+		"TextENG": "``......Speaking of her, I haven't seen her since this commotion started.``"
 	},
 	{
 		"type": "MSGSET",
@@ -366,7 +366,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0040.",
 		"TextJPN": "「入江所長を大至急呼んで来てくれないかい……。大変なことになるっ」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``We have to get director Irie immediately...... This is serious.``"
+		"TextENG": "``Could you summon Director Irie here at once......? Something terrible's going to happen.``"
 	},
 	{
 		"type": "MSGSET",
@@ -375,7 +375,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0340.",
 		"TextJPN": "「もう大変なことは起こり終わっているのですよ？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Don't you think what has happened is already serious?``"
+		"TextENG": "``Something terrible has already happened, and ended.``"
 	},
 	{
 		"type": "MSGSET",
@@ -384,19 +384,19 @@
 		"PreTextTags": "@vS25/08/NTOM_0050.",
 		"TextJPN": "「違うよ、もっと大変なことが起こるっ。鷹野さんは、雛見沢症候群を日本中に、いや、世界中にばら撒くつもりだ……！！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``That's not what I meant. I know what has happened is serious. But Takano-san wants to spread the Hinamizawa Syndrome all over Japan... No, she wants to scatter it across the entire world......!!``"
+		"TextENG": "``No, something even more terrible is going to happen. Takano-san is planning to spread Hinamizawa Syndrome to all of Japan, no, the entire world...!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154350,
 		"TextJPN": "事の始まりは、今から何日前に遡るだろう。",
-		"TextENG": "The beginning of things, all date back to several days ago."
+		"TextENG": "Apparently, it had all started several days back."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154351,
 		"TextJPN": "まだ、何も起こっていない平穏だった頃に、もう富竹はここに閉じ込められていたのだ……。",
-		"TextENG": "Still, by the time peace was not yet disrupted, Tomitake had already been trapped in here......"
+		"TextENG": "Tomitake had already been locked up in here back when everything was peaceful, before anything had happened......"
 	},
 	{
 		"type": "MSGSET",
@@ -405,7 +405,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0060.",
 		"TextJPN": "「……ぅぅ、………う…………」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``......Uuu......... .........Uu............``"
+		"TextENG": "``......Nnh ......nh.........``"
 	},
 	{
 		"type": "MSGSET",
@@ -414,31 +414,31 @@
 		"PreTextTags": "@vS25/09/NTAK_0000.",
 		"TextJPN": "「起きた…？　ジロウさん」",
 		"NamesENG": "Takano",
-		"TextENG": "``Are you awake... Jirou-san?``"
+		"TextENG": "``You awake...? Jirou-san.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154354,
 		"TextJPN": "アンモニアの小瓶を嗅がされたのだ。",
-		"TextENG": "He is given a sniff from a small bottle of ammonia."
+		"TextENG": "He had been forced to breathe in from an ammonia bottle."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154355,
 		"TextJPN": "富竹は鉛のように重い体を揺すりながら、ゆっくりと鷹野を見上げる……。",
-		"TextENG": "Tomitake shakes his heavy body like lead, and looks up slowly at Takano......"
+		"TextENG": "Tomitake's body wavered like heavy lead as he slowly looked up at Takano......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154356,
 		"TextJPN": "足を動かそうとして、ジャラリと冷たく重い感触を覚える。",
-		"TextENG": "He attempts to move his legs, trying to remember that cold and heavy feel."
+		"TextENG": "He tried to move his legs, but felt a cold, heavy sensation against them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154357,
 		"TextJPN": "見れば、足首に手錠が掛けられ、配管に括りつけられていた。",
-		"TextENG": "If you look, the handcuffs are placed on his ankles, they have been tied to a pipe."
+		"TextENG": "Looking down, there were handcuffs on his ankles that were fastened to the pipes."
 	},
 	{
 		"type": "MSGSET",
@@ -447,7 +447,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0070.",
 		"TextJPN": "「あぁ、鷹野さん……。これは一体、何の冗談かな……」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Takano-san...... What kind of joke is this......``"
+		"TextENG": "``Takano-san...... What kind of joke is this......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -456,7 +456,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0010.",
 		"TextJPN": "「冗談？　……くすくす、とんでもない。これは、本当の天の啓示なの」",
 		"NamesENG": "Takano",
-		"TextENG": "``A joke? Heh heh, not at all. This is a true revelation from the heavens.``"
+		"TextENG": "``Joke? ......Heehee, heavens, no. This is truly a divine revelation.``"
 	},
 	{
 		"type": "MSGSET",
@@ -465,7 +465,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0080.",
 		"TextJPN": "「……何の話だい………」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``......What are you talking about......``"
+		"TextENG": "``......What are you talking about.........?``"
 	},
 	{
 		"type": "MSGSET",
@@ -474,25 +474,25 @@
 		"PreTextTags": "@vS25/09/NTAK_0020.",
 		"TextJPN": "「私が神に選ばれたのよ。……そう。これは全て、天の啓示……」",
 		"NamesENG": "Takano",
-		"TextENG": "``I was chosen by God. ......Yes. All of this is simply the revelation of heavens......``"
+		"TextENG": "``I've been chosen by God. ......Yes. This was all a divine revelation......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154362,
 		"TextJPN": "鷹野の目は、まるで熱病に浮かされているかのようだった。",
-		"TextENG": "The eyes of Takano seem to be totally feverly delirious."
+		"TextENG": "Takano's eyes looked like she was delirious with fever."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154363,
 		"TextJPN": "彼女自身は、この上なく冷静なつもりなのだろう。",
-		"TextENG": "She herself must think she's calm."
+		"TextENG": "Though she herself was probably calmer than ever."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154364,
 		"TextJPN": "しかし、富竹の目には、まるで悪い酒で白昼夢にでも酔っているかのように見えるのだ……。",
-		"TextENG": "But for Tomitake his gaze was as if he was after heavy alcohol drinking......"
+		"TextENG": "Still, to Tomitake's eyes, she looked like she was drunk on some strong liquor and caught up in a daydream......"
 	},
 	{
 		"type": "MSGSET",
@@ -501,7 +501,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0090.",
 		"TextJPN": "「落ち着いて欲しいな……。そして、僕にもわかるように話してくれないかい」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``I want you to calm down...... And tell me something I can understand.``"
+		"TextENG": "``I wish you would calm down...... Could you explain this so I can understand?``"
 	},
 	{
 		"type": "MSGSET",
@@ -510,7 +510,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0030.",
 		"TextJPN": "「………そうね。考えてもみれば、ジロウさんにもわかるように話すのはあまりに難しいことだったわ。でも、あなたに言わずにはいられなかったのよ。たとえ、あなたに意味がわからないとしてもね」",
 		"NamesENG": "Takano",
-		"TextENG": "``.........Fine. Look and I may consider it, although I know that it may be difficult for you to speak, Jirou-san. But, I can't say no to you. Even though, you may not understand.``"
+		"TextENG": "``......Yes. Thinking about it, it wouldn't be that hard to explain in a way you can understand. But I must tell you. Even if you don't understand what it means at all.``"
 	},
 	{
 		"type": "MSGSET",
@@ -519,7 +519,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0100.",
 		"TextJPN": "「………それでも、僕に話したいと思ってくれたんだね。……少し光栄だよ」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``.........Still, for you to want to talk with me. ......I feel slightly honored.``"
+		"TextENG": "``.........So you still want to tell me, then? ......I'm a little honored.``"
 	},
 	{
 		"type": "MSGSET",
@@ -528,7 +528,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0040.",
 		"TextJPN": "「くす。ありがとう。そう言ってくれて。……やはりジロウさんは、私にとって特別な人なんだわ」",
 		"NamesENG": "Takano",
-		"TextENG": "``Hee hee hee. Thank you. If you say so. ......After all, you are a special person to me, Jirou-san.``"
+		"TextENG": "``Heehee. Thank you. For saying that. ......You really are a special person, Jirou-san.``"
 	},
 	{
 		"type": "MSGSET",
@@ -537,7 +537,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0110.",
 		"TextJPN": "「その特別な人を、こんなところに縛り付けるのかい？」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``So, are you the one who tied this special person to such a place?``"
+		"TextENG": "``And you'd tie this special person up in a place like this?``"
 	},
 	{
 		"type": "MSGSET",
@@ -546,7 +546,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0050.",
 		"TextJPN": "「新しい世界に、世界が生まれ変わるまでの間、ここで大人しくしていて欲しいのよ」",
 		"NamesENG": "Takano",
-		"TextENG": "``For a new world, so until this world is reborn, I want you stay here and behave yourself.``"
+		"TextENG": "``I want you to stay here until the world is finished transforming into a new one.``"
 	},
 	{
 		"type": "MSGSET",
@@ -555,7 +555,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0120.",
 		"TextJPN": "「君は何を企んでいるんだい……」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``What are you plotting......?``"
+		"TextENG": "``What are you plotting...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -564,19 +564,19 @@
 		"PreTextTags": "@vS25/09/NTAK_0060.",
 		"TextJPN": "「企みじゃないわ。天の啓示よ、私は神に選ばれた………！」",
 		"NamesENG": "Takano",
-		"TextENG": "``It is not a plot. By the revelation of heavens, I was chosen by God.........!``"
+		"TextENG": "``No plot this time. It's a divine revelation. I've been chosen by God......!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154373,
 		"TextJPN": "富竹も愚かではない。",
-		"TextENG": "Tomitake is also not stupid."
+		"TextENG": "Tomitake wasn't a fool."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154374,
 		"TextJPN": "このやりとりから、鷹野が何を目論んでいるか、おぼろげに悟る。",
-		"TextENG": "From this exchange, about Takano's scheme, he has realized it vaguely."
+		"TextENG": "He had a vague idea of what Takano was plotting from that exchange."
 	},
 	{
 		"type": "MSGSET",
@@ -585,7 +585,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0130.",
 		"TextJPN": "「まさか君は、恐ろしいことを引き起こそうとしているんじゃないだろうね……？」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``No way, are you trying to cause such a terrible thing......?``"
+		"TextENG": "``Don't tell me you're trying to cause something terrifying to occur, are you...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -594,7 +594,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0070.",
 		"TextJPN": "「恐ろしいことは起こるかもしれない。でも、神の啓示だもの。きっとこれは素晴らしいことが始まる予感なの」",
 		"NamesENG": "Takano",
-		"TextENG": "``Something terrible may happen. But, it is the revelation of God. Surely this is the beginning of wonderful things to come.``"
+		"TextENG": "``There might be something terrifying indeed. But it's God's revelation. I have a feeling something wonderful is about to happen too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -603,7 +603,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0140.",
 		"TextJPN": "「……研究中のウィルスを、持ち出そうというつもりじゃないだろうね？」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``......Are you trying to say you intend to take this virus you are studying?``"
+		"TextENG": "``......You're not planning to take the virus we're researching out of here, are you?``"
 	},
 	{
 		"type": "MSGSET",
@@ -612,7 +612,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0080.",
 		"TextJPN": "「くすくす。きっと、私はこの日の為に研究をさせられていたのだわ。神は、私を選んだ。私の崇高な使命を、理解して下さった…！！」",
 		"NamesENG": "Takano",
-		"TextENG": "``Heh heh. Certainly, my research has led me to this day. God chose me. God understands my noble mission...!!``"
+		"TextENG": "``Heehee, heehee. I'm positive that all of our research has been for the sake of this day. God has chosen me. He understands my noble purpose...!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -621,7 +621,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0150.",
 		"TextJPN": "「やめるんだ…！　誰が君をそそのかしたのか知らないが、それは天の啓示じゃない！　悪魔の囁きだ！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Stop this...!  I don't know who seduced you, but this is not the revelation of heaven! It's a whisper from the devil!``"
+		"TextENG": "``Stop it...! I don't know who's instigated this, but that's not a divine revelation! It's the whisper of a devil!``"
 	},
 	{
 		"type": "MSGSET",
@@ -630,31 +630,31 @@
 		"PreTextTags": "@vS25/09/NTAK_0090.",
 		"TextJPN": "「悪魔なんて、酷いことを言うわねぇ。……あなたには、この神々しい姿が見えないのかしら？　まぁ、見えないわよね。凡人のあなたには。くすくすくすくす……」",
 		"NamesENG": "Takano",
-		"TextENG": "``The devil, don't say such cruel things. ......Can you not see this divine figure? Well, if you cannot see it, then you are just an ordinary man. Heh heh heh heh......``"
+		"TextENG": "``A devil? What a cruel thing to say. ......Perhaps you can't see their divine glory? Well, of course you can't. You're just an average person. Heehee, heehee, heehee......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154381,
 		"TextJPN": "鷹野は懐から何かを取り出し、それを富竹に放る。",
-		"TextENG": "Takano takes out something from her breast pocket, and throws it at Tomitake."
+		"TextENG": "Takano pulled something out of her pocket and tossed it to Tomitake."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154382,
 		"TextJPN": "それは、注射器と薬の小瓶が収められた小箱だった。",
-		"TextENG": "It is a small box with a syringe and a small bottle of medicine inside."
+		"TextENG": "It was a box with a syringe and a bottle of medicine."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154383,
 		"TextJPN": "見覚えがある。雛見沢症候群の新型予防薬だ。",
-		"TextENG": "I recognise this. It's the new prophylactic medicine of the Hinamizawa Syndrome."
+		"TextENG": "He recognized it. It was the new prophylactic for the Hinamizawa Syndrome."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154384,
 		"TextJPN": "もっとも、まだ研究中のもののはずだが……。",
-		"TextENG": "In fact, this thing should still be in research......"
+		"TextENG": "Though that was only supposed to be in development still......"
 	},
 	{
 		"type": "MSGSET",
@@ -663,7 +663,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0100.",
 		"TextJPN": "「もしも。……ジロウさんが新しい世界を見てみたいと思うなら。それを注射なさい。……運が良ければ、ジロウさんは急性発症を逃れることが出来るでしょうよ」",
 		"NamesENG": "Takano",
-		"TextENG": "``......If you want to look at the new world, Jirou-san, inject yourself with it. ......If you are lucky, you may escape an acute crisis.``"
+		"TextENG": "``If... If you would like to witness the new world, then inject that into yourself. ......If you're fortunate, then you'll avoid an acute outbreak.``"
 	},
 	{
 		"type": "MSGSET",
@@ -672,49 +672,49 @@
 		"PreTextTags": "@vS25/08/NTOM_0160.",
 		"TextJPN": "「やめるんだッ。今ならまだ取り返しがつく！　僕と話し合おう！　まずはこの手錠を外してくれ！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Stop. We can still undo this! Just talk it over with me! But first take off these handcuffs!``"
+		"TextENG": "``Stop this! You can still turn back from this! Talk this out with me! And undo these handcuffs first!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154387,
 		"TextJPN": "鷹野は足元に置いてあるアタッシュケースをゆっくりと持ち上げる。",
-		"TextENG": "Takano slowly lifts the attache case and puts it at my feet."
+		"TextENG": "Takano slowly lifted the attache case sitting at her feet."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154388,
 		"TextJPN": "ただのアタッシュケースではない。η１７３を輸送する為の、特別なアタッシュケースだ。",
-		"TextENG": "However, this is not just an ordinary attache case. But a special attache case designed to transport η-173."
+		"TextENG": "It wasn't an ordinary attache case, though. It was a special one, used to transport η173."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154389,
 		"TextJPN": "あの中身をぶちまけたら、広範囲の人々が雛見沢症候群に罹患し、やがてはＬ５に至り、恐ろしい惨事を引き起こすのだ。",
-		"TextENG": "If she dumps those contents, an extensive amount of people would contract the Hinamizawa Syndrome, eventually leading to an L5 outbreak, causing a terrible disaster."
+		"TextENG": "If she spread its contents through the air, then a wide range of people would contract Hinamizawa Syndrome, eventually reach L5, and cause a terrifying disaster."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154390,
 		"TextJPN": "鷹野にとって、雛見沢症候群の研究は、彼女の祖父の偉業を知らしめることで、神に列することが出来る神聖な行為だ。それは知っている。",
-		"TextENG": "For Takano, the study of the Hinamizawa Syndrome is for showing the world the greatest achievement of her grandfather, a sacred act that only God can take part in. That much I know."
+		"TextENG": "For Takano, researching the Syndrome was her way of proving her grandfather's great work to be true, so it was a holy act, akin to worshipping god."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154391,
 		"TextJPN": "しかし、雛見沢症候群のアウトブレイクによって、恐ろしい終末を引き起こすことが目的ではなかったはず……。",
-		"TextENG": "However, causing an outbreak of the Hinamizawa syndrome will only lead to a terrible end......"
+		"TextENG": "He knew that. Yet an outbreak of Hinamizawa Syndrome and the terrifying ruin that would bring about should not be her goal......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154392,
 		"TextJPN": "彼女がどんな妄想に取り憑かれたのかは、想像も出来ない。",
-		"TextENG": "Whether she's obsessed in some delusion or not, I can't imagine."
+		"TextENG": "He couldn't even imagine what sort of delusions had come to possess her."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154393,
 		"TextJPN": "しかし、彼女はやる気だ。……何の躊躇いもなく。",
-		"TextENG": "However, she is motivated. ......And will act without hesitation."
+		"TextENG": "But she was prepared to do it. ......Without hesitation."
 	},
 	{
 		"type": "MSGSET",
@@ -723,7 +723,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0110.",
 		"TextJPN": "「じゃあね、ジロウさん。運が良ければ、また。……ここは防災倉庫だから、ジロウさんの手の届く範囲には水も食料もあるでしょう」",
 		"NamesENG": "Takano",
-		"TextENG": "``Bye, Jiro-san. You may still get lucky. ......Because you are here in the diaster prevention warehouse, with water and food in reach of your hands, Jirou-san.``"
+		"TextENG": "``See you later, Jirou-san. If you're lucky, we'll meet again. ......Since this is an emergency storage room, you should find food and water within your reach.``"
 	},
 	{
 		"type": "MSGSET",
@@ -732,19 +732,19 @@
 		"PreTextTags": "@vS25/09/NTAK_0120.",
 		"TextJPN": "「ジロウさんなら、きっと手錠だって何とか出来るはず。たとえ、この扉を外から施錠したとしてもね？」",
 		"NamesENG": "Takano",
-		"TextENG": "``So, Jirou-san, I'm sure you'll be able to do it somehow even with those handcuffs. However, I will be locking the door from the outside.``"
+		"TextENG": "``Knowing you, you'll be able to take care of those handcuffs too. Even if I lock this door from the outside, right?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154396,
 		"TextJPN": "富竹なら、時間さえ与えられるなら、必ずこの手錠を外すことが出来るだろう。",
-		"TextENG": "Tomitake, given the time, will be able to remove those handcuffs by any means."
+		"TextENG": "As long as he had time, then Tomitake was certain he could break out of the handcuffs."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154397,
 		"TextJPN": "しかし、それは鷹野の恐ろしい野望を実行に移す十分な時間を与えてしまうのだ……。",
-		"TextENG": "However, this will give enough time for Takano to put her terrible ambition into practice......"
+		"TextENG": "But that would grant Takano plenty of time to carry out her terrifying ambition......"
 	},
 	{
 		"type": "MSGSET",
@@ -753,7 +753,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0170.",
 		"TextJPN": "「待てッ、待つんだ、鷹野さん！！　待てぇええぇええええぇ！！　君は世界を滅ぼすつもりなのかッ！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Wait, wait, Takano-san!! Waiiiiiiiiit!! Do you intend to destroy the world!``"
+		"TextENG": "``Wait! Hold on, Takano-san!! Waaaaaaaaaaaaaaaaiiiiiiiiiiit!! Are you planning to destroy the world?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -762,7 +762,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0130.",
 		"TextJPN": "「とんでもない。……私は神の啓示を受け、人類を救済する為に行くのよ？　この、可愛い子たちを一斉に羽ばたかせるの！」",
 		"NamesENG": "Takano",
-		"TextENG": "``Far from it. ......I shall receive a revelation from God, or don't you want me to go and rescue the human race? Because with this all the cute children will flap their wings in unison!``"
+		"TextENG": "``Heavens, no. ......I'm going to save humanity, as God has revealed to me. By letting his cute little children here fly free!``"
 	},
 	{
 		"type": "MSGSET",
@@ -771,7 +771,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0180.",
 		"TextJPN": "「それは悪魔の囁きだ！　耳を貸しちゃいけない！！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``It's a whisper from the devil! You musn't pay attention!!``"
+		"TextENG": "``That's the whisper of the devil! You mustn't listen to it!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -780,7 +780,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0140.",
 		"TextJPN": "「悪魔はね、他にいるそうなのよ」",
 		"NamesENG": "Takano",
-		"TextENG": "``The devil seems to be elsewhere.``"
+		"TextENG": "``I hear the devil is elsewhere.``"
 	},
 	{
 		"type": "MSGSET",
@@ -789,7 +789,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0190.",
 		"TextJPN": "「え？」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Eh?``"
+		"TextENG": "``Huh?``"
 	},
 	{
 		"type": "MSGSET",
@@ -798,7 +798,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0150.",
 		"TextJPN": "「人類を滅ぼそうとする悪魔が、現れたそうなの。……神は言ったわ。それを阻止できるのは私しかいないって」",
 		"NamesENG": "Takano",
-		"TextENG": "``The devil who will try to destroy the human race had already materialised. ......And God said, that the only one who can prevent it is me.``"
+		"TextENG": "``The devil trying to destroy humanity has already appeared. ......God told me. And he told me I'm the only one who can stop it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -807,7 +807,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0200.",
 		"TextJPN": "「君のしようとしていることこそ、悪魔の所業だ！　たぶらかされてはいけない！！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``What they are trying to make you do is the devil's work! Don't be deceived by them!!``"
+		"TextENG": "``What you're about to do really is the work of the devil! Don't let yourself be fooled by him!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -816,7 +816,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0160.",
 		"TextJPN": "「大丈夫よ。だって、私は常に神とあるんだもの。……じゃあね、私は興宮へ行くわ。そこにいるのね？」",
 		"NamesENG": "Takano",
-		"TextENG": "``I'll be alright. Because God will always be here with me. ......Well then, I'm off to Okinomiya. Stay put, okay?"
+		"TextENG": "``Don't worry. After all, God is always with me. ......Farewell. I'm going to Okinomiya. You're there, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -825,7 +825,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0170.",
 		"TextJPN": "「えぇ、わかっているわ。くすくす、うふふふふふ……。はっはははははははははははは……！！」",
 		"NamesENG": "Takano",
-		"TextENG": "Yeah, I know what you were thinking. Heh heh, hee hee hee hee hee...... Aah ha ha ha ha ha ha ha ha ha ha ha ha......!!``"
+		"TextENG": "``Yes, I know. Heehee, heehee, ufufufufufu...... Hah hahahahahahahahahahahaha......!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -834,7 +834,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0200.",
 		"TextJPN": "「な、……何ということでしょう……。あぅあぅあぅ……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......Wh-What is she planning to do...... Au au au......``"
+		"TextENG": "``Wha... How could this be...? Auauau......``"
 	},
 	{
 		"type": "MSGSET",
@@ -843,7 +843,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0350.",
 		"TextJPN": "「案の定というか、性懲りもなくというか。……また、あいつなわけね」",
 		"NamesENG": "Rika",
-		"TextENG": "``What she said was expected, or rather incorrigible. ......Still, he said she has her reasons.``"
+		"TextENG": "``As expected, I guess. That woman never learns. ......So it's her fault again.``"
 	},
 	{
 		"type": "MSGSET",
@@ -852,61 +852,61 @@
 		"PreTextTags": "@vS25/08/NTOM_0210.",
 		"TextJPN": "「遅かったか……。何てことだ………」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Are we too late......? Can we do anything.........?``"
+		"TextENG": "``We're too late......? What a disaster......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154410,
 		"TextJPN": "富竹は、事件の直前に鷹野に捕らえられ、今日までずっと閉じ込められていたのだ。",
-		"TextENG": "Tomitake was seized by Takano just before this incident, so to date, he has been shut in here since."
+		"TextENG": "Tomitake was captured right before the incident, and had been shut inside here up until today."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154411,
 		"TextJPN": "もう、全てが遅い。鷹野はその感染を、すでに村の外にまで広げている。",
-		"TextENG": "Already, we are late. Takano and the infection have already spread outside the village."
+		"TextENG": "It was all too late for him to do anything. Takano had already spread the infection far beyond the village."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154412,
 		"TextJPN": "いや、ひょっとしたらもう、市内全域か、あるいは県内全域にまで及んでいるかもしれない……。",
-		"TextENG": "No, perhaps the entire city, or even the whole prefecture......"
+		"TextENG": "Maybe she's already spread it to the entire city or even the entire prefecture......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154413,
 		"TextJPN": "梨花が話す現状に、富竹は首を何度も横に振った。",
-		"TextENG": "To the current situation Rika talks about, Tomitake shakes his head many times."
+		"TextENG": "Tomitake shook his head many times as Rika described the present situation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154414,
 		"TextJPN": "受け入れ難い現実だろうが、研究員たちの死体が転がる凄惨な光景が、有無を言わせなかった……。",
-		"TextENG": "This is our unacceptable reality, the researchers killed one another, or gruesomely took their own lives......"
+		"TextENG": "The reality was hard for him to accept, but the gruesome sight of the researchers who murdered each other or took their own lives wouldn't permit him to consider otherwise......."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154415,
 		"TextJPN": "富竹は保安室に入り、無線機をいじるが、外部との連絡は取れそうになかった。",
-		"TextENG": "Tomitake enters the security room, and tampers with the transceivers, but there seems to be no contact with the outside."
+		"TextENG": "Tomitake entered the security room and started fiddling with the radio, but it didn't look like he was going to be able to contact anyone outside."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154416,
 		"TextJPN": "緊急時のマニュアルで、雛見沢症候群のアウトブレイクが発生した場合には、混乱の拡大を防ぐ為、妨害電波で市内全域が無線妨害されることになっている。",
-		"TextENG": "In the emergency manual, if an outbreak of the Hinamizawa Syndrome occurs, in order to prevent confusion, the entire city is jammed with radio interference."
+		"TextENG": "According to the emergency manual, in the event of an outbreak of Hinamizawa Syndrome, they are to employ jamming waves throughout the region in order to prevent the spread of chaos."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154417,
 		"TextJPN": "もちろん電話も不通。",
-		"TextENG": "Of course, telephones are also cut off."
+		"TextENG": "Of course, the phone lines were down too."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154418,
 		"TextJPN": "鷹野が元凶であるという重要な情報を、外部へ伝えることは出来なかった……。",
-		"TextENG": "So, the important information that Takano is the main cause of all this, is not able to be transmitted to the outside......"
+		"TextENG": "So there was no way to get the crucial information about Takano's involvement to those outside......"
 	},
 	{
 		"type": "MSGSET",
@@ -915,7 +915,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0220.",
 		"TextJPN": "「……どうやら、ハザードレベルはＸ２で進行しているようだね」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``......It seems that the hazard level will progress into X2.``"
+		"TextENG": "``......Apparently they've already escalated to Hazard Level X2.``"
 	},
 	{
 		"type": "MSGSET",
@@ -924,7 +924,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0360.",
 		"TextJPN": "「それは何のことなのですか？」",
 		"NamesENG": "Rika",
-		"TextENG": "``What is that?``"
+		"TextENG": "``What does that mean?``"
 	},
 	{
 		"type": "MSGSET",
@@ -933,7 +933,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0230.",
 		"TextJPN": "「鹿骨市内にまで雛見沢症候群が拡散したということさ。現在は市外と隔離され、橋は全て落とされているはずだ。……その間に、東京が何か手を打てるといいんだけどね」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``It's enacted if Hinamizawa Syndrome would spread to Shishibone city. By now, they've probably already isolated the suburbs, and destroyed all the bridges. Meanwhile, Tokyo will take the appropriate steps.``"
+		"TextENG": "``It means the Syndrome has spread to Shishibone City. At present the city is quarantined off from the outside, and all of the bridges have been blocked off. ......Hopefully Tokyo manages to do something with that time.``"
 	},
 	{
 		"type": "MSGSET",
@@ -942,7 +942,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0370.",
 		"TextJPN": "「ボクたちは、待っていることしか出来ないのですか？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Do we just wait then?``"
+		"TextENG": "``So all we can do is wait?``"
 	},
 	{
 		"type": "MSGSET",
@@ -951,25 +951,25 @@
 		"PreTextTags": "@vS25/08/NTOM_0240.",
 		"TextJPN": "「残念ながら、そういうわけにはいかないんだ。……鷹野さんを、野放しには出来ない」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Unfortunately, I can't tell you that. ......Takano-san can't go unchecked.``"
+		"TextENG": "``Unfortunately, that's not the case. ......We can't leave Takano-san on the loose.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154424,
 		"TextJPN": "彼女は言った。",
-		"TextENG": "She said"
+		"TextENG": "She had said,"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154425,
 		"TextJPN": "人類を滅ぼそうとする悪魔が現れた。",
-		"TextENG": "that the devil who is going to destroy the human race has appeared."
+		"TextENG": "``A devil has appeared to destroy humanity."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154426,
 		"TextJPN": "私は興宮へ行くわ。そこにいるのね……？",
-		"TextENG": "And that she is going to Okinomiya. But why there......?"
+		"TextENG": "I'm heading to Okinomiya. That's where you are, isn't it......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -978,7 +978,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0250.",
 		"TextJPN": "「彼女の定義する悪魔が何なのかはわからない。でも、」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``I don't know who this devil she defines is. But...``"
+		"TextENG": "``I don't know what she's calling a devil, but...``"
 	},
 	{
 		"type": "MSGSET",
@@ -987,7 +987,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0380.",
 		"TextJPN": "「……あんにゃろうの好き放題に、これ以上させることは出来ないわね」",
 		"NamesENG": "Rika",
-		"TextENG": "``......She's self-indulging herself, we can't let her do it any longer.``"
+		"TextENG": "``......We can't afford to let her have her way any more than she already has, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -996,7 +996,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0260.",
 		"TextJPN": "「そういうことだね。……鷹野さんは恐らく、市内にまだいるはずだ」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``That's what I'm talking about. ......Takano-san's probably still in the city.``"
+		"TextENG": "``That's right. ......Takano-san is most likely still within the city.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1005,7 +1005,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0210.",
 		"TextJPN": "「橋が全て落とされているから、鷹野も出られないのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``But since all the bridges have been destroyed, Takano can't leave.``"
+		"TextENG": "``If the bridges have been blocked off, then Takano can't get out either.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1014,7 +1014,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0270.",
 		"TextJPN": "「彼女がη１７３を市外へも拡散するつもりなら、何としても捕らえなければならない。彼女は、興宮にいるはずだ」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``If she intends to scatter η-173 in the suburbs, we must stop her at any cost. She should still be in Okinomiya.``"
+		"TextENG": "``If she's planning to take η173 and spread it beyond the city, then she can't afford to be captured. She should still be in Okinomiya.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1023,7 +1023,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0390.",
 		"TextJPN": "「富竹。ボクも手伝うのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``Tomitake. I'll help you.``"
+		"TextENG": "``Tomitake. I'll help too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1032,7 +1032,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0280.",
 		"TextJPN": "「危険だよ。君はここに隠れていた方がいい」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``It's dangerous. You're better off hiding here.``"
+		"TextENG": "``It's dangerous. You should hide down here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1041,7 +1041,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0400.",
 		"TextJPN": "「いくら富竹でも、今の興宮は危険だと思いますのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``No matter what, Tomitake, we know the dangers of entering Okinomiya.``"
+		"TextENG": "``Right now Okinomiya is dangerous even for you, Tomitake.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1050,7 +1050,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0220.",
 		"TextJPN": "「興宮は若者が多い……。鬼に心を明け渡した者の危険度も違うでしょう」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``There are also many youths in Okinomiya...... The risk will be different when facing those who have surrendered their heart to the demon.``"
+		"TextENG": "``There are a lot of young people in Okinomiya...... They'll be much more dangerous after handing their heart over to the demon.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1059,7 +1059,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0410.",
 		"TextJPN": "「ボクは女王感染者なのです。ボクには確か、近くの感染者を沈静化する力があったはずなのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``I am the Queen of the infected people. So certainly with me around, the infected people will be forced to calm down.``"
+		"TextENG": "``I'm the queen carrier. If I'm not mistaken, I should have the power to calm down nearby infected.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1068,7 +1068,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0290.",
 		"TextJPN": "「……そういえば、そうだったねぇ。………………」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``......Now that you mention it, you're probably right.``"
+		"TextENG": "``......Now that you mention it, I suppose that's true. ...............``"
 	},
 	{
 		"type": "MSGSET",
@@ -1077,7 +1077,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0420.",
 		"TextJPN": "「ボクにレディーファーストを気取るより、鷹野を捕らえ、さらなる被害を食い止める方が最優先なのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``Put on airs that ladies first, capturing Takano should be our top priority to stave off any further damage.``"
+		"TextENG": "``Trying to be a gentleman toward me is less important than capturing Takano and preventing the further spread of harm.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1086,7 +1086,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0300.",
 		"TextJPN": "「しかし、君にもしものことがあったら……」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``However, if anything should happen to you......``"
+		"TextENG": "``Still, if anything were to happen to you......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1095,43 +1095,43 @@
 		"PreTextTags": "@vS25/05/NRIK_0430.",
 		"TextJPN": "「すでに最悪の事態は起こっていますのです。ボクが死んでしまっても、これ以上、悪くはならないのですよ？」",
 		"NamesENG": "Rika",
-		"TextENG": "``The worst situation has already happened. So even if I die, the situation can't get any worse, don't you understand that?``"
+		"TextENG": "``The worst possible outcome is already happening. Even if I were to die, things wouldn't get any worse than they already are.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154441,
 		"TextJPN": "梨花に万一のことがあってはならないのは、このような事態を防ぐ為だ。",
-		"TextENG": "Nothing should ever happen to Rika, in order to prevent such a situation."
+		"TextENG": "Preventing this situation was exactly why they had to prevent disaster from befalling Rika."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154442,
 		"TextJPN": "しかし、梨花が死なずともすでに最悪の事態である、集団Ｌ５発症は起こってしまっている。",
-		"TextENG": "However, even if Rika dies, the worst situation has already happened, as the population is developing L5."
+		"TextENG": "But their worst fear - a mass outbreak of Level 5 symptoms - was already taking place without Rika's death."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154443,
 		"TextJPN": "……なるほど。これ以上、悪くなりようがないのも一理ある。",
-		"TextENG": "......I see. The situation can't get any worse is the truth."
+		"TextENG": "......It made sense to him. Logically, the situation couldn't worsen."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154444,
 		"TextJPN": "それに、鷹野を放置すれば、さらにこれ以上の最悪の事態もあり得るのだ。",
-		"TextENG": "Moreover, if we leave Takano as she is, there's a chance the situation will get even worse."
+		"TextENG": "Besides, if Takano remained at large, it was likely that things would become even more disastrous."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154445,
 		"TextJPN": "日本中に雛見沢症候群をまき散らすか。",
-		"TextENG": "She intents to scatter the Hinamizawa syndrome all across Japan."
+		"TextENG": "Either she would spread Hinamizawa Syndrome throughout Japan..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154446,
 		"TextJPN": "さもなくば、彼女の言うところの「悪魔」を阻止されてしまうのか。",
-		"TextENG": "Otherwise, this ``devil`` she speaks off can't be stopped."
+		"TextENG": "Or this thing she called a ``devil`` would move to interfere."
 	},
 	{
 		"type": "MSGSET",
@@ -1140,7 +1140,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0440.",
 		"TextJPN": "「鷹野にとっての悪魔なら、……敵の敵は味方ということなのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``This devil Takano speaks of...... You know what they say, the enemy of my enemy is my friend.``"
+		"TextENG": "``If they're a devil for Takano... then the enemy of our enemy is our ally.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1149,7 +1149,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0310.",
 		"TextJPN": "「……確かにそれも一理あるね。わかったよ。こうして議論する時間も惜しいね」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``......You certainly have a point. I understand. Time is precious, we shouldn't argue on this.``"
+		"TextENG": "``......You have a point there. Alright. We don't have time to waste on debates.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1158,7 +1158,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0450.",
 		"TextJPN": "「止めないでよ、羽入。これも世界を救う為よ？」",
 		"NamesENG": "Rika",
-		"TextENG": "``We have to stop them, Hanyuu. Ready to save the world?``"
+		"TextENG": "``Don't stop me, Hanyuu. I'm doing this to save the world, you know?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1167,7 +1167,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0230.",
 		"TextJPN": "「あぅあぅ……。梨花が面白がってるように思いますです……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Au au...... I think you're amused by this, Rika......``"
+		"TextENG": "``Auau...... It looks like you're enjoying this......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1176,31 +1176,31 @@
 		"PreTextTags": "@vS25/08/NTOM_0320.",
 		"TextJPN": "「行こう。鷹野さんを探しにっ」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Let's go. We have to look for Takano-san.``"
+		"TextENG": "``Let's go, to find Takano-san!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154452,
 		"TextJPN": "富竹は診療所の車を拝借することにする。",
-		"TextENG": "It's decided, so we and Tomitake borrow a car from the clinic."
+		"TextENG": "Tomitake borrowed a car parked at the clinic."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154453,
 		"TextJPN": "このようなゾンビアポカリプス的世界において、車は動くシェルターも同然だ。後部座席に唐突にゾンビがスポーンしない限り。",
-		"TextENG": "In such a zombie apocapylse world, using a car can double as shelter. As long as a zombie doesn't abruptly spawn in the back seat though."
+		"TextENG": "In this world not dissimilar from a zombie apocalypse, a car was the same as a moving shelter. So long as no zombies sprang up from the back seat."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154454,
 		"TextJPN": "車は今、興宮に向かっている。",
-		"TextENG": "In the car, they now head to Okinomiya."
+		"TextENG": "The car was heading into Okinomiya."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154455,
 		"TextJPN": "梨花たちは後部座席でくつろいでいた……。",
-		"TextENG": "Rika and Hanyuu seem to be relaxing in the back seats......"
+		"TextENG": "Rika and Hanyuu were relaxing in the back seat......"
 	},
 	{
 		"type": "MSGSET",
@@ -1209,7 +1209,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0460.",
 		"TextJPN": "「雛見沢でのんびりと事態が収まるのを待つつもりだったけど、気が変わったわ。……鷹野のヤツの思惑なら、邪魔しないわけにはいかないもの」",
 		"NamesENG": "Rika",
-		"TextENG": "``I had originally intended to leisurely wait for the situation to calm itself in Hinamizawa, but I've changed my mind. ......If his speculations about Takano are correct, then we can't sit idly by.``"
+		"TextENG": "``I was planning to wait quietly for all of this to settle down back in Hinamizawa, but I've changed my mind. ......If this is Takano's plot, then I have to interfere.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1218,7 +1218,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0240.",
 		"TextJPN": "「しかし、鷹野がいう悪魔とは一体何なのでしょう……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``However, who on earth is this devil Takano speaks of......``"
+		"TextENG": "``Still, what on earth could this 'devil' of hers be......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1227,7 +1227,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0470.",
 		"TextJPN": "「さぁね。私たちのご同類かしらね」",
 		"NamesENG": "Rika",
-		"TextENG": "``Who knows. I wonder if it's someone like you.``"
+		"TextENG": "``Who knows. Maybe someone like us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1254,7 +1254,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0260.",
 		"TextJPN": "「………はい。……どうやら、ご同類のようなのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``.........Yes. ......It appears that, it's someone like me.``"
+		"TextENG": "``.........Yes. ......Apparently it is someone like us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1263,37 +1263,37 @@
 		"PreTextTags": "@vS25/05/NRIK_0490.",
 		"TextJPN": "「え？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Eh?``"
+		"TextENG": "``Huh?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154463,
 		"TextJPN": "車の中にいるはずなのに、……ふわっと、まるで魂だけが抜け出るような錯覚を味わう。",
-		"TextENG": "They should be in the car...... But, they softly drift and enjoy an illusion that comes from their souls."
+		"TextENG": "Though they had just been inside the car... it felt like their souls were floating up out of their bodies."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154464,
 		"TextJPN": "気付けば、梨花たちは白昼夢のような不思議な世界にいた。",
-		"TextENG": "There, Rika and Hanyuu enter a strange world as if they were daydreaming."
+		"TextENG": "Next thing they knew, Rika and Hanyuu found themselves in a strange, dreamlike world."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154465,
 		"TextJPN": "何事？　しかし、この感覚は………。",
-		"TextENG": "What is this? However, this feeling........."
+		"TextENG": "What was happening? That sensation........."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154466,
 		"TextJPN": "羽入の表情は、千年の昔を語る時のような、厳かなものに変わっていた……。",
-		"TextENG": "The expression of Hanyuu changes to a solemn thing, such as when she talks about the old days of a thousand years......"
+		"TextENG": "Hanyuu's expression had grown solemn, like when she spoke of her past a thousand years ago......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154467,
 		"TextJPN": "その時、霧のようなゆらめきが集まり、人型を作り出す……。",
-		"TextENG": "At that moment, fog begins to gather in the form of a humanoid......"
+		"TextENG": "That was when something akin to mist began to flicker and coalesce into human shape......"
 	},
 	{
 		"type": "MSGSET",
@@ -1302,7 +1302,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0500.",
 		"TextJPN": "「な、何？　誰……」",
 		"NamesENG": "Rika",
-		"TextENG": "``Wh-What? Who is it......``"
+		"TextENG": "``W-What? Who......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1311,31 +1311,31 @@
 		"PreTextTags": "@vS25/12/NHAN_0270.",
 		"TextJPN": "「……出来るなら、二度と会いたくなかった相手です」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......If possible, I wanted to never meet this companion again.``"
+		"TextENG": "``......It's someone I hoped to never see again.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154470,
 		"TextJPN": "百年の魔女の梨花でさえ戸惑う。",
-		"TextENG": "Even Rika, the witch of one hundred years is puzzled."
+		"TextENG": "Even the hundred year witch, Rika, was left bewildered."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154471,
 		"TextJPN": "羽入の口から、一度も聞いたことがない言葉だったからだ。",
-		"TextENG": "That is because, she had never heard those words from Hanyuu's mouth before."
+		"TextENG": "Because she had never heard Hanyuu utter those words before."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154472,
 		"TextJPN": "羽入が、二度と会いたくない相手………。",
-		"TextENG": "A companion Hanyuu never wanted to meet again........."
+		"TextENG": "Someone Hanyuu never wanted to see again......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154473,
 		"TextJPN": "霧の人型は……、人の形なれど、人ならざる者を形作る。",
-		"TextENG": "The humanoid fog...... forms the shape of a person unlike any other, a non-human."
+		"TextENG": "Human-shaped mist...... An inhuman being taking human form."
 	},
 	{
 		"type": "MSGSET",
@@ -1344,7 +1344,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0280.",
 		"TextJPN": "「……まさか、また相見えることになるとは。@bタムラヒメノミコト.@<田村媛命@>……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......Indeed, to meet once again, Tamurahime no Mikoto......``"
+		"TextENG": "``......To think we should meet again, Tamurahime-no-Mikoto......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1353,7 +1353,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0000.",
 		"TextJPN": "「角の民の長、羽入……。我輩こそ、そなたに再び相見えることなど望みはせぬ也や」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Leader of the nation of horns, Hanyuu...... I had hoped to never see the likes of you again.``"
+		"TextENG": "``Leader of the horned people, Hanyuu...... I have had no desire to meet with you once more.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1362,7 +1362,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0290.",
 		"TextJPN": "「その言葉、そのままお返しします。……あなたに、なぜに再びこうして会わねばならぬのか……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Those words, I will return them. ......To you, why must we meet in this way again......``"
+		"TextENG": "``I could return those exact same words. ......Why must I see you like this again......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1371,7 +1371,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0510.",
 		"TextJPN": "「……らしくもなく、敵意剥き出しね」",
 		"NamesENG": "Rika",
-		"TextENG": "``......This is unusual, such exposed hostility.``"
+		"TextENG": "``......You aren't usually so hostile.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1380,7 +1380,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0300.",
 		"TextJPN": "「私たちの存在を認めぬ、敵です。心を許してはなりません」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``It's unexpected for you to acknowledge our presence, adversary. You must be off guard.``"
+		"TextENG": "``We are enemies, who refuse to accept one another. You must not trust her.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1389,7 +1389,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0520.",
 		"TextJPN": "「バケモノ仲間の同族嫌悪ってわけね」",
 		"NamesENG": "Rika",
-		"TextENG": "``This spirit must be a companion from the same hated tribe as you.``"
+		"TextENG": "``I guess you monsters hate your own kind.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1398,37 +1398,37 @@
 		"PreTextTags": "@vS25/51/NTAM_0010.",
 		"TextJPN": "「我輩を角を隠せぬ鬼と同族呼ばわりとは許しがたきこと也や。身の程を弁え給え、角の民の巫女よ」",
 		"NamesENG": "Tamura",
-		"TextENG": "``It is unexpected for someone not a demon from the same tribe to talk to me and expect forgiveness. So know your place, shrine maiden of the nation of horns.``"
+		"TextENG": "``I will not permit you to call me the same as that demon not even hiding her horns. Know your place, priestess of the horned people.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154481,
 		"TextJPN": "彼女の鋭い眼光に、梨花に一度だけ頭痛が走る。",
-		"TextENG": "Her eyes sharply light up, Rika's head begins to ache."
+		"TextENG": "Rika got a sudden headache from her sharp gaze."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154482,
 		"TextJPN": "神通力だけでなく、冷え切った瞳には、痛みを覚えるほどの拒絶と蔑みが浮かんでいた……。",
-		"TextENG": "Not only are supernatural powers being used against her, but her eyes have also become cold, she refuses to give in and looks down in an attempt to bear the pain......"
+		"TextENG": "Her hardened eyes carried not only supernatural power, but enough rejection and scorn to cause physical pain......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154483,
 		"TextJPN": "……思えば、梨花はこれまで常に敬われてきた。",
-		"TextENG": "......In retrospect, Rika has always been one to be respected, until now."
+		"TextENG": "......Thinking back, Rika had only ever received constant respect."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154484,
 		"TextJPN": "幾百の死を越え、百年を生きようとも、……このような眼差しを向けられたことは、ただの一度もなかったのだ。",
-		"TextENG": "Even beyond the several hundred deaths, she's lived for over one hundred years...... But she's never felt such eyes directed at her, not even once."
+		"TextENG": "No matter how many hundreds of deaths or years she had lived through... she had never faced down such a hostile gaze before."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154485,
 		"TextJPN": "それを覚え、梨花は初めての感情に固唾を呑み込む……。",
-		"TextENG": "As if remembering, Rika swallows her saliva like it was her first feeling......"
+		"TextENG": "Rika could only gulp hard, in the face of that......"
 	},
 	{
 		"type": "MSGSET",
@@ -1437,7 +1437,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0020.",
 		"TextJPN": "「羽入。……なぜ我輩が姿を現したか、わかり申すか」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Hanyuu. ......You have to tell me why this person has appeared.``"
+		"TextENG": "``Hanyuu. ......Do you understand why I have appeared before you?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1455,43 +1455,43 @@
 		"PreTextTags": "@vS25/51/NTAM_0030.",
 		"TextJPN": "「この、眼下の惨状を何とする也や」",
 		"NamesENG": "Tamura",
-		"TextENG": "``I assume you have never seen such a terrible sight before.``"
+		"TextENG": "``What do you make of this disaster below us?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154489,
 		"TextJPN": "ゆっくりと、足元の霧が晴れていく。",
-		"TextENG": "Slowly, the fog begins to clear."
+		"TextENG": "Slowly, the mist cleared beneath their feet."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154490,
 		"TextJPN": "梨花はようやく理解した。ここは霧の中ではなく、雲の中だったのだ。",
-		"TextENG": "Rika finally understands. They were not inside a fog, but a cloud."
+		"TextENG": "Finally Rika understood. They weren't inside mist, but inside a cloud."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154491,
 		"TextJPN": "眼下には、飛行機から見下ろしたかのような景色が広がっていた。",
-		"TextENG": "They look below themselves, and see the spreading landscape as if looking down from an airplane."
+		"TextENG": "Below them was a sight like one might see from an airplane."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154492,
 		"TextJPN": "目を凝らさずとも、それが興宮の街であることがわかる……。",
-		"TextENG": "They look hard, and understand that it is the town of Okinomiya......"
+		"TextENG": "Even without straining their eyes, they could tell the city of Okinomiya was below......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154493,
 		"TextJPN": "街のあちこちから黒い煙があがり、それで薄暗いもやがかかっているのがわかる。",
-		"TextENG": "Black smoke rises from all over the town, causing a dusky haze to appear."
+		"TextENG": "Black smoke rose from various points in the city, and they could see a dark haze hanging over it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154494,
 		"TextJPN": "もっとよく目を凝らせば、通りで殺し合う、鬼に心を許した人々の姿も見ることが出来るだろう……。",
-		"TextENG": "They look closer, people are murdering one another on the streets, they have surrendered their hearts to the demon......"
+		"TextENG": "When they focused their eyes even more they could see the people who gave their hearts over to the demons killing each other in the streets......"
 	},
 	{
 		"type": "MSGSET",
@@ -1500,7 +1500,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0040.",
 		"TextJPN": "「何と醜き光景か……。己が罪に震えよ。全て、そなたの民の仕業也や。恥を知り給え、角の民の長よ」",
 		"NamesENG": "Tamura",
-		"TextENG": "``What an ugly sight...... You must be shaken after witnessing such a sin. After all, it is the act of your people. You should feel ashamed, leader of the nation of horns.``"
+		"TextENG": "``What an awful sight...... Shudder with the weight of your own sin. All of this is the work of your kind. Know shame, leader of the horned people.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1509,43 +1509,43 @@
 		"PreTextTags": "@vS25/12/NHAN_0320.",
 		"TextJPN": "「………………っ………」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``...........................``"
+		"TextENG": "``..................! .........``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154497,
 		"TextJPN": "梨花たち人間の目線から見れば、悪いのは鷹野だ。",
-		"TextENG": "From Rika and Hanyuu's human point of view, Takano is evil."
+		"TextENG": "From the perspective of humans like Rika, Takano was at fault."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154498,
 		"TextJPN": "しかし、羽入たち人ならざる者の目線から見れば、……眼下の惨状は全て、羽入たちの仕業なのだ。",
-		"TextENG": "However, judging Hanyuu from the perspective of this non-human...... all the devastation before our very eyes, is the work of Hanyuu."
+		"TextENG": "But from the perspective of inhuman beings like Hanyuu... the disaster below was all Hanyuu's fault."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154499,
 		"TextJPN": "η１７３そのものが、羽入たち、角の民でもあるのだから。",
-		"TextENG": "Because η-173 itself is Hanyuu, and the nation of horns."
+		"TextENG": "After all, η173 was Hanyuu. It was the horned people."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154500,
 		"TextJPN": "羽入は下唇を噛み締めたまま、何も言い返せない。",
-		"TextENG": "Hanyuu chews her lower lip, she has nothing to retort."
+		"TextENG": "Hanyuu bit her bottom lip, unable to refute her claims."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154501,
 		"TextJPN": "鷹野は角の民を凶暴にする研究を重ねていた。",
-		"TextENG": "Takano had been furiously studying the nation of horns."
+		"TextENG": "Takano had conducted the research to turn the horned people ferocious."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154502,
 		"TextJPN": "それは羽入の責任ではない。しかし、さりとて人ならざる者たちが、人に罪を転嫁することなど許されないのだ。",
-		"TextENG": "That was not Hanyuu's responsibility. However, having said that, who is this non-human, trying to charge her with such a crime."
+		"TextENG": "Hanyuu wasn't to blame for that. But that being said, these inhuman beings wouldn't allow a human to be blamed for that sin."
 	},
 	{
 		"type": "MSGSET",
@@ -1554,7 +1554,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0330.",
 		"TextJPN": "「……その責任は、……我らの手で取ります」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......The responsibility...... I take it with my hands.``"
+		"TextENG": "``......We shall take responsibility... with our own hands.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1563,7 +1563,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0050.",
 		"TextJPN": "「ならぬ。それは不要也や。不浄なる角の民がこれ以上、我らの地を穢すことは許さぬものと知り給え」",
 		"NamesENG": "Tamura",
-		"TextENG": "``That cannot solve anything. You are no longer necessary. The nation of horns have become impurities, you know I cannot allow them to defile our earth any longer.``"
+		"TextENG": "``You will not. That is unnecessary now. Know that your tainted horned people will not be allowed to corrupt our lands any further.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1572,7 +1572,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0530.",
 		"TextJPN": "「同じバケモノ仲間のくせに、ずいぶんな言い様じゃない」",
 		"NamesENG": "Rika",
-		"TextENG": "``Despite being spirit companions, you are speaking in a rather unconsiderable manner.``"
+		"TextENG": "``That's quite the rude statement, coming from someone who's as much of a monster.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1581,7 +1581,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0060.",
 		"TextJPN": "「黙り給え。人の子の身の程を弁えよ。汚らわしき角の民の巫女の分際で」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Silence. Know your place child of man. And your social standing as a shrine maiden in the repulsive nation of horns.``"
+		"TextENG": "``Silence. Know your place, child of man. You are but the priestess of the tainted horned people.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1590,19 +1590,19 @@
 		"PreTextTags": "@vS25/05/NRIK_0540.",
 		"TextJPN": "「クッ………」",
 		"NamesENG": "Rika",
-		"TextENG": "``.........``"
+		"TextENG": "``Kh......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154508,
 		"TextJPN": "田村媛命に一瞥されると、梨花の頭が再びズキリと痛む。",
-		"TextENG": "Tamurahime no Mikoto glances at Rika, her head begins to ache again."
+		"TextENG": "Rika's head throbbed with pain again when Tamurahime-no-Mikoto glanced at her."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154509,
 		"TextJPN": "羽入の同類であることは間違いないが、まったく相容れない存在であることは、もはや説明の必要もなさそうだ。",
-		"TextENG": "It's certain that she is the same kind as Hanyuu, but it seems they are an incompatible existence, there isn't a need for an explanation."
+		"TextENG": "There was no doubt she was the same as Hanyuu, but it was no longer even necessary to explain that the two were beings at total odds with one another."
 	},
 	{
 		"type": "MSGSET",
@@ -1611,7 +1611,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0340.",
 		"TextJPN": "「あなたとは金輪際、言葉を交わしたくありません。……角の民による惨劇は、角の民の長と巫女である我らの責任で食い止めます」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I never wanted to exchange words with you again. ......A tragedy has befallen the nation of horns, so as leader of the nation of horns, I understand that I must take share of this responsibility on behalf of my shrine maiden.``"
+		"TextENG": "``I never wish to speak to you again by any means. ......I, the leader of the horned people, and my priestess shall take responsibility for ending this tragedy.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1620,25 +1620,25 @@
 		"PreTextTags": "@vS25/51/NTAM_0070.",
 		"TextJPN": "「ならぬ。帰れ、不浄の民よ。我が民の地の災厄は、我が責任において解決する。そなたは未熟なる民を恥じて雛見沢の地に帰るがいいっ。消え給え、羽入と巫女よッ」",
 		"NamesENG": "Tamura",
-		"TextENG": "``That won't solve anything. Return home, and take your filthy people with you. This calamity has afflicted my people on my land, resolving it is my responsibility. Your people are far too inexperienced, return home to the land of Hinamizawa in shame. Now please disappear, Hanyuu and shrine maiden.``"
+		"TextENG": "``You will not. Go home, tainted one. I shall take responsibility for resolving the disaster brought upon my people's lands. You should return to your land of Hinamizawa and be ashamed of your immature charges! Now be gone, Hanyuu and priestess!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154512,
 		"TextJPN": "激しい衝撃が体を震わせた、と思った次の瞬間には、揺れる車の後部座席に戻っていた。",
-		"TextENG": "A violent shock shakes our bodies, but then the next moment, we are back in the back seat of the shaking car."
+		"TextENG": "A violent shock shook her body, and the very next moment she had returned to the back seat of the car."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154513,
 		"TextJPN": "まるで白昼夢。しかし、二人には確かにあった現実。",
-		"TextENG": "It seemed like a daydream. However, it was certainly reality for the two people."
+		"TextENG": "It was all like a daydream. However, it was undoubtedly real for them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154514,
 		"TextJPN": "人ならざる者たちの、数百年、あるいは千年を越えての冷たき再会だった。",
-		"TextENG": "That non-human, it could have been several hundred years since they last meet, or a cold reunion surpassing even one thousand years."
+		"TextENG": "That had been the cold reunion between inhuman beings after centuries, or possibly even millennia."
 	},
 	{
 		"type": "MSGSET",
@@ -1647,7 +1647,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0550.",
 		"TextJPN": "「……あいつは何者？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Who was that?``"
+		"TextENG": "``......Who on earth was that?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1656,7 +1656,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0350.",
 		"TextJPN": "「田村媛命。……僕たちが来るより前から存在し、この地を支配していた、先住民の長です」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Tamurahime no Mikoto. ......She has existed even before my coming, ruling this land as leader of all indigenous people.``"
+		"TextENG": "``Tamurahime-no-Mikoto. ......The leader of the previous residents, who ruled these lands before we ever arrived here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1665,7 +1665,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0560.",
 		"TextJPN": "「なるほど。仲が良くなる理由はないわね」",
 		"NamesENG": "Rika",
-		"TextENG": "``I see. So that's why you're not on good terms.``"
+		"TextENG": "``I see. So there's no reason you'd get along, then.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1674,13 +1674,13 @@
 		"PreTextTags": "@vS25/12/NHAN_0360.",
 		"TextJPN": "「流浪の民にとって、ようやく辿り着けた大地は何にも代え難き恵みであり奇跡です。……しかし、田村はそれを冷たく拒絶したのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``My people were wandering, but we struggled on and finally reached the earth, we offered miracles in return for her blessing. ......However, Tamura rejected us coldly.``"
+		"TextENG": "``We were refugees, and it was a miracle that we finally reached this land. It was an incredible blessing to us. ...Yet we were coldly rejected by Tamura.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154519,
 		"TextJPN": "それは、祭具殿にしまわれた最も古い古文書にすら記されていない、……羽入しか知らぬ本当の最古の、神話の物語だ。",
-		"TextENG": "It was never written down, not even in the oldest of ancient documents tucked away in the Ritual Equipment Temple...... So only Hanyuu knows this old truth, this story of legend."
+		"TextENG": "That was something that had never been recorded, even in the most ancient documents within the ritual storehouse. ......It was truly the oldest of myths, known only to Hanyuu."
 	},
 	{
 		"type": "MSGSET",
@@ -1689,7 +1689,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0370.",
 		"TextJPN": "「僕たちは、長い間、安住の地を求めて、宇宙を彷徨っていました。……そして、気の遠くなるような旅路の果てに、ようやくこの青く美しい星に辿り着いたのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Me and my people, for a long time, were searching for a place to live in peace, wandering the universe. ......And then, our distant journey came to an end, we finally arrived at this blue and beautiful star.``"
+		"TextENG": "``We wandered space for a long time in search of a place to live peacefully. ......After a journey so long it could drive one mad, we finally made it to this beautiful blue planet.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1698,151 +1698,151 @@
 		"PreTextTags": "@vS25/05/NRIK_0570.",
 		"TextJPN": "「……あんたたちって一体、何なの？　……私はずっと思ってたわ。決してあんたたちは、神などという抽象的な存在ではない。入江たちが顕微鏡で研究できるような、はっきりと存在する何かよね？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......You and your people, what on earth are you talking about? ......This is unexpected for me. So you aren't an abstract existence called God. If Irie studied you under a microscope, would there be anything that proves you clearly exist?``"
+		"TextENG": "``......Just what on Earth are you people? ......I've always wondered that. You're certainly not some abstract being like a god. You're something that Irie and the others could have studied under a microscope, aren't you?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154522,
 		"TextJPN": "雛見沢症候群の原因ウィルス。それに、意思などあるわけがない……。",
-		"TextENG": "The source of the virus and the Hinamizawa Syndrome. What intention does she have......"
+		"TextENG": "The cause of the Hinamizawa Syndrome was a virus. But there's no way a virus could be sentient......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154523,
 		"TextJPN": "しかし、恐らくは羽入を長とする角の民とやらの正体は、それなのだ。",
-		"TextENG": "However, perhaps Hanyuu's real identity is leader of this alleged nation of horns, that may be the case."
+		"TextENG": "Yet it seemed to be the true identity of Hanyuu's horned people."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154524,
 		"TextJPN": "そして、梨花のその想像は正しい。",
-		"TextENG": "Rika's guess is right."
+		"TextENG": "Rika's guess was correct."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154525,
 		"TextJPN": "人間は、地球に寄生する寄生虫に過ぎない、というＳＦを聞いたこともあろう。",
-		"TextENG": "The science fiction is saying that humans are nothing more than parasites on the earth."
+		"TextENG": "Some science fiction stories have posed the idea that humanity is nothing more than a parasite upon Earth."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154526,
 		"TextJPN": "角の民もまた、その意味で人間と変わらない。",
-		"TextENG": "So, in that sense, the nation of horns are no different than human beings."
+		"TextENG": "So in that sense, the horned people are no different from humans."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154527,
 		"TextJPN": "人間は、地球に寄生する。そして彼らは、その人間の脳に寄生するのだ。",
-		"TextENG": "Humans are parasites on the earth. And they are parasites on the human brain."
+		"TextENG": "Humans are parasites upon the Earth. And they are parasites upon the human brain."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154528,
 		"TextJPN": "つまり、角の民たちにとって、人間の脳は大地なのだ。",
-		"TextENG": "In other words, for the nation of horns, the human brain is the earth."
+		"TextENG": "Which means that to the horned people, the human brain is their land."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154529,
 		"TextJPN": "そして、人間が環境を破壊するようなことがあれば、やがては地球を殺してしまい、そこに住まう者たち全てをも殺してしまうことになる。",
-		"TextENG": "And, with human beings destroying the environment, they will eventually kill the earth, killing everything living on it."
+		"TextENG": "If humanity continues to destroy the environment, then eventually it will kill the Earth, and everything living upon it will die along with it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154530,
 		"TextJPN": "だから、地球にやさしく、共存することが求められているのだ。",
-		"TextENG": "Therefore, we need to be kind to the earth and coexist with it."
+		"TextENG": "That's why humanity must be kind to Earth and strive to live in harmony with it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154531,
 		"TextJPN": "それは、角の民も同じはず。",
-		"TextENG": "But, the same should be said for the nation of horns, too."
+		"TextENG": "The same goes for the horned people."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154532,
 		"TextJPN": "人間と共存できなければ、彼らもまた存在できない。",
-		"TextENG": "If they can't coexist with humans, they can't exist either."
+		"TextENG": "If they cannot coexist with humanity, they will cease to exist at all."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154533,
 		"TextJPN": "……その意味では、雛見沢症候群は彼らによる環境破壊と言える。",
-		"TextENG": "......In that sense, it could be said that the Hinamizawa Syndrome is similar to environmental destruction."
+		"TextENG": "......In that analogy, Hinamizawa Syndrome is their destruction of the environment."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154534,
 		"TextJPN": "人間が疑心暗鬼から狂乱し、自傷行為、もしくは乱暴行為に及び、自らを殺してしまうようなことがあれば、角の民にとっても共倒れのはずだ。",
-		"TextENG": "Humans frenzy in paranoia, inflicting self-harm, or committing acts of violence, killing themselves or others in the process, entering into a mutual destruction with the nation of horns."
+		"TextENG": "When the human becomes paranoid and mad, resorting to self-injury, acts of violence, or suicide, then the horned people die with them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154535,
 		"TextJPN": "そこまでを考え至ると、田村が捨て台詞に残した、未熟なる民という言葉が少し理解できてくる。",
-		"TextENG": "When I think about it, and the lines Tamura parted with, I can understand her words, we are an inexperienced people."
+		"TextENG": "Once her reasoning reached that point, Rika finally understood a bit of what Tamura had said at the end, calling them immature."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154536,
 		"TextJPN": "……恐らくは、あの田村媛命もまた、人間に寄生する超常の存在の長なのだろう。",
-		"TextENG": "......Perhaps, Tamurahime no Mikoto also knows that my paranormal existence as leader is parasitic to humans."
+		"TextENG": "......Tamurahime-no-Mikoto was, most likely, the leader of another supernatural parasite upon humanity."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154537,
 		"TextJPN": "しかし、雛見沢症候群以外には、少なくとも日本では、そのような奇怪な症状は報告されていない。",
-		"TextENG": "However, besides the Hinamizawa Syndrome, and at least in Japan, other strange symptoms haven't yet been reported."
+		"TextENG": "Yet aside from the Hinamizawa Syndrome, she had never heard any report of similar symptoms anywhere else in Japan."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154538,
 		"TextJPN": "つまり、あの田村の民の一族は、人間と穏便に共生する術を身に付けているのだ。",
-		"TextENG": "In other words, Tamura and the people of her clan have found a way to live a peaceful symbiosis with the humans."
+		"TextENG": "Which meant that Tamura's race of people had obtained a means of coexisting peacefully with humanity."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154539,
 		"TextJPN": "しかし、羽入たち角の民は、それを身に付けるには未だ至っていない。……だから、未熟呼ばわりをするのだろう。",
-		"TextENG": "However, Hanyuu and the nation of Horns have not yet reached that stage. ......Therefore, they cry out immaturely."
+		"TextENG": "However, Hanyuu's horned people had yet to obtain that same skill. ......That's why they were declared immature."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154540,
 		"TextJPN": "だが、こちら側からすれば反論もある。",
-		"TextENG": "But, the other side seems to object."
+		"TextENG": "Still, you can argue otherwise as well."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154541,
 		"TextJPN": "確かに太古の昔の鬼ヶ淵村では、そのような騒ぎもあっただろう。",
-		"TextENG": "Surely since ancient times in Onigafuchi village, there has always been such an uproar."
+		"TextENG": "Sure, there was a disaster in Onigafuchi Village back in ancient times."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154542,
 		"TextJPN": "それを長い年月をかけて乗り越え、独特の習慣で、発症することがないように自己管理をしてきたのだ。",
-		"TextENG": "It took a long time to overcome it, so a unique custom of self-administration was created to prevent this."
+		"TextENG": "Yet they have spent many decades developing unique practices to control themselves and prevent any symptoms."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154543,
 		"TextJPN": "そこに、鷹野のような悪党がやってきて、わざと、より凶暴なウィルスになるよう研究を始めてしまったのではないか。",
-		"TextENG": "But then, a villain such a Takano arrived, and deliberately she began to study this ferocious virus."
+		"TextENG": "But then a villain, Takano, came and interfered, intentionally conducting research to turn them into a deadly virus."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154544,
 		"TextJPN": "今回の雛見沢の事件も、羽入たち角の民によるものではあるまい。",
-		"TextENG": "As for the case of Hinamizawa, her intent was aimed at Hanyuu and the nation of horns."
+		"TextENG": "This incident in Hinamizawa wasn't caused by Hanyuu or the horned people."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154545,
 		"TextJPN": "鷹野たちが研究していた、角の民を凶暴にした新種のη１７３なるものが漏洩し、それによって起こされた騒ぎに違いないのだ。",
-		"TextENG": "Takano studied them, naming this new species η-173, forcing the nation of horns to become ferocious, causing this uproar we have today."
+		"TextENG": "This whole commotion was caused by Takano developing η173, a new race of ferocious horned people, and spreading them elsewhere."
 	},
 	{
 		"type": "MSGSET",
@@ -1851,7 +1851,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0580.",
 		"TextJPN": "「あの堅物っぽいバケモノには、理解できるわけもなさそうね」",
 		"NamesENG": "Rika",
-		"TextENG": "``That spirit seemed very stubborn, it's unlikely she would understand.``"
+		"TextENG": "``It doesn't look like that stubborn monster is capable of understanding.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1860,7 +1860,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0380.",
 		"TextJPN": "「あいつは人の話を聞かない、とにかく冷たい、融通の利かないヤツなのですよ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I doubt she would even want to hear my story, that person is cold, and inflexible.``"
+		"TextENG": "``She never listens to anyone. She's always just cold and inflexible.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1869,7 +1869,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0590.",
 		"TextJPN": "「向こうから見れば、鷹野がばら蒔いたウィルスも私たちも同じものだから同罪。でもこっちから見れば、全部、鷹野のせいよ。……これだけの大惨事を引き起こしてくれたんだもの。あんにゃろうをぶん殴らなきゃ、腹が収まらないわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``If she saw it from our point of view, then she would understand that the virus Takano scattered is the same offence. So judging from this, everything is Takano's fault. ......Because she is the one who caused this catastrophe. You shouldn't be punished, it's not right.``"
+		"TextENG": "``From her point of view, we're no different from the virus Takano spread, and thus equally guilty. But from our perspective, it's all Takano's fault. ......She's the one who caused this great disaster. I won't be able to calm down until I punch that woman in the face.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1878,25 +1878,25 @@
 		"PreTextTags": "@vS25/12/NHAN_0390.",
 		"TextJPN": "「……田村が邪魔をしないとよいのですが」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......We shouldn't interfere with Tamura.``"
+		"TextENG": "``......I just hope Tamura doesn't get in our way.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154550,
 		"TextJPN": "どうやら、羽入たち角の民の土地が雛見沢だとすると、それ以外の土地は全て、あの田村の民のものらしい。",
-		"TextENG": "It seems that the land of Hanyuu and the nation of horns is Hinamizawa, while all other land belongs to Tamura and her people."
+		"TextENG": "It would seem the land of Hinamizawa was the land of the horned people, while all the other lands belonged to Tamura's people."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154551,
 		"TextJPN": "……田村の民って、何者……？",
-		"TextENG": "......But Tamura's people, who are they......?"
+		"TextENG": "......Just what is Tamura's people......?"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154552,
 		"TextJPN": "というか、人間に寄生する存在と同類ということは、……まさか、日本中の人間って………。",
-		"TextENG": "Or rather, why is their existence similar to her as parasites on human beings...... It can't be, the people of Japan........."
+		"TextENG": "Also, if she's also a human parasite... does that mean everyone in Japan is......?"
 	},
 	{
 		"type": "MSGSET",
@@ -1905,7 +1905,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0330.",
 		"TextJPN": "「そろそろ街が近付いてきたね。……何があるかわからないから、用心してね」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``We'll arrive at the town soon. ......But since we don't know what will be waiting for us, we have to be careful.``"
+		"TextENG": "``We're about to come up on the town. ......I don't know what we'll find here, so be careful.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1914,7 +1914,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0600.",
 		"TextJPN": "「わかってますのです。オヤシロパワーで、悪い人が来ないように退けますですよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``I understand. With Oyashiro's power, those bad people will not come near us.``"
+		"TextENG": "``I know. I'll use Oyashiro's power to make sure none of the bad people come to us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1923,7 +1923,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0340.",
 		"TextJPN": "「その力を確かめずに済むのが一番だねぇ。ははは」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``I think it's best not to test his power. Ha ha ha.``"
+		"TextENG": "``It'd be better if we never have to test that power of yours at all. Hahaha.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1932,7 +1932,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0610.",
 		"TextJPN": "「富竹。……これだけ広い街の中から、どうやって鷹野を探し出すのですか」",
 		"NamesENG": "Rika",
-		"TextENG": "``Tomitake. ......It is a very spacious town, how will we find Takano?``"
+		"TextENG": "``Tomitake. ......How do you plan to hunt down Takano in a town this large?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1941,19 +1941,19 @@
 		"PreTextTags": "@vS25/08/NTOM_0350.",
 		"TextJPN": "「鷹野さんにとっても、今の興宮は危険な街のはずさ。仮に拳銃を持ちだしていたとしても、とても身を守れやしないはずさ」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Well Takano-san should know that present Okinomiya will be a dangerous town. So she probably took a handgun with her, as she's not very good at defending herself.``"
+		"TextENG": "``Right now, Okinomiya is a dangerous town for Takano-san too. Even if she has brought a handgun along, it won't be enough to really protect her.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154558,
 		"TextJPN": "山狗も壊滅している。今の鷹野は、か弱いひとりの女性に過ぎない。",
-		"TextENG": "The Mountain Dogs have also been destroyed, too. So at present, Takano is only one weak woman."
+		"TextENG": "The Mountain Dogs were annihilated. Right now Takano was nothing more than a lone woman."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154559,
 		"TextJPN": "徘徊する末期発症を起こした殺人鬼たちに襲われたら、ひとたまりもあるまい。",
-		"TextENG": "Therefore, if she is attacked by murderous fiends who have terminally developed, she will be completely helpless."
+		"TextENG": "She wouldn't be able to last if she was attacked by the murderers wandering around with their terminal symptoms."
 	},
 	{
 		"type": "MSGSET",
@@ -1962,7 +1962,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0360.",
 		"TextJPN": "「恐らく、避難者たちが寄り合うコロニーのようなところに身を寄せているはずさ。……まぁ、それでも探し出すのは気が遠くなる話だろうけどねぇ。梨花ちゃんの神通力で、鷹野さんを探し出すことが出来れば、一番いいんだけどねぇ、ははは」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Perhaps, she will huddle in place and stay together with a colony of evacuees. ......Well, I'd probably lose consciousness trying to figure out where she is. But, using your supernatural powers, Rika-chan, I know it's possible you can find Takano-san.Ddon't you think that's our best option? Ha ha ha.``"
+		"TextENG": "``She's probably taking shelter with a colony of evacuees. ......Well, it's still dizzying to think about hunting her down. If you're able to use your powers to uncover Takano-san, that would be perfect, hahaha.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1971,7 +1971,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0620.",
 		"TextJPN": "「出来るの、羽入？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Can I do that, Hanyuu?``"
+		"TextENG": "``Can you do it, Hanyuu?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1980,7 +1980,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0400.",
 		"TextJPN": "「……出来たらもうやっていますですよ、あぅあぅ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......I'm afraid I can't answer that, au au.``"
+		"TextENG": "``......If I could, I already would be. Auau.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1989,19 +1989,19 @@
 		"PreTextTags": "@vS25/08/NTOM_0370.",
 		"TextJPN": "「あるいは、何とか外部と連絡を取る手段を見つけるのもいいかもしれない。東京と連絡さえ取れれば、打てる手はいくらでもあるだろうからね」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Or it might be a good idea to try and contact the outside. If we can contact Tokyo, there's a good chance they'll make a move.``"
+		"TextENG": "``Another possibility would be finding a means of contacting people outside of here. If we're able to contact Tokyo, then we'll have plenty of options.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154564,
 		"TextJPN": "富竹の頼もしいところは、このような緊急事態にあっても、まったく動じず、普段通りのままであることだ。",
-		"TextENG": "Even in such an emergency, Tomitake is reliable as ever, he is not fazed at all, he remains the same."
+		"TextENG": "The reassuring thing about Tomitake was that he could act like normal, completely unfazed, even in emergencies like this."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154565,
 		"TextJPN": "鷹野が与えた、新型予防薬が効果を発揮したお陰だろう。",
-		"TextENG": "We should be thankful that new prophylactic medicine Takano gave him has had an effect."
+		"TextENG": "That was probably thanks to the effects of the new prophylactic Takano had administered."
 	},
 	{
 		"type": "MSGSET",
@@ -2010,7 +2010,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0630.",
 		"TextJPN": "「……鷹野の考えることはわからないわ。どうして富竹を生かしたのかしら。……この状況下では、自分の最も面倒な敵になるだろうことは予想がつくはずなのに」",
 		"NamesENG": "Rika",
-		"TextENG": "``......I don't understand how Takano thinks. I wonder why she kept Tomitake alive. ......Under these circumstances, she should have anticipated he would become her most troublesome enemy.``"
+		"TextENG": "``......I don't know what Takano's thinking. Why did she let Tomitake live? ......She should've predicted that he'd become her most difficult adversary in this situation.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2019,7 +2019,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0410.",
 		"TextJPN": "「千年を生きても、まったく理解できない人間は稀にいますのです。……あいつもそういう内のひとりなのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Even after living a thousand years, it was rare to encounter another person who I could understand completely. ......But I'm guessing, he is one of those people.``"
+		"TextENG": "``Even after living a thousand years, there is still the occasional human completely beyond comprehension. ......She's one of those people.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2028,7 +2028,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0640.",
 		"TextJPN": "「そうね。ただひとつ確実なことは、あいつに好き放題にさせれば、この惨状は日本中、いや、世界中に広がるってことだわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``You're right. But I need to make one thing certain, is she just doing as she pleases, to devastate all of Japan, no, she probably plans to spread it around the entire world.``"
+		"TextENG": "``True. The one thing we can be sure of is that if we let her have her way, then disaster will spread to all of Japan, no, all the world.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2037,7 +2037,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0650.",
 		"TextJPN": "「そうしたら、世界中の自称神さまのバケモノがやってきてあんたを罵るわけかしら？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Then, I wonder why she sweared to this self-proclaimed spirit God of the world?``"
+		"TextENG": "``I wonder, if that happens will all the monsters of this world claiming to be gods come to ream you out?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2046,7 +2046,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0420.",
 		"TextJPN": "「……あぅあぅあぅ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......Au au au.``"
+		"TextENG": "``......Auauau.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2055,24 +2055,24 @@
 		"PreTextTags": "@vS25/05/NRIK_0660.",
 		"TextJPN": "「神になりたいと妄言をのたまう鷹野。そして、あんたと同類の田村媛命。……なるほどね、これはもはや人間の世界でどうこうという問題じゃないわけだわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``I guess Takano's words were rather thoughtless when she said she wanted to become God. Espically, when faced with the likes of Tamurahime no Mikoto. ......Indeed, she will not be a problem in the human world any longer.``"
+		"TextENG": "``Takano was talking about wanting to become a god herself. Then there's you and that Tamurahime-no-Mikoto. ......I see. The human world doesn't have a say in this matter anymore.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154572,
 		"TextJPN": "恐らくこれは、……羽入を神と呼ぶなら、神々の世界の騒ぎなのだ。",
-		"TextENG": "Perhaps, if I call Hanyuu God, there will be a worldwide uproar of Gods."
+		"TextENG": "Most likely... If Hanyuu is to be called a god, then there must be a disturbance in their world."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154573,
 		"TextJPN": "人間など、それに巻き込まれているだけに過ぎない。",
-		"TextENG": "But, even humans would be involved in something like that."
+		"TextENG": "Humans have just been caught up in their mess."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154574,
 		"TextJPN": "……考えれば考えるほどに、今回の事件は、自分たちにしか食い止められないのだ。",
-		"TextENG": "......The more I think about it, the more I realize that we are the only ones who can stop this incident from happening."
+		"TextENG": "......The more I think about it, the more I realized we're the only ones who can stop this incident."
 	}
 ]

--- a/kamikashimashi_4.json
+++ b/kamikashimashi_4.json
@@ -12,19 +12,19 @@
 		"PreTextTags": "@vS25/03/NMIO_1100.",
 		"TextJPN": "「………見たところ、園崎組の事務所は、冷静を保ててるように見えるねぇ……」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........Judging from the look of things, the Sonozaki family office has seemed to keep calm......``"
+		"TextENG": "``.........From what I can see, the office of the Sonozaki Group still seems to be safe......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154576,
 		"TextJPN": "建物伝いに移動した魅音たちは、途中でオペラグラスを手に入れ、それを双眼鏡代わりにしていた。",
-		"TextENG": "Mion moves along the building, and puts away the opera glasses on the move, substituting them for binoculars."
+		"TextENG": "Mion and the others had traveled building to building, stopping at one point to pick up some opera glasses to use them as binoculars."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154577,
 		"TextJPN": "しばらくの偵察で、建物伝いで可能な行動範囲と、その周囲の暴徒たちの動きを把握することが出来た。",
-		"TextENG": "After a short moment of reconnaissance, a range of activities were possible as we moved along the buildings, allowing us to grasp the movements of the surrounding mobs."
+		"TextENG": "After a bit of surveillance, they had a good idea of what actions they could take between the buildings as well as the movements of the surrounding rioters."
 	},
 	{
 		"type": "MSGSET",
@@ -33,7 +33,7 @@
 		"PreTextTags": "@vS25/02/NREN_0930.",
 		"TextJPN": "「やっぱり、雛見沢の自警団と同じ動きだね」",
 		"NamesENG": "Rena",
-		"TextENG": "``After all, their movements are the same as the vigilance committee of Hinamizawa.``"
+		"TextENG": "``Figures they'd be behaving the same as Hinamizawa's neighborhood watch.``"
 	},
 	{
 		"type": "MSGSET",
@@ -42,7 +42,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1020.",
 		"TextJPN": "「普段は怯えるようにバリケード前に陣取り、何か物音が聞こえたと騒いではドタドタと駆けつけて大暴れしての繰り返しだ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``They're probably terrified of someone playing prisoner's base with their barricades, as they made a racket when some noise was heard, nosily rushing towards it in a cycle of rampage.``"
+		"TextENG": "``Generally they take up positions hiding behind the barricades, but every time they hear something, they shout and race toward it in a rampage.``"
 	},
 	{
 		"type": "MSGSET",
@@ -51,7 +51,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0340.",
 		"TextJPN": "「自分たちは冷静なつもりでいるのが滑稽ですわね……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``It's funny we are the only ones with a calm intention......``"
+		"TextENG": "``It's ridiculous that they think they're acting reasonably......``"
 	},
 	{
 		"type": "MSGSET",
@@ -60,7 +60,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1110.",
 		"TextJPN": "「でも、行動パターンは読めたよ。私たちが出くわした時が、一番ホットだったってこともね」",
 		"NamesENG": "Mion",
-		"TextENG": "``But, our behavior pattern was readable. When we came across them, we sure did panic.``"
+		"TextENG": "``But now we know their behavior patterns. It also means they were at their hottest back when we first ran into them.``"
 	},
 	{
 		"type": "MSGSET",
@@ -69,7 +69,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0100.",
 		"TextJPN": "「いつもドタドタしている、……わけでもない」",
 		"NamesENG": "Une",
-		"TextENG": "``You made alot of noise...... That was it.``"
+		"TextENG": "``It's not like they're, racing around all the time.``"
 	},
 	{
 		"type": "MSGSET",
@@ -78,7 +78,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1120.",
 		"TextJPN": "「だねぇ。それがわかっただけでも大きな情報だよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``You're right. I only understood the big information.``"
+		"TextENG": "``Right. For us that's big news all on its own.``"
 	},
 	{
 		"type": "MSGSET",
@@ -87,7 +87,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0350.",
 		"TextJPN": "「何れにせよ、この大河を渡らないことには、どうにもなりませんでしてよ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``In any case, I don't think we'll be able to cross that large river, unless we come up with something.``"
+		"TextENG": "``Either way, we'll be unable to do anything without crossing this river.``"
 	},
 	{
 		"type": "MSGSET",
@@ -96,7 +96,7 @@
 		"PreTextTags": "@vS25/02/NREN_0940.",
 		"TextJPN": "「この幹線道路を横断しないことには、……これ以上は進めないからね」",
 		"NamesENG": "Rena",
-		"TextENG": "``But without crossing the main road...... we can't move any further.``"
+		"TextENG": "``We can't go any further, without crossing.``"
 	},
 	{
 		"type": "MSGSET",
@@ -105,7 +105,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1030.",
 		"TextJPN": "「静かに行くか、賑やかに行くか。そのどちらかしかないだろうな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``We should either go quietly, or very noisily. Those are our only options.``"
+		"TextENG": "``So we go quietly, or we go loudly. One or the other.``"
 	},
 	{
 		"type": "MSGSET",
@@ -114,7 +114,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1130.",
 		"TextJPN": "「夜陰に乗じて隠密に行こう」",
 		"NamesENG": "Mion",
-		"TextENG": "``Let's covertly move under the cover of night.``"
+		"TextENG": "``Let's use the cover of night to sneak across.``"
 	},
 	{
 		"type": "MSGSET",
@@ -123,7 +123,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1040.",
 		"TextJPN": "「魅音の怪我が悪化しない内に行動したいんだけどな。……まだ大丈夫そうか？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I'd like to act before Mion's injuries worsen. Are you okay?``"
+		"TextENG": "``I'd rather we take action before your injury gets any worse, Mion. ...You sure you're still doing okay?``"
 	},
 	{
 		"type": "MSGSET",
@@ -132,25 +132,25 @@
 		"PreTextTags": "@vS25/03/NMIO_1140.",
 		"TextJPN": "「へへっ、おじさんを舐めるんじゃないよ。これくらいの傷、どうって事は……@k@|@y@vS25/03/NMIO_1141.あいたたた！？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Hey, don't underestimate this old man. A scratch like this is nothing to worry about......@k@|@y@vS25/03/NMIO_1141. Oww!``"
+		"TextENG": "``Heh heh, don't count this ol' man out. A scratch like this is nothing...@k@|@y@vS25/03/NMIO_1141. Ah, ow, ow, ow?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154590,
 		"TextJPN": "気を使わせまいと腕を持ち上げる魅音だが、銃による傷痕が一日二日で塞がるわけもない。",
-		"TextENG": "She lifted her arm to keep her attention, but the scar from the gun would not heal in a day or two."
+		"TextENG": "Mion raises her arm like she's not the least bit concerned, but there's no way a gunshot wound could heal in less than a day or two."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154591,
 		"TextJPN": "これまで動けていたのは、魅音自身の体力、そして精神力の強さがあってこそだ。",
-		"TextENG": "The fact that she had been able to move so far was due to her own physical and mental strength."
+		"TextENG": "The only thing keeping Mion moving is her own sheer physical and mental strength."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154592,
 		"TextJPN": "素人治療によって出血こそ治まっているが、医者に診せるべき傷である事に変わりはない。",
-		"TextENG": "The bleeding had stopped after some amateur treatment, but it was still a wound that needed to be treated by a doctor."
+		"TextENG": "The bleeding has stopped thanks to some amateur first aid, but it's still a wound that needs proper treatment from a medical professional."
 	},
 	{
 		"type": "MSGSET",
@@ -159,7 +159,7 @@
 		"PreTextTags": "@vS25/02/NREN_0950.",
 		"TextJPN": "「もう、あんまり無理しちゃダメだよ？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Don't push yourself too hard anymore, okay?``"
+		"TextENG": "``Don't push yourself too hard, okay?``"
 	},
 	{
 		"type": "MSGSET",
@@ -168,7 +168,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1150.",
 		"TextJPN": "「だ、大丈夫大丈夫。この程度の怪我じゃ、園崎の血は止められないっての」",
 		"NamesENG": "Mion",
-		"TextENG": "``Don't worry, don't worry. This level of injury won't stop Sonozaki's blood.``"
+		"TextENG": "``I-it's fine, it's fine. A wound this small can't stop Sonozaki blood.``"
 	},
 	{
 		"type": "MSGSET",
@@ -177,7 +177,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0360.",
 		"TextJPN": "「本当に血が止まらなくなったら大事ですわよ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``If you really can't stop the bleeding, you're in trouble.``"
+		"TextENG": "``If the blood doesn't stop, then we've got a serious problem.``"
 	},
 	{
 		"type": "MSGSET",
@@ -186,7 +186,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1160.",
 		"TextJPN": "「ま、事務所につけばもう少しマシな治療もきっと出来るって。だからもう一踏ん張りしないとね」",
 		"NamesENG": "Mion",
-		"TextENG": "``Well, I'm sure they can treat me a little better once we're in the office. We just have to hang on a little longer.``"
+		"TextENG": "``Well, I'm sure we can give it more proper treatment once we get to the office. So we just need to hold out a little longer.``"
 	},
 	{
 		"type": "MSGSET",
@@ -195,7 +195,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1050.",
 		"TextJPN": "「今は時間をかけてでも、確実に事務所に辿り着くって事だな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Now, even if it takes time, I'm sure we will reach the office.``"
+		"TextENG": "``So, even if it takes time, we definitely need to get to the office.``"
 	},
 	{
 		"type": "MSGSET",
@@ -204,7 +204,7 @@
 		"PreTextTags": "@vS25/02/NREN_0960.",
 		"TextJPN": "「采ちゃんはどうしよう……？」",
 		"NamesENG": "Rena",
-		"TextENG": "``What will you do, Une-chan......?``"
+		"TextENG": "``What are you going to do, Une-chan......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -213,7 +213,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1170.",
 		"TextJPN": "「あんたも来る？　いつ来るかもわからない助けを待つには、ここはちょっと心細いと思うよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Are you coming with us? I don't know when help will come if you wait here, and it'll also be a little lonely.``"
+		"TextENG": "``You coming with us? It'll probably be a little lonely here waiting for help that may never come.``"
 	},
 	{
 		"type": "MSGSET",
@@ -231,7 +231,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0370.",
 		"TextJPN": "「……みんな、そう言ってここを出て行ってやられてしまったんですものね。……気持ちもわかりますですわ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``......Everyone, it's okay if she doesn't want to leave. ......We should understand her feelings.``"
+		"TextENG": "``......Everyone else said the same thing before leaving and getting killed, didn't they? ......I can understand how you feel.``"
 	},
 	{
 		"type": "MSGSET",
@@ -240,7 +240,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0120.",
 		"TextJPN": "「怖いからここを出たくない……、というわけではないのです」",
 		"NamesENG": "Une",
-		"TextENG": "``I don't want to leave here, it's scary...... It's not if I stay.``"
+		"TextENG": "``It's not like, I don't want to leave here because it's scary.``"
 	},
 	{
 		"type": "MSGSET",
@@ -249,7 +249,7 @@
 		"PreTextTags": "@vS25/02/NREN_0970.",
 		"TextJPN": "「……私たちを、信じてくれる？」",
 		"NamesENG": "Rena",
-		"TextENG": "``......Don't you trust us?``"
+		"TextENG": "``......Do you trust us?``"
 	},
 	{
 		"type": "MSGSET",
@@ -258,7 +258,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0130.",
 		"TextJPN": "「いいえ、……などと言うわけがないのです。皆さんと一緒にいた方が危ない、……という気持ちは、見ている内になくなりましたです」",
 		"NamesENG": "Une",
-		"TextENG": "``No...... I don't have a reason not to. But I'd rather you stay and not risk it...... Feeling that, I don't want you to disappear.``"
+		"TextENG": "``It's, not that I don't. The more I watch you all in action, the less it feels dangerous to stay with you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -267,7 +267,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1060.",
 		"TextJPN": "「俺たち部活メンバーは、個として最強、揃えば無敵だぜ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``We club members are strongest as a unit, our power is unrivaled when we're together!``"
+		"TextENG": "``Every one of our club members is strong individually, but together, we're invincible!``"
 	},
 	{
 		"type": "MSGSET",
@@ -276,7 +276,7 @@
 		"PreTextTags": "@vS25/02/NREN_0980.",
 		"TextJPN": "「私たちを信頼してくれるなら、絶対に采ちゃんを守るから」",
 		"NamesENG": "Rena",
-		"TextENG": "``If you are willing to trust us, we will absolutely protect you, Une-chan.``"
+		"TextENG": "``If you're willing to trust us, then we'll definitely protect you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -285,7 +285,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0380.",
 		"TextJPN": "「園崎組の事務所が、ここより安全であるという保証があればでございますけれどもね」",
 		"NamesENG": "Satoko",
-		"TextENG": "``And at the Sonozaki family office, I can guarantee you'll be safer there than here.``"
+		"TextENG": "``Though that assumes some guarantee that the Sonozaki Group's office is safer than it is here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -294,7 +294,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1180.",
 		"TextJPN": "「それは問題ないよ。万一の際は籠城できるように、あそこにはあらゆる備蓄があるからねぇ」",
 		"NamesENG": "Mion",
-		"TextENG": "``There won't be any problems. Even during an event like this, they'll be able to hold out against a siege, since they have an emergency stockpile over there.``"
+		"TextENG": "``That's not an issue. They keep all kinds of emergency reserves in there so they can hole up if anything bad happens.``"
 	},
 	{
 		"type": "MSGSET",
@@ -303,7 +303,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1070.",
 		"TextJPN": "「魅音の一族は、つくづく備えるのが得意だなぁ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Mion's family is really well prepared.``"
+		"TextENG": "``Your family is seriously good at preparing for things.``"
 	},
 	{
 		"type": "MSGSET",
@@ -312,7 +312,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1190.",
 		"TextJPN": "「くっくっく。戦いは始まる前にすでに終わっているのが、おじさんの一族のポリシーさね」",
 		"NamesENG": "Mion",
-		"TextENG": "``Hee hee hee. The battle was already over before it even began, as is the policy of this Old Man's family.``"
+		"TextENG": "``Kukuku. Our family's policy is to finish fights by the time they start.``"
 	},
 	{
 		"type": "MSGSET",
@@ -321,7 +321,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0390.",
 		"TextJPN": "「采さんは私たちを助けてくれた命の恩人ですわ。だから、私たちはその恩をお返ししましてよ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``You're the savior that helped us, Une-san. Therefore, we have to return the favor.``"
+		"TextENG": "``We owe you for saving us, Une-san. So we'll repay that debt to you.``"
 	},
 	{
 		"type": "MSGSET",
@@ -330,7 +330,7 @@
 		"PreTextTags": "@vS25/02/NREN_0990.",
 		"TextJPN": "「必ず、安全なところへ連れて行ってあげるから」",
 		"NamesENG": "Rena",
-		"TextENG": "``So by all means, we'll take you to a safe place.``"
+		"TextENG": "``We'll make sure to bring you somewhere safe.``"
 	},
 	{
 		"type": "MSGSET",
@@ -339,31 +339,31 @@
 		"PreTextTags": "@vS25/50/NUNE_0140.",
 		"TextJPN": "「……嬉しくない、……わけはないのです」",
 		"NamesENG": "Une",
-		"TextENG": "``......I'm not happy...... There isn't a reason.``"
+		"TextENG": "``......It's not like, I'm happy.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154614,
 		"TextJPN": "少女がたったひとりで、このような前代未聞の大惨事に巻き込まれたのだ。心細くなかったわけもない。",
-		"TextENG": "This girl was all alone, dragged into such an unprecedented catastrophe. She must be feeling lonely."
+		"TextENG": "That little girl was stuck all alone in this unprecedented disaster. Of course she'd be anxious."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154615,
 		"TextJPN": "最初、無口で無表情だと思っていた彼女も、少しずつ元気いっぱいの部活メンバーに心を許し始めるようになっていた。",
-		"TextENG": "First, I thought she was an expressionless taciturn, but she came to trust our energetic club members little by little."
+		"TextENG": "At first we thought she was silent and expressionless, but she was slowly opening up to our energetic club members."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154616,
 		"TextJPN": "元々から無口な少女のわけもない。",
-		"TextENG": "So she can't be the taciturn girl I originally though of."
+		"TextENG": "This young girl wasn't originally the silent type."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154617,
 		"TextJPN": "このような大惨事の衝撃から心を守る為に、少しだけ心を閉ざしてしまっていただけなのだ。",
-		"TextENG": "But in order to protect her heart from the impact of such a catastrophe, she had to close her heart a little."
+		"TextENG": "She'd just closed her heart off a bit in order to protect it from the shock of this disaster."
 	},
 	{
 		"type": "MSGSET",
@@ -372,7 +372,7 @@
 		"PreTextTags": "@vS25/02/NREN_1000.",
 		"TextJPN": "「采ちゃんのお家はどこなの？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Where is your home, Une-chan?``"
+		"TextENG": "``Where's your home, Une-chan?``"
 	},
 	{
 		"type": "MSGSET",
@@ -381,7 +381,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0150.",
 		"TextJPN": "「……この街に住んでいる、……のではないです」",
 		"NamesENG": "Une",
-		"TextENG": "``......I live in this town...... but I don't know where.``"
+		"TextENG": "``......It's not like, I lived in this town.``"
 	},
 	{
 		"type": "MSGSET",
@@ -390,7 +390,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0400.",
 		"TextJPN": "「え？　じゃあお家はどこなんですの？！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Eh? Then where is your house?!``"
+		"TextENG": "``Huh? Then where is your home?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -399,7 +399,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1080.",
 		"TextJPN": "「まさか、……興宮に遊びに来てる時に巻き込まれたとか……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Perhaps...... she came to Okinomiya to play and got caught up in this mess......``"
+		"TextENG": "``Don't tell me you got caught up this mess while hanging out with someone in Okinomiya...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -417,7 +417,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1200.",
 		"TextJPN": "「それは……、……さぞや心細かったろうに……」",
 		"NamesENG": "Mion",
-		"TextENG": "``That may be so...... ......I'm sure you must have felt terrible.......``"
+		"TextENG": "``That's...... You must have been real worried......``"
 	},
 	{
 		"type": "MSGSET",
@@ -426,7 +426,7 @@
 		"PreTextTags": "@vS25/02/NREN_1010.",
 		"TextJPN": "「遠いの？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Is it far?``"
+		"TextENG": "``Is it far from here?``"
 	},
 	{
 		"type": "MSGSET",
@@ -435,7 +435,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0170.",
 		"TextJPN": "「………近く、……ではないのです。……でも、橋がみんな壊れてて、帰れない……」",
 		"NamesENG": "Une",
-		"TextENG": "``.........It's nearby...... so it's not that far. ......But, all the bridges are destroyed, so we won't be able to come back......``"
+		"TextENG": "``......It's, not close. ......But all the bridges are broken and I can't get home......``"
 	},
 	{
 		"type": "MSGSET",
@@ -444,7 +444,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1090.",
 		"TextJPN": "「そうだったのか……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I see......``"
+		"TextENG": "``I see...``"
 	},
 	{
 		"type": "MSGSET",
@@ -453,7 +453,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0410.",
 		"TextJPN": "「可哀想に……」",
 		"NamesENG": "Satoko",
-		"TextENG": "``That's too bad......``"
+		"TextENG": "``That's so sad......``"
 	},
 	{
 		"type": "MSGSET",
@@ -462,7 +462,7 @@
 		"PreTextTags": "@vS25/02/NREN_1020.",
 		"TextJPN": "「でも、ひとつだけ幸運だったこともあるよ」",
 		"NamesENG": "Rena",
-		"TextENG": "``But, that's fortunate for some of us.``"
+		"TextENG": "``But there's one fortunate thing about that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -471,7 +471,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1100.",
 		"TextJPN": "「……そうか、それもそうだな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Yeah, you're right.``"
+		"TextENG": "``......Right, I suppose there is.``"
 	},
 	{
 		"type": "MSGSET",
@@ -480,7 +480,7 @@
 		"PreTextTags": "@vS25/02/NREN_1030.",
 		"TextJPN": "「采ちゃんのお家や家族は、この騒ぎの外側だもん。だからお家は無事。そうでしょ？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Une-chan's family and home must be somewhere outside this uproar. Therefore her house will be safe. Don't you think so?``"
+		"TextENG": "``It means that your family's not caught in this uproar. So they're all safe. Isn't that right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -489,67 +489,67 @@
 		"PreTextTags": "@vS25/50/NUNE_0180.",
 		"TextJPN": "「…………………。……そう、なのです」",
 		"NamesENG": "Une",
-		"TextENG": "``......Yes, you're right.``"
+		"TextENG": "``..................... ......That's right.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154632,
 		"TextJPN": "レナの言う通り、これは唯一の不幸中の幸いだ。",
-		"TextENG": "As Rena says, this is a blessing in disguise."
+		"TextENG": "That was the one saving grace for her."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154633,
 		"TextJPN": "彼女には、帰るべき家と家族が、無事に違いないのだ。",
-		"TextENG": "So she can return to her home and family safely."
+		"TextENG": "She knew for certain that her family and her home were safe."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154634,
 		"TextJPN": "政府は鹿骨市に繋がる橋やトンネルの全てを破壊し、物理的な封鎖を行なっている。",
-		"TextENG": "The government destroyed all bridges and tunnels leading to Shishibone City, performing a physical blockade."
+		"TextENG": "The government had destroyed all the tunnels and bridges leading into Shishibone City, so it was physically cut off."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154635,
 		"TextJPN": "それは、この事態への対処に少なからぬ時間が掛かることを認めたも同然だ。",
-		"TextENG": "So, they rightfully admitted coping with this situation will take a considerable amount of time."
+		"TextENG": "That basically meant they were admitting that it would at least take time to determine a solution for this problem."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154636,
 		"TextJPN": "しかしその一方で、そこまでをしたお陰で、被害を市内に食い止められたという側面もある。",
-		"TextENG": "However, thanks to that they stemmed damage of the city."
+		"TextENG": "On the other hand though, since they went that far, they were also able to keep the damage from spreading beyond the city."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154637,
 		"TextJPN": "市内の人々は、自分たちが政府に見捨てられたと落胆し、あるいは憤っているようだが、大局的に見れば正しい判断だ。",
-		"TextENG": "Although the people of the city became discouraged and thought the government had abandoned them, making everyone very upset, but looking at it from their perspective it was the right decision to make."
+		"TextENG": "Those living in the city were probably depressed or enraged, believing that the government had abandoned them, but in terms of the big picture, that was the right call."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154638,
 		"TextJPN": "そしてそのお陰で、采の帰るべき場所は守られたのだ。",
-		"TextENG": "And thanks to that, we should be able to protect Une until she gets home."
+		"TextENG": "Thanks to that decision, Une's home was safe."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154639,
 		"TextJPN": "……彼女には、まだ希望がある。",
-		"TextENG": "......So she still has hope."
+		"TextENG": "......She still had hope."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154640,
 		"TextJPN": "だからこそ、心細くて潰れそうになりながらも、……気丈に今日までを頑張り抜くことが出来たのだろう。",
-		"TextENG": "That is why, even though all may seem lost...... We have been able to be stout-hearted and do our best until this very day."
+		"TextENG": "That was how she was able to keep going this long... even amidst crushing despair."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154641,
 		"TextJPN": "彼女の境遇を理解すると、一同は俯き、そして湧き上がる使命感に拳を握り締めた。",
-		"TextENG": "So we all consider her circumstances, look down, and grasp our fists as a sense of duty overwhelms us."
+		"TextENG": "Once we understood what she was going through, we all looked down for a moment, and then clenched our fists with a growing sense of purpose."
 	},
 	{
 		"type": "MSGSET",
@@ -558,7 +558,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1210.",
 		"TextJPN": "「采ちゃんが助けてくれなかったら、おじさんたちはどうなってたかわからない」",
 		"NamesENG": "Mion",
-		"TextENG": "``If you never helped us, Une-chan, I don't know what would've happened to this Old Man.``"
+		"TextENG": "``If you hadn't rescued us, who knows what would have happened to us.``"
 	},
 	{
 		"type": "MSGSET",
@@ -567,7 +567,7 @@
 		"PreTextTags": "@vS25/02/NREN_1040.",
 		"TextJPN": "「痛ましい犠牲が出ていた可能性は高いね」",
 		"NamesENG": "Rena",
-		"TextENG": "``It's quite possible that there would have been a tragic loss of life.``"
+		"TextENG": "``It's very likely that some of us would have died.``"
 	},
 	{
 		"type": "MSGSET",
@@ -576,7 +576,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0420.",
 		"TextJPN": "「命を助けて下さった御恩、……安くは付きませんでしてよ！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``We owe you a favor for saving our lives...... so we can't be cheap!``"
+		"TextENG": "``The debt we owe you for saving our lives... can't be called a cheap one!``"
 	},
 	{
 		"type": "MSGSET",
@@ -585,7 +585,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1110.",
 		"TextJPN": "「あぁ、そういうことだな。采ちゃん。……俺たち部活メンバーが、全戦力を挙げて、必ず君を家に帰してやるからなッ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Well, for doing such a thing, Une-chan...... We club members will lend you all our strength to get you home by all means.``"
+		"TextENG": "``Yeah, that's right, Une-chan. ......Us club members will do everything within our power to ensure you make it home!``"
 	},
 	{
 		"type": "MSGSET",
@@ -594,7 +594,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0190.",
 		"TextJPN": "「あ、……ありがとう……、…………です…………」",
 		"NamesENG": "Une",
-		"TextENG": "``Oh...... thank...... ............you............``"
+		"TextENG": "``Th......Thank you...... .........for that............``"
 	},
 	{
 		"type": "MSGSET",
@@ -603,30 +603,30 @@
 		"PreTextTags": "@vS25/03/NMIO_1220.",
 		"TextJPN": "「渡河作戦の決行は、未明の午前４時とする！　夜陰に乗じて一気に幹線道路を越え、事務所へ至るよ！　万一に備え、私が先頭で斥候する！　考えたくはないけど、事務所のみんなもおかしくなってる可能性も否定できないからねぇ」",
 		"NamesENG": "Mion",
-		"TextENG": "``River crossing will be our decisive action and strategy. Operation will begin at 4:00 am early in the morning! We'll make our move all at once and cross the main road under cover of night, leading us to the office! But as a precaution, I'll scout before it begins! I don't want to consider it, but there's a possibility that everyone in the office has already become strange.``"
+		"TextENG": "``Operation Crossing will commence tomorrow morning at 4 AM! We'll use the cover of night to cross the main street in one go, and reach the office! I'll be taking the lead and scouting ahead to prepare for the worst! I don't want to think about it, but we can't deny the possibility that everyone in the office has gone crazy too.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154648,
 		"TextJPN": "そうは脅すが、魅音はそれはないと確信しているようだ。",
-		"TextENG": "They could pose a threat, but Mion's convinced they won't."
+		"TextENG": "While Mion warned us about that, she seemed confident it wasn't the case."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154649,
 		"TextJPN": "恐らく、事務所をオペラグラスで偵察した時、冷静が保てていると確信できるものを確認できたのだろう。",
-		"TextENG": "Perhaps, when she spied upon the office with the opera glasses, she was able to confirm that they have kept their calm."
+		"TextENG": "She was probably able to confirm they retained their sanity when she was observing the office with the opera glasses."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154650,
 		"TextJPN": "一同は早めに休みを取り、万全の準備を整える。",
-		"TextENG": "All the members take an early break, and prepare themselves thoroughly."
+		"TextENG": "We all went to bed early so we'd be in top condition."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154651,
 		"TextJPN": "沙都子が仕掛けた、侵入者検知用トラップの空き缶の転がる音が聞こえやしないか、怯えながら眠るのが、少しだけ堪えた。",
-		"TextENG": "Satoko planted some traps, so we'll be able to hear the sound of the empty cans trap if an intruder is detected rolling in, and now I can sleep in spite of being scared, I was only a little though."
+		"TextENG": "Satoko set a trap to detect intruders, but it was hard to sleep while fearing the sound of that empty can."
 	}
 ]

--- a/kamikashimashi_5.json
+++ b/kamikashimashi_5.json
@@ -9,13 +9,13 @@
 		"type": "MSGSET",
 		"MessageID": 154652,
 		"TextJPN": "………それでも、いつの間にか寝入ってしまっていたに違いない。",
-		"TextENG": ".........Still, I fell asleep all too soon."
+		"TextENG": ".........Even so, I definitely fell asleep at some point."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154653,
 		"TextJPN": "圭一は、魅音に小突かれ、目を覚ます……。",
-		"TextENG": "Keiichi is pushed by Mion, and wakes up......"
+		"TextENG": "Then, I woke up to Mion poking me......"
 	},
 	{
 		"type": "MSGSET",
@@ -24,7 +24,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1230.",
 		"TextJPN": "「そろそろ起きなよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Get up.``"
+		"TextENG": "``It's time to get up.``"
 	},
 	{
 		"type": "MSGSET",
@@ -33,7 +33,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1120.",
 		"TextJPN": "「ん……、…あ、あぁ……。目覚ましもないのに、よく正確に起きられるもんだな……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......R-Right...... I don't know how you get up so accurately without an alarm......``"
+		"TextENG": "``Mmn...... ...Oh, yeah...... I'm surprised you woke up on time without any alarms......``"
 	},
 	{
 		"type": "MSGSET",
@@ -42,7 +42,7 @@
 		"PreTextTags": "@vS25/02/NREN_1050.",
 		"TextJPN": "「魅ぃちゃん、寝てなかったんだって」",
 		"NamesENG": "Rena",
-		"TextENG": "``Mii-chan can't seem to lie down.``"
+		"TextENG": "``Mii-chan said she didn't sleep.``"
 	},
 	{
 		"type": "MSGSET",
@@ -51,7 +51,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0430.",
 		"TextJPN": "「一番グースカ寝てたのは圭一さんですわね。まったく、大した図太さですわ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Keiichi was the one who slept the longest, wasn't he? That was truly very bold of you.``"
+		"TextENG": "``You were the one who slept soundest of us all. Good grief, how bold.``"
 	},
 	{
 		"type": "MSGSET",
@@ -60,7 +60,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0200.",
 		"TextJPN": "「………真っ暗……、という感じはしないのです」",
 		"NamesENG": "Une",
-		"TextENG": "``.........It's pitch black outside...... It doesn't feel like it.``"
+		"TextENG": "``.........It should be pitch black, but it isn't.``"
 	},
 	{
 		"type": "MSGSET",
@@ -69,49 +69,49 @@
 		"PreTextTags": "@vS25/04/NSAT_0440.",
 		"TextJPN": "「そうですわね。案外、月明かりって明るいものですわ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``You're right. Although unexpectedly, the moonlight is also bright.``"
+		"TextENG": "``You're right. Moonlight is surprisingly bright.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154660,
 		"TextJPN": "本当に月明かりだったなら、少しはロマンチックだったかもしれない。",
-		"TextENG": "If that really is moonlight, it could be slightly romantic."
+		"TextENG": "If it really was the moonlight, it might have been a bit romantic."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154661,
 		"TextJPN": "信号や点きっぱなしの電飾などは、眠ることなく街を照らし続けている。",
-		"TextENG": "We see decorative illuminations and traffic lights in the distance, continuing against a city without sleep."
+		"TextENG": "The traffic lights and other illumination were still on, lighting up the city without rest."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154662,
 		"TextJPN": "雛見沢と違い、興宮の夜は、漆黒の闇にはならないのだ。",
-		"TextENG": "Unlike Hinamizawa, Okinomiya at night doesn't become enveloped in a jet black darkness."
+		"TextENG": "Unlike Hinamizawa, Okinomiya never had nights of pitch black darkness."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154663,
 		"TextJPN": "それを幸いと見るか、隠密に不利と考えるかはわからない。",
-		"TextENG": "Although, we don't know if we should look at this fortunately or not, it could be disadvantageous to our covert actions."
+		"TextENG": "I didn't know if we should consider that fortunate or disadvantageous for our stealth."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154664,
 		"TextJPN": "無人の車が列を為す幹線道路の大河には、時折、懐中電灯の明かりがちらつく。",
-		"TextENG": "On the main road crossing the big river, unmanned cars have formed a column, occasionally flickering their lights like a flashlight."
+		"TextENG": "Occasionally there were glimpses of light from flashlights on the main street, filled with rows of unoccupied vehicles."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154665,
 		"TextJPN": "予想通り、不寝番を立てているようだ。",
-		"TextENG": "As expected, this must have been put up by the night watchman."
+		"TextENG": "They had set up a watch, just as we predicted."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154666,
 		"TextJPN": "しかしそれでも、日中よりははるかに薄い警戒だ。",
-		"TextENG": "However, this is still much safer than during daytime."
+		"TextENG": "But regardless, their guard was still thinner than it was in broad daylight."
 	},
 	{
 		"type": "MSGSET",
@@ -120,7 +120,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1240.",
 		"TextJPN": "「……ＯＫ。行けるね……」",
 		"NamesENG": "Mion",
-		"TextENG": "``......OK. We can go......``"
+		"TextENG": "``......Okay. We can do this......``"
 	},
 	{
 		"type": "MSGSET",
@@ -129,7 +129,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0210.",
 		"TextJPN": "「……大丈夫、……なわけ、……ありますよね……？」",
 		"NamesENG": "Une",
-		"TextENG": "``......For sure...... ......it's not okay outside, right......?``"
+		"TextENG": "``......We're going, to be okay, aren't we......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -138,7 +138,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0450.",
 		"TextJPN": "「私たちにお任せですわ。怖いことなどありませんもの。あっさりと渡り切りましてよ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Leave that to us. Don't be scared. We'll pass by them easily.``"
+		"TextENG": "``Just leave it to us. There's nothing to fear. We'll cross it easily.``"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1130.",
 		"TextJPN": "「例の秘密兵器もあるしな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``And we have a secret weapon.``"
+		"TextENG": "``We have our secret weapon, too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -156,7 +156,7 @@
 		"PreTextTags": "@vS25/02/NREN_1060.",
 		"TextJPN": "「何とか、静かに行きたいね。賑やかな状態で駆け込めば、事務所の人たちにも迷惑を掛けちゃう」",
 		"NamesENG": "Rena",
-		"TextENG": "``Somehow, we need to pass by them quietly. We shouldn't energetically rush, that would cause trouble for everyone in the office.``"
+		"TextENG": "``I hope we manage to do this quietly. If we rush in and make a lot of noise, we'll cause issues for those in the office too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -165,49 +165,49 @@
 		"PreTextTags": "@vS25/03/NMIO_1250.",
 		"TextJPN": "「確かに、ね」",
 		"NamesENG": "Mion",
-		"TextENG": "``Certainly, you're right.``"
+		"TextENG": "``That's true.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154673,
 		"TextJPN": "偵察の様子からは、園崎組事務所は外部とは一切の交流を絶っているように見えた。",
-		"TextENG": "From its appearance during reconnaissance, the Sonozaki family office seems to have broken off all exchanges with the outside."
+		"TextENG": "From our reconnaissance, it looked like the Sonozaki Office was cutting off all contact with the outside."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154674,
 		"TextJPN": "バリケードでしっかりと守りを固め、暴徒たちとは交流している様子がない。",
-		"TextENG": "They've also strengthened their defenses with barricades very well, it doesn't seem they've had any exchanges with the mobs."
+		"TextENG": "They had set up barricades, and they weren't interacting with the rioters at all."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154675,
 		"TextJPN": "もし、彼らが暴徒たちと同じに心を鬼に明け渡していたなら、守りなど固めず、感染者狩りに大いに参加していたに違いない。",
-		"TextENG": "However, if they did surrender their hearts to the demon, they would be the same as the mob, and not have such a firm defense, but heavily participating in the hunting of infected people very much."
+		"TextENG": "If they had surrendered their hearts to demons like the rioters had, then they wouldn't be setting up defenses, and they'd be fully participating in the hunt for infected."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154676,
 		"TextJPN": "しかし、もし暴徒たちに追われながら駆け込むようなことになれば、園崎組は感染者を匿ったなどと言われ、騒ぎの火種となる。",
-		"TextENG": "But, if we rush towards there while being chased by a mob, the Sonozaki family would be said to be sheltering infected people, sparking an uproar."
+		"TextENG": "But if we were to rush in there while being chased by rioters, then they'd say that the Sonozaki Group is harboring the infected, and end up causing an uproar."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154677,
 		"TextJPN": "徹底的な隠密を心掛ける他はないのだ。",
-		"TextENG": "I can't help but keep this in mind when we sneak by."
+		"TextENG": "We had to strive for complete stealth."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154678,
 		"TextJPN": "采は、外へ通じる玄関の扉の鍵を、ゆっくりと外す。",
-		"TextENG": "Une takes the key for the entrance door leading to the outside, and turns it slowly."
+		"TextENG": "Une slowly unlocked the door leading outside."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154679,
 		"TextJPN": "地上は鮫の泳ぐ大海も同然という興宮で、玄関の扉を開けるのはまるで、ライオンの檻に踏み入ろうとするかのような恐怖感を覚える……。",
-		"TextENG": "In Okinomiya it looks like there's an ocean on the ground swimming with sharks, that could encircle us even as we open the door. I remember this feeling of fear, as if I'm stepping into a lion's cage......"
+		"TextENG": "Opening that door here in Okinomiya, where the streets were basically an ocean teeming with sharks, meant facing the same fear as trying to step into a lion's cage......"
 	},
 	{
 		"type": "MSGSET",
@@ -216,7 +216,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0220.",
 		"TextJPN": "「怖くない、……わけはないのです………」",
 		"NamesENG": "Une",
-		"TextENG": "``I'm not scared...... There isn't a reason.........``"
+		"TextENG": "``It's not like, I'm not afraid......``"
 	},
 	{
 		"type": "MSGSET",
@@ -225,7 +225,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1260.",
 		"TextJPN": "「先頭は私が。……失敗時には、計画通りに迅速な撤退を。その時はおじさんを助けようなんて思わないんだよ。いいね！」",
 		"NamesENG": "Mion",
-		"TextENG": "``I'll go first. ......If it fails, withdraw quickly as planned. But at that time, don't try and help this Old Man. Got it?``"
+		"TextENG": "``I'll take the lead. ......If I fail, retreat quickly, just as we planned. Don't even think about trying to save me. Got it?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -234,7 +234,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1140.",
 		"TextJPN": "「………それはお互い様だぜ。今度は俺が足を挫いても見捨てろよ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``.........That goes for all of us. Don't bother helping me if I sprain my foot again.``"
+		"TextENG": "``.........That goes both ways. If I sprain my foot again, abandon me.``"
 	},
 	{
 		"type": "MSGSET",
@@ -243,7 +243,7 @@
 		"PreTextTags": "@vS25/02/NREN_1070.",
 		"TextJPN": "「今度は本当にそうするから、慎重にね、圭一くん」",
 		"NamesENG": "Rena",
-		"TextENG": "``I hope that really doesn't happen this time. So be careful, Keiichi-kun.``"
+		"TextENG": "``We really will this time, so be careful, Keiichi-kun.``"
 	},
 	{
 		"type": "MSGSET",
@@ -252,7 +252,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1150.",
 		"TextJPN": "「おうっ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Yeah.``"
+		"TextENG": "``Yeah!``"
 	},
 	{
 		"type": "MSGSET",
@@ -261,43 +261,43 @@
 		"PreTextTags": "@vS25/04/NSAT_0460.",
 		"TextJPN": "「動作確認ＯＫ。いざという時はお任せですわ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Operation check is OK. Leave it to me in the case of an emergency.``"
+		"TextENG": "``The operation will now begin! If something happens, leave it to me.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154686,
 		"TextJPN": "沙都子が抱えているのは、どこぞの２階から拝借したラジコンカーだ。",
-		"TextENG": "Satoko stands holding a radio controlled car which she borrowed from the second floor of this building."
+		"TextENG": "Satoko was carrying a radio controlled car she borrowed from somewhere on the second floor."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154687,
 		"TextJPN": "リモコン操作で一直線に走り、括り付けてある空き缶を引き摺るという仕掛けだ。",
-		"TextENG": "She runs in a straight line with the remote controller, tying a trail of empty cans to the device."
+		"TextENG": "She tested moving it in a straight line with the remote controls, then set it up to drag an empty can fastened behind it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154688,
 		"TextJPN": "万一の際は囮に出来る。ただし、その音は、無用の関心を引いてしまう。",
-		"TextENG": "On the occasion of an emergency, we can use that as a decoy. However, the sound may attract unwanted attention."
+		"TextENG": "It could be our decoy if the worst happened. However, that sound would draw unwanted attention."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154689,
 		"TextJPN": "事務所に辿り着く為の切り札ではなく、作戦失敗時に退却する為の隙を稼ぐ切り札だ。",
-		"TextENG": "So we shouldn't use this trump card to arrive at the office, but as a trump card earning us the chance to retreat if our strategy fails."
+		"TextENG": "It wasn't a trump card to help us reach the office, it was a trump card to buy us a chance to retreat if the operation failed."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154690,
 		"TextJPN": "魅音は作戦の成功率を９５％と見積もる。しかしそれでも、失敗率を０％には出来ない。",
-		"TextENG": "Mion estimates the success rate of our operation to be at 95％. But still, we should aim for a failure rate of 0％."
+		"TextENG": "The success rate of Mion's operation was roughly 95%. But we still couldn't bring the chance of failure down to zero."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154691,
 		"TextJPN": "あらゆる事態を想定し、備えることをポリシーとする魅音は、その万一に備え、沙都子のラジコン作戦にゴーサインを与えたのだ。",
-		"TextENG": "We assumed every possible situation, and Mion created a policy in preparation, so in the case of an emergency, she green lit the radio control operation which Satoko proposed."
+		"TextENG": "It was Mion's policy to imagine all possibilities and prepare for each one of them, so to ensure that the worst possible outcome not catch them off guard, she gave the go-sign to Satoko's remote control plan."
 	},
 	{
 		"type": "MSGSET",
@@ -306,25 +306,25 @@
 		"PreTextTags": "@vS25/03/NMIO_1270.",
 		"TextJPN": "「出発するよ。……私とはある程度、距離を空けておくように」",
 		"NamesENG": "Mion",
-		"TextENG": "``Let's depart. ......And set aside some distance from one another.``"
+		"TextENG": "``I'm heading out. ......Make sure you stay a fair bit away from me.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154693,
 		"TextJPN": "慎重に扉を開け、辺りの静寂の気配を充分に感じ取ってから、……魅音はするりと外へ抜け出る。",
-		"TextENG": "The door is opened carefully, and after thoroughly taking in signs that the area is quiet...... Mion slips through the exit to the outside."
+		"TextENG": "We carefully opened the door, and once we were certain enough that everything was quiet around us...... Mion slipped outside."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154694,
 		"TextJPN": "……雛見沢と違い、何もかもがコンクリートで覆われている興宮では、案外、わずかの物音でも残響する。",
-		"TextENG": "......Unlike Hinamizawa, everything in Okinomiya is covered in concrete, so unexpectedly, even the slightest sound will echo."
+		"TextENG": "......Unlike Hinamizawa, everything in Okinomiya was covered in concrete, so even the faintest sounds echoed."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154695,
 		"TextJPN": "アスファルトの上で小さな小石を踏みつけると、それだけでかなり遠くまで音が聞こえてしまう。",
-		"TextENG": "So if I stamp a small pebble on the asphalt, I will hear that alone echo a considerable distance."
+		"TextENG": "If you stepped on a small rock on the asphalt, you could hear it from rather far away."
 	},
 	{
 		"type": "MSGSET",
@@ -333,31 +333,31 @@
 		"PreTextTags": "@vS25/03/NMIO_1280.",
 		"TextJPN": "「……こりゃあ、……裸足の方がまだマシかもね……」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Damn it...... maybe it'll be better if I walk barefoot......``"
+		"TextENG": "``......Well...... it might be better going barefoot......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154697,
 		"TextJPN": "魅音は靴を脱ぐ。",
-		"TextENG": "Mion takes off her shoes."
+		"TextENG": "Mion took off her shoes."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154698,
 		"TextJPN": "硬いゴム底では、どんなに慎重に歩いても、小石とアスファルトを擦り付ける音が殺せないのだ。",
-		"TextENG": "No matter how careful you walk, the firm rubber soles cannot suppress the sound of rubbing pebbles and asphalt."
+		"TextENG": "No matter how carefully we walked, the hard rubber soles couldn't silence the sound of pebbles scraping asphalt."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154699,
 		"TextJPN": "靴下越しとはいえ、都会っ子では表を裸足で歩くのは堪える。",
-		"TextENG": "Although she is wearing socks, but she will have to endure facing those city kids barefoot."
+		"TextENG": "Even with socks on, it would hurt a city kid to walk on the surface barefoot."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154700,
 		"TextJPN": "しかし、裸足で駆けっこや木登りが当り前な雛見沢っ子には、アスファルトを裸足で歩くなど、造作もないことだった。",
-		"TextENG": "However, kids climbing and racing up trees barefoot is pretty commonplace in Hinamizawa, so walking across the asphalt barefoot isn't any trouble at all."
+		"TextENG": "But for us Hinamizawa kids who always chased each other around, climbing trees barefoot, walking on asphalt with no shoes was nothing."
 	},
 	{
 		"type": "MSGSET",
@@ -366,7 +366,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0470.",
 		"TextJPN": "「元都会っ子の圭一さんが裸足が大丈夫か、見物ですわね？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``We'll have to see if Keiichi, a former city kid, can handle being barefoot, won't we?``"
+		"TextENG": "``It's time to see whether or not Keiichi-san, our former city kid, can tolerate going barefoot.``"
 	},
 	{
 		"type": "MSGSET",
@@ -375,7 +375,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1160.",
 		"TextJPN": "「俺ももう、だいぶ鍛えられたぜ。馬鹿にするんじゃねぇぜ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I have already trained considerably. Don't be stupid.``"
+		"TextENG": "``I've trained myself up a lot by now. Don't take me lightly.``"
 	},
 	{
 		"type": "MSGSET",
@@ -384,7 +384,7 @@
 		"PreTextTags": "@vS25/02/NREN_1080.",
 		"TextJPN": "「采ちゃんは裸足、大丈夫……？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Une-chan, are you okay barefoot......?``"
+		"TextENG": "``Une-chan, are you okay going barefoot......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -402,43 +402,43 @@
 		"PreTextTags": "@vS25/02/NREN_1090.",
 		"TextJPN": "「ごめんね。しばらくの間だけ辛抱してね……」",
 		"NamesENG": "Rena",
-		"TextENG": "``I'm sorry. You'll only have to bear it a little while......``"
+		"TextENG": "``I'm sorry. Just bear with it for a little while, okay......?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154706,
 		"TextJPN": "魅音は、裏路地から首だけを覗かせ、無人の車列が並ぶ大河の様子を見る。",
-		"TextENG": "Mion peeps from the neck of a back alley, and looks at the state of the big river where the uninhabited convoys forms a line."
+		"TextENG": "Mion poked her head out of the alley, and checked on the 'river' with rows of unoccupied cars."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154707,
 		"TextJPN": "太い歩道は見通しが良過ぎる。一気に横断して、車列の中に飛び込む他はない。",
-		"TextENG": "That big sidewalk has also very good visibility. We may have to cross it all at once, and try our best to avoid the convoy."
+		"TextENG": "It was too easy to see across the wide sidewalk. We'd have to cut across it in one go and duck behind the row of cars."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154708,
 		"TextJPN": "自称自警団たちも、その見通しの良さから、ここが見張りに最適だと理解しているようだった。",
-		"TextENG": "The self-styled vigilance committee, from the merit of their outlook, seem to understand that's the best place to keep a lookout."
+		"TextENG": "The self-proclaimed watch also realized that clear view meant it was the best place for keeping a lookout."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154709,
 		"TextJPN": "時折、懐中電灯のビームライトが歩道を一直線に照らすのがわかる。",
-		"TextENG": "Occasionally, they send beams of light in a straight line like a flashlight to light up the sidewalk."
+		"TextENG": "We could see them shining a beam of light straight down the sidewalk every now and then with their flashlights."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154710,
 		"TextJPN": "……彼らは過剰に怯え、敵を求めている。",
-		"TextENG": "......They are excessively frightened, and are only asking for an enemy."
+		"TextENG": "......They were excessively frightened, and were seeking out an enemy."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154711,
 		"TextJPN": "少しでも気配を気取られることがあれば、大騒ぎして、仲間を呼び寄せるだろう。",
-		"TextENG": "She could make a sign even just for a little while, but that could create a fuss, and then they would call their buddies over."
+		"TextENG": "If they sensed even the slightest presence, they'd cause a lot of noise and summon their friends."
 	},
 	{
 		"type": "MSGSET",
@@ -447,43 +447,43 @@
 		"PreTextTags": "@vS25/03/NMIO_1290.",
 		"TextJPN": "「………いいねぇ。おじさんはこういうスリルを求めてたんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........Good. I never knew this Old Man was looking for such a thrill.``"
+		"TextENG": "``.........This is good. I've been looking for a thrill like this.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154713,
 		"TextJPN": "魅音は鼻を伝い落ちる汗を、不敵に舐め取り笑う。",
-		"TextENG": "Sweat begins to run down Mion's nose, she smiles fearlessly and licks it up."
+		"TextENG": "Mion boldly licked up the sweat trailing down her nose and smiled."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154714,
 		"TextJPN": "ハンドサインで、続く仲間たちに待機を指示してから、タイミングを計る。",
-		"TextENG": "By a hand signature, she orders a wait to her following friends, and measures the timing."
+		"TextENG": "She used hand signs to signal her friends to wait and calculated her timing."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154715,
 		"TextJPN": "……自警団のライトは落ち着きがない。",
-		"TextENG": "......The light of the vigilance committee is restless."
+		"TextENG": "......The watch's lights were restless."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154716,
 		"TextJPN": "ふらふらきょろきょろと、忙しなく動き回る。",
-		"TextENG": "Unsteady and restless, it searches in a hurry."
+		"TextENG": "They wandered back and forth, glancing everywhere in fidgety motions."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154717,
 		"TextJPN": "怯えにより、全ての物陰を照らさずにはいられないのだ。",
-		"TextENG": "Frightened, they cannot help but to illuminate all the shadows."
+		"TextENG": "Their fear left them needing to light up every shadow."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154718,
 		"TextJPN": "その落ち着きのなさは、隙だらけとも言える……。",
-		"TextENG": "Although this restlessness is full of chances......"
+		"TextENG": "So that anxiety created plenty of openings......"
 	},
 	{
 		"type": "MSGSET",
@@ -495,31 +495,31 @@
 		"type": "MSGSET",
 		"MessageID": 154720,
 		"TextJPN": "猫のように素早く、しなやかに。魅音は歩道を駆け抜け、車列の狭間に飛び込む。",
-		"TextENG": "She moves quick as a cat, flexibly. Mion runs through the sidewalk, and dives between the convoy."
+		"TextENG": "Quick and nimble, like a cat. Mion dashed across the sidewalk and ducked into the row of cars."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154721,
 		"TextJPN": "直前までの緊張感が嘘のように、あっさりと、あっという間の出来事だった。",
-		"TextENG": "A feeling of tension lies immediately before her, quickly, it was an instant event."
+		"TextENG": "It went so quickly and easily that all her prior tension seemed misplaced."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154722,
 		"TextJPN": "物陰からその様子をうかがっていた圭一たちも、ほうっと深い安堵の息を漏らす。",
-		"TextENG": "Keiichi, who watched the situation from the shadows, sighs a very deep breath of relief."
+		"TextENG": "Keiichi and the other heaved a heavy sigh of relief as they watched from the shadows."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154723,
 		"TextJPN": "二番手の圭一も続こうとするが、魅音はまだだとサインを送る。",
-		"TextENG": "The second person is Keiichi ready to follow, but Mion has not yet sent the signal."
+		"TextENG": "Keiichi, the second one up, was about to follow after her, but Mion gave them the sign to hold."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154724,
 		"TextJPN": "慎重に車列の河を越え、対岸の歩道の様子も確認したいようだった。",
-		"TextENG": "He carefully moves beyond the convoy at the river, seemingly wanting to confirm the state of the sidewalk on the opposite side of the bank."
+		"TextENG": "It looked like she wanted to carefully cross the river of cars and check out the sidewalk on the opposite bank."
 	},
 	{
 		"type": "MSGSET",
@@ -528,61 +528,61 @@
 		"PreTextTags": "@vS25/03/NMIO_1300.",
 		"TextJPN": "「……あちゃ……。参ったね……」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Damn it...... We're in a pickle......``"
+		"TextENG": "``......Shoot...... That's bad......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154726,
 		"TextJPN": "決行の直前に屋上から偵察した時には、こんな場所に人影はなかった。",
-		"TextENG": "When I spied from the roof just before carrying out our plan, there wasn't the shadow of any person in that spot."
+		"TextENG": "When she had scouted it from the roof right before commencing the operation, there wasn't anyone over there."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154727,
 		"TextJPN": "いつの間にか対岸の歩道の向こうに、３人ほどの自警団の姿があった。",
-		"TextENG": "But before I even knew it, on the other side of the sidewalk on the opposite bank, there was the figures of about three vigilance committee members."
+		"TextENG": "But at some point, three men from the watch had taken up posts on the opposite shore."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154728,
 		"TextJPN": "……こちらへ向かってくる。",
-		"TextENG": "......They're coming towards here."
+		"TextENG": "......They were heading right towards her."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154729,
 		"TextJPN": "大丈夫、バレてるわけじゃない。車列を適当に照らしながら歩いてるだけだ。",
-		"TextENG": "It's alright, they don't know about us. Then I only have to walk against the light of the convoy properly."
+		"TextENG": "She wasn't exposed just yet. They were just walking around shining lights randomly at the cars."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154730,
 		"TextJPN": "魅音は冷静に、車高の高いトラックを見つけると、その下に潜り込む……。",
-		"TextENG": "Mion acts calm, and finds a truck with a large vehicle height, she crawls under it......"
+		"TextENG": "Mion calmly found a truck with a high frame and slid underneath it......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154731,
 		"TextJPN": "大丈夫大丈夫……。バレてるわけじゃない。",
-		"TextENG": "I'll be fine, I'll be fine...... They won't find me."
+		"TextENG": "It's okay, it's okay...... They haven't spotted us."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154732,
 		"TextJPN": "仮に気付いてたら、あんなにも呑気に歩いてるものか……。",
-		"TextENG": "But if they do, I won't be able to walk it off......"
+		"TextENG": "If they had noticed us, would they be walking so carelessly......?"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154733,
 		"TextJPN": "９９％大丈夫だとわかっていても、……絶対ではないことを意識してしまうと、脂汗が浮くのがわかる。",
-		"TextENG": "Even if I know I'll be 99％ okay...... my conscious won't let me, I can see even my greasy sweat fall off."
+		"TextENG": "Even if she was 99% certain she was safe... she could feel herself sweating."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154734,
 		"TextJPN": "……情けないね、園崎魅音。おじさんが、隠れん坊ごときで冷や汗を垂らすなんてね……。",
-		"TextENG": "......Shame on you, Mion Sonozaki. Old Man would never drip a greasy sweat even when playing hide-and-seek......"
+		"TextENG": "......Pathetic, Mion Sonozaki. To think I'd be sweating this badly over a little hide and seek......"
 	},
 	{
 		"type": "MSGSET",
@@ -591,7 +591,7 @@
 		"PreTextTags": "@vS25/00/NBOA_0030.",
 		"TextJPN": "「感染野郎を絶対に見逃すんじゃねぇぞ……」",
 		"NamesENG": "Mob",
-		"TextENG": "``Don't let that infected bastard get away with it......``"
+		"TextENG": "``Make sure you don't overlook any infected......``"
 	},
 	{
 		"type": "MSGSET",
@@ -600,19 +600,19 @@
 		"PreTextTags": "@vS25/00/NBOB_0020.",
 		"TextJPN": "「連中は脳をやられてる。そして俺たちに噛み付いて、ウィルスを伝染させようとしてるんだ」",
 		"NamesENG": "Mob",
-		"TextENG": "``Those guys have had their brains stolen. So if they bite us, we'll then be carrying the virus.``"
+		"TextENG": "``All their brains are damaged. Plus, they'll try to bite us and spread the virus further.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154737,
 		"TextJPN": "脳をやられてるのはあんたたちの方でしょーが。魅音は苦笑いする。",
-		"TextENG": "Even though they have had their brains stolen. Mion smiles wryly."
+		"TextENG": "You're the ones with damaged brains, though. Mion smirked."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154738,
 		"TextJPN": "しかし、彼らの足が、自分の潜んでいるトラックの前で止まると、その笑いは凍りつく。",
-		"TextENG": "However, their footsteps come to a hard frozen stop in front of her, and she stops smiling."
+		"TextENG": "Still, once their feet stopped in front of the truck she hid under, her smile froze."
 	},
 	{
 		"type": "MSGSET",
@@ -621,7 +621,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1170.",
 		"TextJPN": "「み、見つかったのか…？！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Ha-Has she been found...?!``"
+		"TextENG": "``D-Did they find her...?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -630,7 +630,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0240.",
 		"TextJPN": "「……も、……もう駄目………、」",
 		"NamesENG": "Une",
-		"TextENG": "``......I knew it was useless.........``"
+		"TextENG": "``......We're, we're done for.........``"
 	},
 	{
 		"type": "MSGSET",
@@ -639,7 +639,7 @@
 		"PreTextTags": "@vS25/02/NREN_1100.",
 		"TextJPN": "「落ち付いて。……ちょっと雰囲気が違う」",
 		"NamesENG": "Rena",
-		"TextENG": "``Easy. ......The atmosphere's slightly different.``"
+		"TextENG": "``Calm down. ......They're not acting like they have.``"
 	},
 	{
 		"type": "MSGSET",
@@ -648,25 +648,25 @@
 		"PreTextTags": "@vS25/04/NSAT_0480.",
 		"TextJPN": "「あいつら、荷台に？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Are they on the loading platform?``"
+		"TextENG": "``They're getting in?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154743,
 		"TextJPN": "自警団の男たちは、魅音の潜むトラックの荷台によじ登っていく。",
-		"TextENG": "The men of the vigilance committee climb into the back of the truck which Mion lurks under."
+		"TextENG": "The men from the watch climbed up into the bed of the truck Mion had hidden under."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154744,
 		"TextJPN": "どうやら荷台の上にはパイプ椅子か何かが置かれているらしい。男たちはそれに腰掛けている。",
-		"TextENG": "They place something like a pipe chair on top of the loading platform. The men sit down on it."
+		"TextENG": "Apparently there were folding chairs or something inside the truck bed. The men then sat down on them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154745,
 		"TextJPN": "つまり、男たちは魅音の真上に陣取ったわけだ。即ち、魅音はまるで、虫ピンに刺された昆虫のような状態だ……。",
-		"TextENG": "In other words, those men have placed themselves right above Mion. That is, Mion is now in the state of an insect stabbed by a setting pin......"
+		"TextENG": "Which meant the men had taken position directly above Mion. She was practically a bug pinned in place......"
 	},
 	{
 		"type": "MSGSET",
@@ -675,37 +675,37 @@
 		"PreTextTags": "@vS25/03/NMIO_1310.",
 		"TextJPN": "「ちょ……、マジ………？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Is this...... for real.........?``"
+		"TextENG": "``Hey...... Seriously......?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154747,
 		"TextJPN": "魅音の額を脂汗が滴り落ちる。",
-		"TextENG": "A greasy sweat drips off Mion."
+		"TextENG": "Sweat dripped from Mion's forehead."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154748,
 		"TextJPN": "状況は圭一たちにも理解できた。魅音は、動くに動けなくなってしまう。",
-		"TextENG": "Keiichi is able to understand the situation. However Mion has become stuck and cannot move."
+		"TextENG": "Keiichi and the others understood the situation just as well. Mion couldn't move at all."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154749,
 		"TextJPN": "トラックの下から這い出る時の音を聞かれない保証はない。そればかりでなく、魅音には上の状況がまったく見えない。",
-		"TextENG": "There is no guarantee they will not hear the sound of her crawling out from under the truck. Not only that, but Mion will also not be able to see what's above her."
+		"TextENG": "There was no guaranteeing they wouldn't hear anything when she crawled out from under the truck. Not only that, but Mion couldn't see what was going on above her at all."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154750,
 		"TextJPN": "仮に音をさせずに抜け出られたとしても、その時に気紛れな彼らが向けていた視界に入らない保証もない。",
-		"TextENG": "And even if she were to escape without a sound, there is no guarantee she won't enter the whimsical view they are facing at that time."
+		"TextENG": "Even if she were able to slip out without making a sound, there was no guarantee they wouldn't happen to look around and catch sight of her."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154751,
 		"TextJPN": "……彼らが立ち去るまで、魅音は動くことが出来ないのだ……。",
-		"TextENG": "......Therefore until they leave, Mion can't move at all......"
+		"TextENG": "......Mion couldn't move from there until they left that post......"
 	},
 	{
 		"type": "MSGSET",
@@ -714,7 +714,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0250.",
 		"TextJPN": "「ど、どうすればいいのかわかる……、わけないのです……」",
 		"NamesENG": "Une",
-		"TextENG": "``I-I don't know what...... we should do......``"
+		"TextENG": "``I-It's not like I know, what to do......``"
 	},
 	{
 		"type": "MSGSET",
@@ -723,7 +723,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0490.",
 		"TextJPN": "「いよいよ秘密兵器の出番ですの？！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Maybe it's finally time for our secret weapon?!``"
+		"TextENG": "``Is it finally time for our secret weapon?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -732,7 +732,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1180.",
 		"TextJPN": "「そいつは最後の手段だ。魅音は救えるが、大騒ぎになっちまう…！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``That's our last resort. It may be able to save Mion, but it will also make an uproar...!``"
+		"TextENG": "``Only as a last resort. We could save Mion, but that would cause way too much noise...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -741,19 +741,19 @@
 		"PreTextTags": "@vS25/02/NREN_1110.",
 		"TextJPN": "「でも準備はしておいて」",
 		"NamesENG": "Rena",
-		"TextENG": "``However, we have to be prepared.``"
+		"TextENG": "``Still, get it ready.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154756,
 		"TextJPN": "沙都子は頷き、ラジコンカーを歩道にセットし、空き缶を括り付ける。",
-		"TextENG": "Satoko nods, and sets the radio controlled car on the sidewalk, with its attached empty cans."
+		"TextENG": "Satoko nodded, set her remote controlled car on the sidewalk, and fastened the empty can to it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154757,
 		"TextJPN": "こいつを走らせれば、その騒々しい音は必ず彼らの気を引く。",
-		"TextENG": "The little fellow is now ready to be sent off, able to create a noisy sound to draw their attention by all means."
+		"TextENG": "Once we let it loose, it was sure to draw their attention."
 	},
 	{
 		"type": "MSGSET",
@@ -762,7 +762,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1190.",
 		"TextJPN": "「何れにせよ、作戦は失敗だな。何とか魅音が脱出できる隙を作って、今回は出直した方がいい」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``In any case, current strategy already failed. We still have to create a chance for Mion to escape, we won't have another chance.``"
+		"TextENG": "``Either way, the operation's failed. We need to create an opening for Mion to make her escape. It'll be better to try again later.``"
 	},
 	{
 		"type": "MSGSET",
@@ -771,43 +771,43 @@
 		"PreTextTags": "@vS25/02/NREN_1120.",
 		"TextJPN": "「……同感だね。今回はたまたまタイミングが悪かっただけ。出直そう」",
 		"NamesENG": "Rena",
-		"TextENG": "``......I agree. We won't have another chance if we mess up our timing. Let's go.``"
+		"TextENG": "``......I agree. We just had bad timing. Let's try again.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154760,
 		"TextJPN": "冷静な部活メンバーは、数々の部活の修羅場で、退くべき時を身に付けている。",
-		"TextENG": "We calm club members have shared many scenes of bloodshed in numerous club activities, but we know when we should retreat."
+		"TextENG": "The club members knew exactly when to pull out thanks to our many dangerous club activities."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154761,
 		"TextJPN": "同じことは、当然、魅音も考えている。圭一たちが脱出のチャンスを作るだろう。その隙に抜け出すしかない。",
-		"TextENG": "Naturally, Mion is probably thinking the same thing. But Keiichi and we have to give her a chance to escape. There is no other choice but to get her out of there."
+		"TextENG": "Naturally, Mion was thinking the same thing. Keiichi and the others would probably create a chance for her to escape. She'd have to slip out in that moment."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154762,
 		"TextJPN": "……しかし、それは今すぐではない。",
-		"TextENG": "......However, now is the right time."
+		"TextENG": "......Still, they had to wait for a time."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154763,
 		"TextJPN": "上の彼らが、荷台から立ち去り、再びどこかへ行ってしまう可能性もあるのだ。",
-		"TextENG": "As those people above her may leave the loading platform, and go somewhere else."
+		"TextENG": "There was still a chance the men in the bed above her would stand back up and go off somewhere else."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154764,
 		"TextJPN": "撤退に成功しても、騒ぎを起こせば、再びの渡河作戦はより困難なものとなってしまうだろう。",
-		"TextENG": "But even if we succeed in retreating, an uproar will be lit, causing it to be more difficult for us if we want to try crossing again."
+		"TextENG": "Even if they manage to retreat, causing an uproar now would make it even more difficult to cross the river a second time."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154765,
 		"TextJPN": "魅音は、心臓に虫ピンを打ち込まれたようなこの状況下であっても、冷静に勝利のチャンスを窺い続けている……。",
-		"TextENG": "And even if Mion is under a situation such as a setting pin on her heart, we have to continue to calmly pray for a chance at victory......"
+		"TextENG": "Even though Mion practically had a pin pushed through her heart, we had to stay calm and wait for our chance at victory......"
 	},
 	{
 		"type": "MSGSET",
@@ -816,13 +816,13 @@
 		"PreTextTags": "@vS25/01/NKEI_1200.",
 		"TextJPN": "「采ちゃんを先に安全地帯に戻した方がいい」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``You had better return to the safety zone we were at earlier, Une-chan.``"
+		"TextENG": "``We should get Une-chan back to safety first.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154767,
 		"TextJPN": "彼女は裸足に慣れていない。いざという時、全力疾走が難しい可能性がある。",
-		"TextENG": "She isn't used to being barefoot. So in the case of an emergency, the possibility of her sprinting will be difficult."
+		"TextENG": "She wasn't used to being barefoot. She might have trouble running full tilt if it came down to that."
 	},
 	{
 		"type": "MSGSET",
@@ -831,7 +831,7 @@
 		"PreTextTags": "@vS25/02/NREN_1130.",
 		"TextJPN": "「圭一くん、采ちゃんを連れて退路を確保して。沙都子ちゃんは私の背後を守って」",
 		"NamesENG": "Rena",
-		"TextENG": "``Keiichi-kun, secure a path of retreat for Une-chan. Satoko-chan, watch my back.``"
+		"TextENG": "``Keiichi-kun, take Une-chan and secure our retreat. Satoko-chan, watch my back.``"
 	},
 	{
 		"type": "MSGSET",
@@ -840,7 +840,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0500.",
 		"TextJPN": "「お任せでしてよ。圭一さん、責任重大ですわよ！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Leave it to me. Keiichi-san, I'm holding you responsible if anything happens to her!``"
+		"TextENG": "``Leave it to me. Keiichi-san, you've got a great responsibility!``"
 	},
 	{
 		"type": "MSGSET",
@@ -849,7 +849,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1210.",
 		"TextJPN": "「わかってる。ここは任すぜっ。行こう、采ちゃん…！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Understood. Leave it to me. Let's go, Une-chan...!``"
+		"TextENG": "``I know. I'll leave this to you two. Let's go, Une-chan...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -858,25 +858,25 @@
 		"PreTextTags": "@vS25/50/NUNE_0260.",
 		"TextJPN": "「は、……はいです……」",
 		"NamesENG": "Une",
-		"TextENG": "``......Y-Yes......``"
+		"TextENG": "``Y-Yes......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154772,
 		"TextJPN": "圭一は采を連れ、一度、離脱する。",
-		"TextENG": "Keiichi takes Une at once, and leaves."
+		"TextENG": "Keiichi took Une and left for the time being."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154773,
 		"TextJPN": "……雛見沢で死線を潜ったつもりでいた。しかし、所詮は老人たちばかりの雛見沢。そして地の利は自分たちにもあった。",
-		"TextENG": "......I thought I was on the verge of death in Hinamizawa. However, Hinamizawa was just full of old people after all. And it had a geographical advantage."
+		"TextENG": "......He thought he'd faced death in Hinamizawa. But Hinamizawa was full of nothing but old people. Plus they had the homeground advantage there."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154774,
 		"TextJPN": "しかし、ここはまるで勝手が違う、まさにアウェーなのだ。",
-		"TextENG": "However, I feel totally lost here, I don't even know what I'm doing."
+		"TextENG": "But they were playing an away game under different rules in Okinomiya."
 	},
 	{
 		"type": "MSGSET",
@@ -885,7 +885,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1220.",
 		"TextJPN": "「こんなことなら、もっと興宮で遊んでれば良かったぜ……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Such a thing, you should have played more in Okinomiya......``"
+		"TextENG": "``If I'd known this was going to happen, I would've played around here more......``"
 	},
 	{
 		"type": "MSGSET",
@@ -894,19 +894,19 @@
 		"PreTextTags": "@vS25/50/NUNE_0270.",
 		"TextJPN": "「はぁっ、はぁっ、はぁっ……、」",
 		"NamesENG": "Une",
-		"TextENG": "``*Pant-pant*, *pant-pant*, *pant-pant*......``"
+		"TextENG": "``Hahh, hahh, hahh......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154777,
 		"TextJPN": "采の息が荒い。",
-		"TextENG": "Une's breathing is rough."
+		"TextENG": "Une was panting."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154778,
 		"TextJPN": "無理もない。これだけの緊張の中にいるのだ。疲労だけでなく、恐怖感でも息が上がる。",
-		"TextENG": "It's understandable. She is under all this stress. Fatigue has also been building up, so her breathing has naturally raised in fear."
+		"TextENG": "No one could blame her. Things were so tense. Her breathing was ragged from both exhaustion and fear."
 	},
 	{
 		"type": "MSGSET",
@@ -915,7 +915,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1230.",
 		"TextJPN": "「少し休んで呼吸を整えよう」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``We can take a rest here, that'll help your breathing.``"
+		"TextENG": "``Let's rest a moment and catch our breath.``"
 	},
 	{
 		"type": "MSGSET",
@@ -924,19 +924,19 @@
 		"PreTextTags": "@vS25/50/NUNE_0280.",
 		"TextJPN": "「あ、……ありがとう……です……、はぁ……はぁ……、」",
 		"NamesENG": "Une",
-		"TextENG": "``Th-Thank you...... ......*Pant-pant*... ...*pant-pant*......``"
+		"TextENG": "``Th...... Thank...... you...... Hahh...... hahh......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154781,
 		"TextJPN": "采の呼吸が静まったところで、圭一は五感を研ぎ澄まし、辺りの気配を探る。",
-		"TextENG": "They stop in place and Une's breathing begins to subside, while Keiichi sharpens his five senses, investigating the area for any signs."
+		"TextENG": "While Une calmed her breathing, Keiichi sharpened his senses and searched for anyone nearby."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154782,
 		"TextJPN": "……すぐにそれは感じられた。",
-		"TextENG": "......He senses something immediately."
+		"TextENG": "......He sensed one."
 	},
 	{
 		"type": "MSGSET",
@@ -945,7 +945,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1240.",
 		"TextJPN": "「まずいな、……誰か来る」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``This is bad...... someone's coming.``"
+		"TextENG": "``Not good...... Someone's coming.``"
 	},
 	{
 		"type": "MSGSET",
@@ -954,7 +954,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0290.",
 		"TextJPN": "「えっ……」",
 		"NamesENG": "Une",
-		"TextENG": "``Eh......``"
+		"TextENG": "``Huh......?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -963,25 +963,25 @@
 		"PreTextTags": "@vS25/01/NKEI_1250.",
 		"TextJPN": "「足音は複数。自警団だな。…………………」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Multiple footsteps. It's the vigilance committee. .....................``"
+		"TextENG": "``I hear several footsteps. It's the watch. .....................``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154786,
 		"TextJPN": "隠れる場所に乏しい。間違って見つかれば、魅音たちの退路も絶ってしまうことになる。危険は断じて冒せない。",
-		"TextENG": "There were few places to hide. If they were to be found by mistake, it would cut off the path of escape for Mion and the others. We can't take any chances."
+		"TextENG": "There was hardly anywhere to hide. If they screwed up and got caught, then their escape route would be cut off. They couldn't take any risks."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154787,
 		"TextJPN": "他の道もない。彼らが他へ行ってくれることを祈って、戻らざるを得ない。",
-		"TextENG": "There is no other way. I can only pray and hope that they'll turn around and avoid my friends."
+		"TextENG": "There were no other streets. They had to turn back and pray the men went somewhere else."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154788,
 		"TextJPN": "しかし、幹線道路が彼らの警戒線の動脈らしい。まっすぐレナたちの場所に向かう公算が高い。",
-		"TextENG": "However, the main road is likely the artery of their police cordon. So the likelihood they'll head straight towards Rena and the others is very high."
+		"TextENG": "But the main street was the primary artery for their watch circuit. There was a high probability they would head directly toward Rena and the others."
 	},
 	{
 		"type": "MSGSET",
@@ -990,7 +990,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1260.",
 		"TextJPN": "「戻ろう。ここじゃ出くわせない」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Let's go back. They'll come across us if we stay here.``"
+		"TextENG": "``Let's head back. We can't run into them here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -999,7 +999,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0300.",
 		"TextJPN": "「ま、また戻る……、のですか……。は、挟み撃ち……」",
 		"NamesENG": "Une",
-		"TextENG": "``G-Go back...... ......Is it a p-pincer attack......``"
+		"TextENG": "``W-We're going back, again......? A-Attacking us from both sides......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1008,25 +1008,25 @@
 		"PreTextTags": "@vS25/01/NKEI_1270.",
 		"TextJPN": "「になるかもな。とにかく戻ろう…！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I guess you could say that. Anyway, let's go back now...!``"
+		"TextENG": "``That might happen. Anyway, let's head back...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154792,
 		"TextJPN": "圭一の予感は的中する。彼らは他の路地へ行く様子はなく、まっすぐに幹線道路を目指している。",
-		"TextENG": "Keiichi's premonition hit the mark. However, it seems they don't run into another alley, but aim straight for the main road."
+		"TextENG": "Keiichi's prediction was spot on. They didn't go down any other street, and headed straight for the main road."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154793,
 		"TextJPN": "歪んだ金属バットを担いだ大学生くらいの若者たちが、３人もいる。",
-		"TextENG": "I can see some youths about the age of university students carrying crooked metal bats, there's about four of them."
+		"TextENG": "There were four young men about college age carrying bent metal bats."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154794,
 		"TextJPN": "このままではレナたちは背後を突かれてしまう。",
-		"TextENG": "At this rate, Rena and the others will be caught off guard and attacked from behind."
+		"TextENG": "At this rate, they'd attack Rena and the others from the rear."
 	},
 	{
 		"type": "MSGSET",
@@ -1035,7 +1035,7 @@
 		"PreTextTags": "@vS25/02/NREN_1140.",
 		"TextJPN": "「挟み撃ち？　それはまずいね……」",
 		"NamesENG": "Rena",
-		"TextENG": "``A pincer attack? This is bad......``"
+		"TextENG": "``We're pincered in? That's bad......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1044,7 +1044,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0510.",
 		"TextJPN": "「面白いじゃございませんの。まさか、部活程度にはハラハラできるとは思いませんでしたのよ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``This isn't funny at all. No way, I didn't think I'd ever feel this nervous in a club activity.``"
+		"TextENG": "``Well, isn't this interesting? I hardly thought I'd get to feel as much suspense as I do during club activities.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1053,7 +1053,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1280.",
 		"TextJPN": "「退路はない。としたら、どうする？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``We can't retreat either. What should we do?``"
+		"TextENG": "``There's no way back. So then what do we do?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1062,7 +1062,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0310.",
 		"TextJPN": "「ま、まさか……、……なのですか……」",
 		"NamesENG": "Une",
-		"TextENG": "``N-No way...... ......What do we do......``"
+		"TextENG": "``Y-You don't mean...... ......do you......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1071,7 +1071,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0520.",
 		"TextJPN": "「後ろが駄目なら、前に進む他ありませんでしてよっ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``It's useless to come at our backs, they really should have thought their plan through.``"
+		"TextENG": "``If we can't go back, then we have to go forward!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1080,43 +1080,43 @@
 		"PreTextTags": "@vS25/02/NREN_1150.",
 		"TextJPN": "「……ラジコンのトラップを使い、敵の目を引きつけ、……その隙に前へ進むしかない」",
 		"NamesENG": "Rena",
-		"TextENG": "``......Use the radio controlled trap, that will attract the enemy's eyes...... we have no choice but to take our chances and move forward.``"
+		"TextENG": "``......We'll have to use our remote control trap to draw the enemy's attention ......and then seize that chance to advance.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154801,
 		"TextJPN": "危険な作戦だ。この場だけはやり過ごせるだろう。",
-		"TextENG": "This is a dangerous strategy. I'm unsure if we'll even get past."
+		"TextENG": "It was a dangerous strategy. We'd probably be able to get out of this pinch..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154802,
 		"TextJPN": "しかし、騒ぎになれば、眠っている自警団たちも一斉に起き出すだろう。",
-		"TextENG": "However, we have to take advantage of the commotion, as most of the vigilance committee will be asleep once we begin."
+		"TextENG": "But once they start shouting, the rest of the watch will all wake up at once."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154803,
 		"TextJPN": "それが運悪く進行方向と鉢合わせになったら、文字通り袋のネズミだ。",
-		"TextENG": "Unfortunately, running in their direction, we could end up in a literal mouse trap."
+		"TextENG": "If we get unlucky enough to run into them on our way forward, then we'll be trapped like rats."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154804,
 		"TextJPN": "ほんの２～３人なら、部活メンバー総掛かりでなら、何とか出来ないこともないだろう。",
-		"TextENG": "Just 2-3 people, that's all the club members we need, we can do this."
+		"TextENG": "If it's just two or three people, then we can handle them somehow with our club members' full might."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154805,
 		"TextJPN": "しかし、騒ぎになって大勢が駆けつけてきたら、所詮は子供の自分たちには抗いようがない。",
-		"TextENG": "However, a great number of people may rush us in such an uproar, and after all, I doubt they'll hesitate to fight against children."
+		"TextENG": "But if the uproar brings a huge crowd chasing after us, then we'll just be kids, unable to fight back."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154806,
 		"TextJPN": "だが、いくつもの不運が重なりつつも、勝率ゼロのゲームではない。",
-		"TextENG": "But, even though many misfortunes have happened at the same time, our winning percentage at this game isn't zero."
+		"TextENG": "Still, even with a few misfortunes thrown our way, this wasn't a game with no chance of victory."
 	},
 	{
 		"type": "MSGSET",
@@ -1125,7 +1125,7 @@
 		"PreTextTags": "@vS25/02/NREN_1160.",
 		"TextJPN": "「沙都子ちゃん、トラップ、用意……」",
 		"NamesENG": "Rena",
-		"TextENG": "``Satoko-chan, ready the trap......``"
+		"TextENG": "``Satoko-chan, ready your trap......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1134,7 +1134,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0530.",
 		"TextJPN": "「いつでもどうぞですわ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Right.``"
+		"TextENG": "``Ready whenever you are.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1143,7 +1143,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1290.",
 		"TextJPN": "「歩道はＯＫだ。今なら渡れる…！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``The sidewalk is OK. It can cross now...!``"
+		"TextENG": "``Sidewalk's clear. We can cross now...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1161,7 +1161,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0540.",
 		"TextJPN": "「お任せですわ！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Leave everything to me!``"
+		"TextENG": "``Leave it to me!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1170,7 +1170,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1300.",
 		"TextJPN": "「行くぞ、采ちゃん…！　走るんだ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Go, Une-chan...! Run!``"
+		"TextENG": "``Let's go, Une-chan...! Run!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1179,31 +1179,31 @@
 		"PreTextTags": "@vS25/50/NUNE_0320.",
 		"TextJPN": "「走らない……、わけはないのですっ」",
 		"NamesENG": "Une",
-		"TextENG": "``I will run...... There isn't any reason not to.``"
+		"TextENG": "``It's not, like I can't run!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154814,
 		"TextJPN": "一同は一気に横断し、車列に飛び込む。",
-		"TextENG": "All the club members cross at once, and jump into the convoy."
+		"TextENG": "We all crossed at once and ducked into the row of cars."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154815,
 		"TextJPN": "しかし、その走り込む気配はトラック荷台の男たちに気取られてしまうのは防げない。",
-		"TextENG": "However, their trick should affect the men at the trucks loading bay, so they can run past them."
+		"TextENG": "But there was no way to prevent the men in the truck from noticing our dash."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154816,
 		"TextJPN": "彼らが何事かと目を向けたその時、沙都子のラジコントラップが発動する。",
-		"TextENG": "At that time, everyone turns their attention, to the radio controlled trap Satoko put into operation."
+		"TextENG": "The moment they looked over to see what it was, Satoko's remote control trap activated."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154817,
 		"TextJPN": "括り付けられた空き缶を引き摺り、激しい金属音を立てながら歩道を疾走する。",
-		"TextENG": "It drags its trail of empty cans, and races at full speed on the sidewalk while making an intense metallic sound."
+		"TextENG": "The car dragged the empty can fastened to it, making a loud metal noise as it raced down the sidewalk."
 	},
 	{
 		"type": "MSGSET",
@@ -1212,7 +1212,7 @@
 		"PreTextTags": "@vS25/00/NBOA_0040.",
 		"TextJPN": "「なッ、何だ？！　何の音だ？！」",
 		"NamesENG": "Mob",
-		"TextENG": "``What?! What is that sound?!``"
+		"TextENG": "``W-What?! What's that sound?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1221,31 +1221,31 @@
 		"PreTextTags": "@vS25/00/NBOB_0030.",
 		"TextJPN": "「逃げるぞッ、追え！！　感染野郎に違いねぇ！！」",
 		"NamesENG": "Mob",
-		"TextENG": "``Someone's escaping. After them!! It must be one of those infected bastards!!``"
+		"TextENG": "``They're running! After them!! It has to be the infected!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154820,
 		"TextJPN": "疑心暗鬼と恐怖を凶暴な攻撃性に変え、男たちはいきり立つ。",
-		"TextENG": "They change from fear and paranoia into a ferocious aggression, the men fly into a rage."
+		"TextENG": "Their paranoia and fear turned into violent aggression and anger."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154821,
 		"TextJPN": "トラックの荷台から、車列の屋根やボンネットの上に飛び降り、ラジコンカーの騒音の方へ駆け出す。",
-		"TextENG": "From the truck's loading bay, they jump off its roof onto the bonnet of the convoy, and begin to run towards the noise of the radio controlled car."
+		"TextENG": "The men in the truck leapt onto car roofs and car hoods, chasing after the loud remote control car."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154822,
 		"TextJPN": "深夜の静寂は破られ、あちこちから怒鳴り声やホイッスルの音が聞こえてくる。街の狂気は完全に目を覚ましてしまった。",
-		"TextENG": "The late-night silence has been broken, as the sound of whistling and yelling from many places can be heard. This town of madness is now completely awake."
+		"TextENG": "The silence of night was shattered, with angry cries and whistles blasting from here and there. The city's madness was awakened."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154823,
 		"TextJPN": "だが、トラックの下に釘付けにされていた魅音は解放される。",
-		"TextENG": "But, Mion who was nailed under the truck, is now free."
+		"TextENG": "But Mion was released from her prison under the truck."
 	},
 	{
 		"type": "MSGSET",
@@ -1254,7 +1254,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1320.",
 		"TextJPN": "「何やってんの！　まだちょっと早いでしょ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``What were you thinking! That was too early!``"
+		"TextENG": "``What are you doing?! It's still too early for that!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1263,7 +1263,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1310.",
 		"TextJPN": "「挟み撃ちだったんだ！　仕掛けないわけにはいかなかった！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``They were performing a pincer attack! We had to use the device!``"
+		"TextENG": "``We were pincered! We had to set it off!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1272,7 +1272,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0550.",
 		"TextJPN": "「采さん、根性をお見せくださいまし！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Une-san, please show them your spirit!``"
+		"TextENG": "``Une-san, time to show us what you're made of!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1281,7 +1281,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0330.",
 		"TextJPN": "「はぁッ、はあッ、はあッ…！！」",
 		"NamesENG": "Une",
-		"TextENG": "``*Pant-pant*, *pant-pant*, *pant-pant*...!!``"
+		"TextENG": "``Hahh, hahh, hahh...!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1290,25 +1290,25 @@
 		"PreTextTags": "@vS25/02/NREN_1180.",
 		"TextJPN": "「やっぱり後ろには戻れない！　次々にやってくる！」",
 		"NamesENG": "Rena",
-		"TextENG": "``After all, we can't go back! They're coming one after another!``"
+		"TextENG": "``We can't go back! There's more coming that way!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154829,
 		"TextJPN": "ついさっきまで一同が潜んでいた路地からは、次々に目を血走らせた暴徒たちが駆け出してくる。",
-		"TextENG": "From the alley where everyone lay hidden in until just a few moments ago, mobs who have let their eyes become bloodshot chase out one after another."
+		"TextENG": "One after another, rioters with bloodshot eyes dashed out of the alley everyone had just been hiding in."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154830,
 		"TextJPN": "きっと、近くに彼らが詰める建物か何かがあったのだろう。",
-		"TextENG": "Surely, there must be a building where we can pack them in close."
+		"TextENG": "There must have been a building or something housing them all nearby."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154831,
 		"TextJPN": "やはり進まず、安全地帯に戻るという道は絶たれている。進む他はない。",
-		"TextENG": "After all, we can't advance, as the path to return to the safety zone has been cut off. So we can't help, but to advance."
+		"TextENG": "The option of turning back and returning to safety was cut off. We had to move forward."
 	},
 	{
 		"type": "MSGSET",
@@ -1317,7 +1317,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1330.",
 		"TextJPN": "「進むしかないなら進むよ！　もう大して距離はないんだ」",
 		"NamesENG": "Mion",
-		"TextENG": "``We don't have any choice but to move forward! Let's keep a distance.``"
+		"TextENG": "``If we have to go forward, then forward we go! There's not much distance left.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1326,7 +1326,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1320.",
 		"TextJPN": "「園崎組の人たちが、魅音の顔を忘れてないことを祈るぜっ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``People of the Sonozaki family, pray that they do not forget Mion's face.``"
+		"TextENG": "``I just pray the Sonozaki Group hasn't forgotten what you look like.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1335,7 +1335,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1340.",
 		"TextJPN": "「はっははは、圭ちゃん、面白いことを言うねー！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ahh ha ha ha, Kei-chan, you say the most funny things!``"
+		"TextENG": "``Hahahaha, Kei-chan, you sure say some funny things!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1344,7 +1344,7 @@
 		"PreTextTags": "@vS25/02/NREN_1190.",
 		"TextJPN": "「油断しない！　園崎組の事務所の中に入るまで気を抜いちゃ駄目だよ！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Let's not get careless! We musn't relax until we enter the the Sonozaki family office!``"
+		"TextENG": "``Don't let your guard down! We can't relax until we've made it inside the Sonozaki Group's office!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1353,7 +1353,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0560.",
 		"TextJPN": "「同感ですわね。詩音さんに、お姉なんか知りません、アッカンベーって言われる可能性が残ってましてよ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``I agree. I don't know about your sister Shion-san, but she's likely to give us an akanbee if something happens.``"
+		"TextENG": "``Agreed. There's still a chance Shion-san might say, 'who the heck are you, plbbt!'``"
 	},
 	{
 		"type": "MSGSET",
@@ -1362,7 +1362,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1330.",
 		"TextJPN": "「そうだ。それより魅音、ヘソ踊りの約束、忘れるなよ？　采ちゃんが梯子を下ろしてくれる時にしたぞ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``You're right about that. And Mion, you promised to navel dance, remember? It was when Une-chan lowered that ladder!``"
+		"TextENG": "``True. More importantly, Mion, don't forget your promise to belly dance for us. You said you would when Une-chan lowered that ladder!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1371,7 +1371,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1350.",
 		"TextJPN": "「イッヒッヒ、おじさん、そんな約束したっけぇ？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Eek, did Old Man make such a promise?``"
+		"TextENG": "``Ihihi, did I say that?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1380,7 +1380,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0340.",
 		"TextJPN": "「はぁッ、はぁッ、はぁ…！！」",
 		"NamesENG": "Une",
-		"TextENG": "``*Pant-pant*, *pant-pant*, *pant-pant*...!!``"
+		"TextENG": "``Hahh, hahh, hahh...!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1389,7 +1389,7 @@
 		"PreTextTags": "@vS25/02/NREN_1200.",
 		"TextJPN": "「采ちゃん、しっかり！　もう一息だって！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Une-chan, be strong! Just take another breath!``"
+		"TextENG": "``Une-chan, hang in there! Just a little further!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1398,25 +1398,25 @@
 		"PreTextTags": "@vS25/03/NMIO_1360.",
 		"TextJPN": "「そこを曲がってすぐだよ！@k@|@y@vS25/03/NMIO_1361.　……え？！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Turn right up ahead!@k@|@y@vS25/03/NMIO_1361. .........Eh?!``"
+		"TextENG": "``It's right around that corner!@k@|@y@vS25/03/NMIO_1361. ......Huh?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154842,
 		"TextJPN": "魅音は完全に気を許していたと思う。",
-		"TextENG": "Mion has been caught completely off guard."
+		"TextENG": "I think Mion completely let her guard down."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154843,
 		"TextJPN": "ラストスパートして、ゴールのテープを千切るだけ。そう思っていたはずだ。",
-		"TextENG": "Last spurt, and the tape of their goal has been torn off. They should have thought this through."
+		"TextENG": "All we had left was to cut the tape at the finish line after our final spurt."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154844,
 		"TextJPN": "だが、ゴールのテープは、とても千切れるようなシロモノではなかった。",
-		"TextENG": "But, their goal tape was already broken off in the first place."
+		"TextENG": "I'm sure that's what she thought. But the finish line wasn't something we could cut through."
 	},
 	{
 		"type": "MSGSET",
@@ -1425,7 +1425,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1370.",
 		"TextJPN": "「あれぇええ？！　ど、どういうことォ？！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Whaaaaaat?! H-How did this happen?!``"
+		"TextENG": "``Huhhhh?! W-What's going on?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1434,55 +1434,55 @@
 		"PreTextTags": "@vS25/01/NKEI_1340.",
 		"TextJPN": "「な、何だよこれ？！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Wh-What is this?!``"
+		"TextENG": "``W-What is this?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154847,
 		"TextJPN": "有刺鉄線付きの金網のようなもので路地が封鎖されているのだ。",
-		"TextENG": "The alley is blocked with something like wire netting and barbed wire."
+		"TextENG": "The street was sealed off with barbed wire mesh."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154848,
 		"TextJPN": "園崎組の人間が、事務所前の安全を確保する為にやったのか、暴徒たちが感染者を通さない為にやったのか、どちらかはわからない。",
-		"TextENG": "I don't know if the Sonozaki group did it to ensure the safety of the front of the office, or if the mob did it to keep the infected from getting through."
+		"TextENG": "Either the Sonozaki Group did it to secure their safety in front of their office, or the rioters did it to keep infected from coming through, but we didn't know which."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154849,
 		"TextJPN": "しかし、現にこうして、事務所を目前にして、この路地は封鎖されているのだ。",
-		"TextENG": "But this is how it is now, this alley is blocked off right in front of the office."
+		"TextENG": "Regardless, the reality was that the street was blocked off, with the office right in front of us."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154850,
 		"TextJPN": "このバリケードが事前にわかっていれば、作戦計画は大きく違っただろう。",
-		"TextENG": "So if we knew this barricade was here beforehand, our operation plans would have been greatly different."
+		"TextENG": "If we had known about this barricade ahead of time, our strategy would have been greatly different."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154851,
 		"TextJPN": "不幸としか言い様がない。魅音がオペラグラスで偵察した角度からは、この位置だけが綺麗に死角になるのだ。",
-		"TextENG": "This has greatly added to our misfortune. As from the angle Mion spied upon with the opera glasses, this position was in a clear blind spot."
+		"TextENG": "We could only call it bad luck. It was in a perfect blind spot from the angle Mion had when scouting it with the opera glasses."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154852,
 		"TextJPN": "そのわずかの死角に、不幸にもバリケードを築かれるという二重の不幸！",
-		"TextENG": "And in that blind spot, unfortunately layed a barricade, giving us double misfortune!"
+		"TextENG": "And that slight blindspot unfortunately brought a second misfortune with this barricade!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154853,
 		"TextJPN": "有刺鉄線に身を傷つけられる覚悟があるなら、乗り越えられないこともない。",
-		"TextENG": "Although, I am ready to hurt myself and climb over the barbed wire."
+		"TextENG": "It wasn't impossible to climb over it if you were prepared to hurt yourself on the barbed wire."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154854,
 		"TextJPN": "しかしそれを、部活メンバーの覚悟のない采にまでは強いられない。",
-		"TextENG": "However, I doubt the rest of the club members or Une could ready themselves for such a thing."
+		"TextENG": "But we couldn't force that on Une, who didn't have the resolve of us club members."
 	},
 	{
 		"type": "MSGSET",
@@ -1491,7 +1491,7 @@
 		"PreTextTags": "@vS25/02/NREN_1210.",
 		"TextJPN": "「迂回路は？！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Is there an alternative route?!``"
+		"TextENG": "``Alternate routes?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1500,13 +1500,13 @@
 		"PreTextTags": "@vS25/03/NMIO_1380.",
 		"TextJPN": "「あッあッ、あるよッ、ぐるっと向こうの路地から回り込めば……！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``G-G-Give me a second, we can go around from the other side of the alley......!!``"
+		"TextENG": "``T-T-There's one! If we swing around from the alley across...!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154857,
 		"TextJPN": "その時、一同を眩しいビームライトが照らし出す。",
-		"TextENG": "At that time, a dazzling beam of light illuminates everyone."
+		"TextENG": "That was when bright beams of light shone upon us all."
 	},
 	{
 		"type": "MSGSET",
@@ -1515,7 +1515,7 @@
 		"PreTextTags": "@vS25/00/NBOA_0050.",
 		"TextJPN": "「誰だお前らッ！！」",
 		"NamesENG": "Mob",
-		"TextENG": "``Who the hell are these guys!!``"
+		"TextENG": "``Who are you all?!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1524,49 +1524,49 @@
 		"PreTextTags": "@vS25/00/NBOB_0040.",
 		"TextJPN": "「ひゃっははははは！　居たぞッ、感染野郎どもだッ！！」",
 		"NamesENG": "Mob",
-		"TextENG": "``Ahahahaha! They must be residents, infected bastards!!``"
+		"TextENG": "``Whooooa! There! It's the infected!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154860,
 		"TextJPN": "全員の血が凍りつく。万事休す。",
-		"TextENG": "Everyone's blood has frozen. Over every inch of their bodies."
+		"TextENG": "Our blood froze. We were finished."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154861,
 		"TextJPN": "ついに恐怖に耐え切れなくなり、采は絹を裂くような悲鳴をあげる……。",
-		"TextENG": "Finally, no longer able to endure the fear, Une tears out a silky scream......"
+		"TextENG": "Une couldn't bear the fear any longer, and let out a piercing scream......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154862,
 		"TextJPN": "打てる手などない。向こうは体格でも凶暴性でも、その上、人数でも勝る。",
-		"TextENG": "There is no way they can win. The other side is ferocious in physique, and superior in numbers."
+		"TextENG": "We were out of options. Our opponents had us beaten in build, ferocity, and numbers as well."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154863,
 		"TextJPN": "暴徒たちは次々に群がり、……バリケードの袋小路に追い詰められた一行を、取り囲む……。",
-		"TextENG": "The mobs flocks one after another...... forming a line and corning them into a dead-end of barricades, surrounding them......"
+		"TextENG": "The rioters gathered together one after another...... surrounding us and trapping us in the barricaded alley......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154864,
 		"TextJPN": "その時、乾いた破裂音が数度、繰り返された。",
-		"TextENG": "Then, a dry plosive sound is heard several times, it repeats."
+		"TextENG": "That was when several dry shots rang out."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154865,
 		"TextJPN": "魅音はすぐに伏せてと叫んで仲間たちの頭を地面に押し付ける。",
-		"TextENG": "Mion, with her head pressed against the ground, screams to her friends immediately."
+		"TextENG": "Mion quickly shouted, ``Down!`` and pushed our heads to the ground."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154866,
 		"TextJPN": "銃声を聞き慣れない暴徒たちはきょとんとしている。",
-		"TextENG": "The mobs, who are unfamiliar with gunshots, become speechless."
+		"TextENG": "The rioters, who didn't recognize the sound of gunshots, stood there bewildered."
 	},
 	{
 		"type": "MSGSET",
@@ -1575,31 +1575,31 @@
 		"PreTextTags": "@vS25/08/NTOM_0380.",
 		"TextJPN": "「諸君、それまでだ！　法に基づかない私刑は、如何なる状況下でも認められないぞ！！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Gentlemen, back off! Lynching anyone not based on law is not acceptable in any situation!!``"
+		"TextENG": "``Gentlemen, that's enough! Unlawful lynching is unacceptable, no matter the circumstance!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154868,
 		"TextJPN": "富竹が、入江機関の保安室から持ち出したサブマシンガンを空に向けて撃った音だった。",
-		"TextENG": "Tomitake used a sub-machine gun taken from the security room of the Irie Clinic, that was the sound which shot into the sky."
+		"TextENG": "It was the sound of Tomitake firing into the air with a submachine gun he took out of the Irie Institution's security room."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154869,
 		"TextJPN": "暴徒たちはそれをモデルガンか何かだとでも思っているのか、怯む様子もなく、狩りの邪魔をした富竹を睨み付ける。",
-		"TextENG": "But, the mob think it is only a model gun, trying not to falter in this situation, and scowl at Tomitake who disturbed their hunting."
+		"TextENG": "Maybe the rioters thought it was just a model gun or something, but they showed no fear, and only glared at Tomitake for interrupting their hunt."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154870,
 		"TextJPN": "医療機関が麻痺している今の興宮では、例え足を撃とうともそれは致命傷になり得る。",
-		"TextENG": "At present, all medical institutions in Okinomiya are paralysed, so if you are shot in the foot, it will become a fatal injury."
+		"TextENG": "With Okinomiya's medical facilities paralyzed right now, even a shot to the leg could prove fatal."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154871,
 		"TextJPN": "撃ちたくない富竹は、怯まない暴徒たちにごくりと唾を飲み込む……。",
-		"TextENG": "But Tomitake doesn't want to shoot, and swallows his saliva in front of the flinching mob......"
+		"TextENG": "Tomitake didn't want to shoot, but he gulped as the rioters proved unfazed......"
 	},
 	{
 		"type": "MSGSET",
@@ -1608,7 +1608,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0390.",
 		"TextJPN": "「撃ちたくないんだよ、諸君…！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``I don't want to shoot, gentlemen...!``"
+		"TextENG": "``I don't want to shoot you all...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1617,7 +1617,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0670.",
 		"TextJPN": "「ここはボクに任せるのですよ。……羽入！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Leave it to me. ......Hanyuu!``"
+		"TextENG": "``Leave this to me. ......Hanyuu!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1626,37 +1626,37 @@
 		"PreTextTags": "@vS25/12/NHAN_0430.",
 		"TextJPN": "「我が同胞よ……、心を鎮めるのです……。我こそはオヤシロさま、そなたたちの長なり…！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``My brethren...... calm your minds...... I am Oyashiro-sama, leader of thee...!``"
+		"TextENG": "``Comrades of mine...... calm your spirits...... I am Oyashiro-sama, your leader...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154875,
 		"TextJPN": "羽入の厳かな言葉が、人ならざる者たちだけの耳に響き渡る。",
-		"TextENG": "The solemn words of Hanyuu echo through the ears of the non-humans."
+		"TextENG": "Hanyuu's stern words rang out solely for inhuman ears."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154876,
 		"TextJPN": "暴徒たちは、ぽかんと口を開け、寝ぼけ眼でぼんやりと立ち尽くしている。",
-		"TextENG": "The mob blankly open their mouths, and vaguely stand with sleepy eyes."
+		"TextENG": "The rioters stopped and stood still, their mouths wide open."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154877,
 		"TextJPN": "やがて、地べたにぺたりと座り込み、皆、ぼんやりと呆けていた。",
-		"TextENG": "Before long, they begin to sit on the ground, as all of them become mentally slow."
+		"TextENG": "Eventually they sat down directly on the ground and waited absentmindedly."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154878,
 		"TextJPN": "鷹野によって凶暴に改造されたとはいえ、羽入の同胞。その力ある言葉からは逃れられないのだ。",
-		"TextENG": "That said, they only became ferocious after restructuring by Takano, the brethren of Hanyuu. They cannot escape from the power in her words."
+		"TextENG": "Even if Takano had modified them to be more ferocious, they were still Hanyuu's brethren. They couldn't escape the power of her words."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154879,
 		"TextJPN": "魅音たちは目を白黒させるが、九死に一生を得たことは理解する。",
-		"TextENG": "Mion rolls her eyes in bewilderment, understanding that they have narrowly escaped death."
+		"TextENG": "The eyes of Mion and the others went wide with shock, but they realized this was their narrow chance to get out alive."
 	},
 	{
 		"type": "MSGSET",
@@ -1665,7 +1665,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0680.",
 		"TextJPN": "「みんな、今の内に……！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Everyone, now......!``"
+		"TextENG": "``Everyone, go now......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1674,7 +1674,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1390.",
 		"TextJPN": "「な、何これ…？　どういうこと？！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Wh-What is this...? What did you do?!``"
+		"TextENG": "``W-What's this...? What's going on?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1683,7 +1683,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0690.",
 		"TextJPN": "「オヤシロパワーなのですよ、にぱ～☆」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's Oyashiro power, nipah-☆.``"
+		"TextENG": "``It's Oyashiro Power, nipah☆``"
 	},
 	{
 		"type": "MSGSET",
@@ -1692,7 +1692,7 @@
 		"PreTextTags": "@vS25/02/NREN_1220.",
 		"TextJPN": "「助けてくれてありがとう、梨花ちゃん！　富竹さん！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Thank you for your help, Rika-chan! Tomitake-san!``"
+		"TextENG": "``Thank you for rescuing us, Rika-chan! Tomitake-san!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1701,7 +1701,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0400.",
 		"TextJPN": "「騒ぎが聞こえてね。駆けつけて正解だったよ。君たちはこんなところで何を？」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``We heard the uproar. I'm glad we got here in time. What are you doing in a place like this anyway?``"
+		"TextENG": "``We heard the commotion. We made the right choice rushing over. What were you all doing out here?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1710,7 +1710,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0570.",
 		"TextJPN": "「このすぐ向こうが、魅音さんの園崎組の事務所なんですのよ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Directly on the other side is Sonozaki Mion-san's family office.``"
+		"TextENG": "``The office of the Sonozaki Group is just beyond here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1719,7 +1719,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1350.",
 		"TextJPN": "「このバリケードがあるとは気付かなくて、袋のネズミにってわけです」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``We didn't notice there was a barricade here, we were like mice hitting a dead end.``"
+		"TextENG": "``We weren't aware of the barricade and got cornered like rats.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1728,7 +1728,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0000.",
 		"TextJPN": "「なっさけない。お姉がいながら、危機一髪ってわけですか？」",
 		"NamesENG": "???",
-		"TextENG": "``Pitiable. Even though you are my sis, are you actually in such a critical moment?``"
+		"TextENG": "``Pathetic! You cut it that close with my Sis on your side?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1743,19 +1743,19 @@
 		"type": "MSGSET",
 		"MessageID": 154889,
 		"TextJPN": "バリケードの向こうには、詩音と葛西、そして数人の黒服たちがいた。",
-		"TextENG": "On the other side of the barricade Shion and Kasai appear with several people in black clothes."
+		"TextENG": "Shion, Kasai, and a few other men in black outfits approached from behind the barricade."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154890,
 		"TextJPN": "皆、銃を手にしてはいるが、暴徒たちのような凶暴な表情は浮かべていない。",
-		"TextENG": "Everyone of them, with a gun in their hand, display a ferocious expression towards the mob."
+		"TextENG": "Every one of them carried a gun, but none of them had the ferocious expressions of the rioters."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154891,
 		"TextJPN": "やはり、園崎組は冷静を保ち、籠城に務めていたのだ。",
-		"TextENG": "After all, the Sonozaki family have kept their calm, and survived the siege."
+		"TextENG": "Seems the Sonozaki Group had retained their sanity and focused on holing up inside."
 	},
 	{
 		"type": "MSGSET",
@@ -1764,7 +1764,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0010.",
 		"TextJPN": "「勘弁して下さいよね。イカレた連中と関わり合いになりたくないんですから」",
 		"NamesENG": "Shion",
-		"TextENG": "``Please forgive them. They didn't mean to become involved with those crazy people.``"
+		"TextENG": "``Please, give us a break, will you? We don't want to get involved with those crazies.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1773,7 +1773,7 @@
 		"PreTextTags": "@vS25/02/NREN_1230.",
 		"TextJPN": "「ごめんね、騒がしくしちゃって」",
 		"NamesENG": "Rena",
-		"TextENG": "``We're sorry, we had to make such noise.``"
+		"TextENG": "``We're sorry for causing such a stir.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1782,7 +1782,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0580.",
 		"TextJPN": "「詩音さんも無事なら、もう何も怖いことはありませんでしてよ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``If Shion-san's also safe, then there's nothing else to be afraid of anymore.``"
+		"TextENG": "``If you're safe, Shion-san, then we have nothing to fear anymore.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1791,7 +1791,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0020.",
 		"TextJPN": "「そういうことです。私１人で、お姉の１０人分くらいは頼もしいですからね。葛西、開けてあげて」",
 		"NamesENG": "Shion",
-		"TextENG": "``You're right about that. And even if there's only one of me, that's more reliable than ten servings of you, Sis. Kasai, you can open up now.``"
+		"TextENG": "``That's right. I'm more reliable than ten of my sister, all by myself. Kasai, open it for them.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1800,13 +1800,13 @@
 		"PreTextTags": "@vS25/15/NKAS_0000.",
 		"TextJPN": "「皆さん、どうぞ」",
 		"NamesENG": "Kasai",
-		"TextENG": "``Everyone, please come inside.``"
+		"TextENG": "``Come in, everyone.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154897,
 		"TextJPN": "葛西がバリケードの扉に厳重に閉められた鎖の南京錠を外す。",
-		"TextENG": "Kasai removes the padlock and chain off the severely locked and barricaded door."
+		"TextENG": "Kasai unlocked the padlock on the chains securing the barricade's doors shut."
 	},
 	{
 		"type": "MSGSET",
@@ -1815,7 +1815,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0030.",
 		"TextJPN": "「しかし、一体、何がどうしたってんです？　あいつらに何を？」",
 		"NamesENG": "Shion",
-		"TextENG": "``However, what on earth was that? Who were those people?``"
+		"TextENG": "``Still, what on earth is going on? What happened to them?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1824,7 +1824,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0350.",
 		"TextJPN": "「一体、……何が……」",
 		"NamesENG": "Une",
-		"TextENG": "``On earth...... what......``"
+		"TextENG": "``What, on earth......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1833,7 +1833,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0700.",
 		"TextJPN": "「気にしなくていいのです。そっとしておけば、その内にどっかに行っちゃうのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``You don't need to worry about that. We'll be going inside now.``"
+		"TextENG": "``You don't need to worry about them. If you leave them alone, they'll eventually wander off.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1842,7 +1842,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0410.",
 		"TextJPN": "「まぁまぁ！　オヤシロさまの奇跡の力ってことで、ここはありがたくこのチャンスをいただこうじゃないか、はっはっは」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Well, well! Saved by Oyashiro-sama's miraculous power, let's take the chance here and be grateful, ha ha ha.``"
+		"TextENG": "``Now, now! Why don't we just appreciate this chance granted to us through Oyashiro-sama's miracles? Hahaha!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1851,7 +1851,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1360.",
 		"TextJPN": "「さぁ、采ちゃん、もう安心だぜ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Now, Une-chan, you can feel relieved!``"
+		"TextENG": "``Come on, Une-chan, you're safe now!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1860,7 +1860,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0590.",
 		"TextJPN": "「詩音さんまで居てくれたら、もう何の心配もございませんでしてよ！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Shion-san's with us now, so there's no need to worry anymore!``"
+		"TextENG": "``There's nothing to worry about now that we have Shion-san with us too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1869,7 +1869,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0040.",
 		"TextJPN": "「そういうことです。さっすが沙都子はわかってますね。……ところで、その子は？」",
 		"NamesENG": "Shion",
-		"TextENG": "``Yeah, you're with me now. I sympathize with you, and Satoko knows it. ......By the way, who is this child?``"
+		"TextENG": "``That's right. Satoko understands, at least. ......By the way, who's this girl?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1878,7 +1878,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0360.",
 		"TextJPN": "「………ど、どうも……、です……」",
 		"NamesENG": "Une",
-		"TextENG": "``.........Th-Thank you...... ......``"
+		"TextENG": "``.........H-Hello, there......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1887,7 +1887,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1370.",
 		"TextJPN": "「彼女は采ちゃん。俺たちの命の恩人だぜ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``She's Une-chan. The one who saved our lives!``"
+		"TextENG": "``She's Une-chan. She saved our lives!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1923,19 +1923,19 @@
 		"PreTextTags": "@vS25/12/NHAN_0450.",
 		"TextJPN": "「……そなたは……………」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......You...............``"
+		"TextENG": "``......You are............``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154911,
 		"TextJPN": "一同はバリケードを潜り、園崎組事務所に迎え入れられる。",
-		"TextENG": "Everyone crosses the barricade, and are welcomed into the Sonozaki family office."
+		"TextENG": "We all slipped through the barricade and were welcomed into the Sonozaki Group's office."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154912,
 		"TextJPN": "その光景が、……双眼鏡で彼方より観察されていた……。",
-		"TextENG": "While their scene...... is being observed by binoculars from a distance......"
+		"TextENG": "Yet that sight... was being observed from far away through binoculars......"
 	},
 	{
 		"type": "MSGSET",
@@ -1944,6 +1944,6 @@
 		"PreTextTags": "@vS25/09/NTAK_0180.",
 		"TextJPN": "「…………くすくすくす。……見つけたわ。……あの子、ね………」",
 		"NamesENG": "Takano",
-		"TextENG": "``............Heh heh heh. ......I've found her...... that child.........``"
+		"TextENG": "``.........Heeheehee. ......I found you. ......That's the girl......``"
 	}
 ]

--- a/kamikashimashi_5.json
+++ b/kamikashimashi_5.json
@@ -1080,7 +1080,7 @@
 		"PreTextTags": "@vS25/02/NREN_1150.",
 		"TextJPN": "「……ラジコンのトラップを使い、敵の目を引きつけ、……その隙に前へ進むしかない」",
 		"NamesENG": "Rena",
-		"TextENG": "``......We'll have to use our remote control trap to draw the enemy's attention ......and then seize that chance to advance.``"
+		"TextENG": "``......We'll have to use our remote control trap to draw the enemy's attention...... and then seize that chance to advance.``"
 	},
 	{
 		"type": "MSGSET",

--- a/kamikashimashi_6.json
+++ b/kamikashimashi_6.json
@@ -261,7 +261,7 @@
 		"type": "MSGSET",
 		"MessageID": 154945,
 		"TextJPN": "では、……この采という少女は、まさか………。",
-		"TextENG": "Which meant ......This Une girl had to be........."
+		"TextENG": "Which meant...... This Une girl had to be........."
 	},
 	{
 		"type": "MSGSET",
@@ -420,7 +420,7 @@
 		"type": "MSGSET",
 		"MessageID": 154968,
 		"TextJPN": "凍えるような宇宙を長いこと旅して、やっと辿り着いた大地なのに、……その歓迎は余りに悲惨なものだった。",
-		"TextENG": "It was far too sad for her to receive such a welcome ......after finally reaching this land after her long, frozen journey through space."
+		"TextENG": "It was far too sad for her to receive such a welcome...... after finally reaching this land after her long, frozen journey through space."
 	},
 	{
 		"type": "MSGSET",
@@ -582,7 +582,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0520.",
 		"TextJPN": "「私たちと比べると、あまりにか弱い一族です。……しかし、それは誰かの責任でもなければ、運命でもない。ただ、……私たちが生まれ持った特性に過ぎないのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Her people are much weaker than mine. ......However, that's no one's fault, nor is it fate. It's just ......the special nature we were born with.``"
+		"TextENG": "``Her people are much weaker than mine. ......However, that's no one's fault, nor is it fate. It's just...... the special nature we were born with.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1053,7 +1053,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0500.",
 		"TextJPN": "「……我、……どうすれば……？」",
 		"NamesENG": "Une",
-		"TextENG": "``......What .....should I do......?``"
+		"TextENG": "``......What..... should I do......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1089,7 +1089,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0920.",
 		"TextJPN": "「……そう……ね……」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Well ......hmm......``"
+		"TextENG": "``......Well...... hmm......``"
 	},
 	{
 		"type": "MSGSET",

--- a/kamikashimashi_6.json
+++ b/kamikashimashi_6.json
@@ -9,13 +9,13 @@
 		"type": "MSGSET",
 		"MessageID": 154914,
 		"TextJPN": "園崎組の事務所内も、近隣住民のシェルターとなっていた。",
-		"TextENG": "The office of the Sonozaki family also became a shelter for the neighborhoods residents."
+		"TextENG": "The Sonozaki Group's office had been turned into a shelter for the local residents."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154915,
 		"TextJPN": "あちこちに毛布に包まり、横になる市民の姿があった。",
-		"TextENG": "They are wrapped in blankets in many places, some of them even lying down."
+		"TextENG": "We could see the townsfolk lying down here and there, huddled under blankets."
 	},
 	{
 		"type": "MSGSET",
@@ -24,7 +24,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0050.",
 		"TextJPN": "「地域あっての園崎組ですので。母さんの指示で、混乱の初期から、行く宛のない人々を保護しています」",
 		"NamesENG": "Shion",
-		"TextENG": "``The Sonozaki family told everyone in the area to gather here. And under my moms instruction, since the initial confusion, we began to take in and protect people who didn't have anywhere else to go.``"
+		"TextENG": "``You could say that the Sonozaki Group is this region, after all. Under my Mom's orders, we've been taking in people with nowhere else to go since the chaos started.``"
 	},
 	{
 		"type": "MSGSET",
@@ -33,7 +33,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1380.",
 		"TextJPN": "「行く宛のない人々ってのは？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``People who didn't have anywhere else to go?``"
+		"TextENG": "``What do you mean people with nowhere to go?``"
 	},
 	{
 		"type": "MSGSET",
@@ -42,7 +42,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1410.",
 		"TextJPN": "「采ちゃんと同じような人たちってことだよ。仕事で来てたり、遊びに来てたり。興宮の外からここに来て、騒ぎに巻き込まれた人も大勢いると思うよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``People in the same situation as Une-chan I guess. Either they came to work, or they came to play. They may have even came here from outside Okinomiya, I think there's alot of people like that who got caught up in this uproar.``"
+		"TextENG": "``She means people just like Une-chan. Those that came here for work, or visited for pleasure. There are a lot of people from outside of Okinomiya that got caught up in this mess.``"
 	},
 	{
 		"type": "MSGSET",
@@ -51,19 +51,19 @@
 		"PreTextTags": "@vS25/15/NKAS_0010.",
 		"TextJPN": "「そういう行く宛のない皆さんを、自警団連中は真っ先に襲おうとしました。戦うことも出来たのですが、茜さんのご指示でそれは避けることとなりました」",
 		"NamesENG": "Kasai",
-		"TextENG": "``Everyone had nowhere to go, and the people of the vigilance committee even tried to attack us in the beginning. We were going to fight, but that became something we had to avoid under instructions from Akane-san.``"
+		"TextENG": "``The 'watch' went after those with nowhere else to go first. We could've fought against them, but Akane-san ordered us to avoid that.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154920,
 		"TextJPN": "そこで、行く宛のない人々を可能な限り保護し、それ以上のトラブルを避ける為、自警団気取りの連中との接点を隔絶する為、バリケードで周囲を固めたのだという。",
-		"TextENG": "Therefore, they had to protect people without anywhere to go as much as possible, but in order to avoid any further trouble, they had to isolate themselves from contact with people from the vigilance committee, and that's why they strengthened their surroundings with barricades."
+		"TextENG": "So after securing as many people as they could, they built up their surroundings with those barricades to limit their contact with the watch and prevent any further trouble."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154921,
 		"TextJPN": "自警団にとっては、余所者は全て感染者だ。大勢の余所者を匿っていることが知られたら、大変なことになってしまう。",
-		"TextENG": "For the vigilance committee, all outsiders are infected people. So if they know that a large number of outsiders are sheltered here, things will get bad."
+		"TextENG": "To the watch, all outsiders were the infected. If they knew so many outsiders were being sheltered here, there would be big trouble."
 	},
 	{
 		"type": "MSGSET",
@@ -72,7 +72,7 @@
 		"PreTextTags": "@vS25/02/NREN_1240.",
 		"TextJPN": "「……ここは安全なの？」",
 		"NamesENG": "Rena",
-		"TextENG": "``......Are we safe here?``"
+		"TextENG": "``......Is this place safe?``"
 	},
 	{
 		"type": "MSGSET",
@@ -81,7 +81,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0060.",
 		"TextJPN": "「興宮で一番安全な場所だと保証できます。興宮コミュニティホールが一番のシェルターでしたが、あそこは崩壊したようなので、ここが興宮で最大のシェルターでしょうね」",
 		"NamesENG": "Shion",
-		"TextENG": "``I can guarantee this is the safest place in Okinomiya. Okinomiya community hall was the first shelter, but that collapsed, so here is the best shelter in all of Okinomiya.``"
+		"TextENG": "``I can guarantee it's the safest place in Okinomiya. The community center was the main shelter at first, but that place has collapsed, so this is what's left.``"
 	},
 	{
 		"type": "MSGSET",
@@ -99,7 +99,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0070.",
 		"TextJPN": "「船頭多くして何とやら。リーダーシップを巡ってのトラブルから、殺し合いの騒ぎに発展したそうで。……恐ろしいことです」",
 		"NamesENG": "Shion",
-		"TextENG": "``There were too many boatmen. Then trouble rose over leadership, which developed into an uproar of killing one another. ......It must have been frightening.``"
+		"TextENG": "``You know what they say about too many cooks. What started as just fighting over leadership led to murder. ......It's terrifying.``"
 	},
 	{
 		"type": "MSGSET",
@@ -108,7 +108,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1390.",
 		"TextJPN": "「なるほどな。……詩音のところは、リーダーシップがしっかりしてたから、規律が取れ、鬼に心を明け渡すような連中が現れなかったというわけだ……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I see. ......But because leadership was kept strong in your place, Shion, You created order and discipline, so people who surrendered their hearts to the demon did not appear......``"
+		"TextENG": "``I see. ......The leadership here is solid, so you've managed to establish order and keep people from handing their hearts over to the demons......``"
 	},
 	{
 		"type": "MSGSET",
@@ -117,7 +117,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0600.",
 		"TextJPN": "「さすがですわ。じゃあ、警察とかも機能していますの？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``That was expected. Well, are the police still functioning?``"
+		"TextENG": "``Impressive. So are the police and such still operating then?``"
 	},
 	{
 		"type": "MSGSET",
@@ -126,7 +126,7 @@
 		"PreTextTags": "@vS25/15/NKAS_0020.",
 		"TextJPN": "「市内各地の暴動の対応で散らばり、……感染者を匿おうとしているとデマが流れ……」",
 		"NamesENG": "Kasai",
-		"TextENG": "``They're scattered, trying to maintain the various riots around the city...... So, when we tried to shelter infected people, a false rumor was spread......``"
+		"TextENG": "``They're scattered across the city responding to riots... and there are lies going around that they're harboring infected......``"
 	},
 	{
 		"type": "MSGSET",
@@ -135,7 +135,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0420.",
 		"TextJPN": "「警察が想定してる事態を超えてるよ。対応できるはずもないね」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``I'll make an assumption that this situation has surpassed the police. I doubt they can cope.``"
+		"TextENG": "``This situation's beyond anything the police were prepared for. There's no way they could handle it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -144,7 +144,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1420.",
 		"TextJPN": "「それにしても富竹のおじさまは勇ましかったねぇ！　そのステキな銃は一体どこから？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Still, they never had the courage Kasai and Tomitake have! Now, where on earth can I get a beautiful gun around here?``"
+		"TextENG": "``That said, you were brave out there, Tomitake! Where did you get such a wonderful gun?``"
 	},
 	{
 		"type": "MSGSET",
@@ -153,7 +153,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0430.",
 		"TextJPN": "「いやぁ、たまたま拾ってね？　はっはっはっは…！！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``No, I picked this up by chance, okay? Ha ha ha ha ha...!!``"
+		"TextENG": "``Well, I just happened to pick it up? Hahahaha...!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -162,7 +162,7 @@
 		"PreTextTags": "@vS25/15/NKAS_0030.",
 		"TextJPN": "「素人衆に扱えるものではないでしょうに。……謎の多いお方です」",
 		"NamesENG": "Kasai",
-		"TextENG": "``Taking care of a crowd like that wasn't something an amateur could have handled. ......This man is a very mysterious gentlemen.``"
+		"TextENG": "``You know, that's not one amateurs could handle. ......You're a man of many mysteries.``"
 	},
 	{
 		"type": "MSGSET",
@@ -180,7 +180,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1400.",
 		"TextJPN": "「どうしたんだ？　あれ？　梨花ちゃんがいないぞ？　采ちゃんもいない」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``What's wrong? Huh? Where's Rika-chan? Une-chan isn't here either.``"
+		"TextENG": "``What's the matter? Huh? Rika-chan's not here? Une-chan's gone too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -189,7 +189,7 @@
 		"PreTextTags": "@vS25/02/NREN_1260.",
 		"TextJPN": "「さっき２人で向こうで話してるのを見たけど」",
 		"NamesENG": "Rena",
-		"TextENG": "``I saw the both of them talking over there a while ago.``"
+		"TextENG": "``I thought I saw those two talking over there just a moment ago.``"
 	},
 	{
 		"type": "MSGSET",
@@ -198,7 +198,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0720.",
 		"TextJPN": "「何だってのよ、羽入。この子がどうしたって言うの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``What is it, Hanyuu? What is it this child has done?``"
+		"TextENG": "``What do you mean, Hanyuu? What's your issue with this girl?``"
 	},
 	{
 		"type": "MSGSET",
@@ -207,7 +207,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0460.",
 		"TextJPN": "「…………静かに。今、語り掛けているところです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``............Be quiet. Now, I am speaking to her now.``"
+		"TextENG": "``............Quiet. I'm speaking to her right now.``"
 	},
 	{
 		"type": "MSGSET",
@@ -225,43 +225,43 @@
 		"PreTextTags": "@vS25/05/NRIK_0730.",
 		"TextJPN": "「どういうこと？　……この采って子が、一体何だってのよ？」",
 		"NamesENG": "Rika",
-		"TextENG": "``What do you mean? ......What on earth has Une done?``"
+		"TextENG": "``What are you saying? ......Who on earth is this Une girl?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154940,
 		"TextJPN": "音叉のような音が、梨花の頭の中に響き出す。",
-		"TextENG": "A sound similar to a tuning fork begins to resonate through Rika's head."
+		"TextENG": "The sound of a tuning fork echoed in Rika's head."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154941,
 		"TextJPN": "それはまるでチューニングしているかのように、音程を次々に変える。",
-		"TextENG": "It intensely increases its tune, changing its pitch in sequence."
+		"TextENG": "The tone gradually changed, almost like it was being, well, tuned."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154942,
 		"TextJPN": "……梨花は悟る。これは、人ならざる者の会話だ。",
-		"TextENG": "......Rika realises something. This is a conversation of non-humans."
+		"TextENG": "......Rika understood. This was a conversation between inhuman beings."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154943,
 		"TextJPN": "例えるなら無線。",
-		"TextENG": "It's similar to a radio."
+		"TextENG": "It was like they were using a radio."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154944,
 		"TextJPN": "互いの会話できる波長を探り合っているのだ。",
-		"TextENG": "So, I will probe each other's wavelengths as they talk."
+		"TextENG": "They were searching for the right wavelength to allow mutual conversation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154945,
 		"TextJPN": "では、……この采という少女は、まさか………。",
-		"TextENG": "Then...... this girl called Une, no way........."
+		"TextENG": "Which meant ......This Une girl had to be........."
 	},
 	{
 		"type": "MSGSET",
@@ -270,7 +270,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0470.",
 		"TextJPN": "「………我こそは、角の民の長、羽入なり。……汝は何者か………」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``.........I am leader of the nation of Horns, Hanyuu. ......Who are you.........?``"
+		"TextENG": "``......This is Hanyuu, leader of the horned people. ......Who are you.........?``"
 	},
 	{
 		"type": "MSGSET",
@@ -285,37 +285,37 @@
 		"type": "MSGSET",
 		"MessageID": 154948,
 		"TextJPN": "その時、２つの音叉の音が共鳴する。",
-		"TextENG": "At that time, the sound of two tuning forks resonate."
+		"TextENG": "That was when both tones began to resonate."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154949,
 		"TextJPN": "眩い光が、全てを飲み込む……。",
-		"TextENG": "Then, a dazzling light swallows all......"
+		"TextENG": "A bright light enveloped everything......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154950,
 		"TextJPN": "その光が晴れた時、梨花と羽入と采は、人ならざる者たちの世界に浮かんでいた。",
-		"TextENG": "The light clears, and Rika, Hanyuu and Une are floating in the world of the non-humans."
+		"TextENG": "The moment that light cleared away, Rika, Hanyuu, and Une were floating in the world of inhuman beings."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154951,
 		"TextJPN": "采と名乗った少女の瞳に、……羽入が時折浮かべるのと同じ光が宿っている。",
-		"TextENG": "From the eyes of the girl who calls herself Une...... Hanyuu dwells in the same light, occasionally floating."
+		"TextENG": "The eyes of the young girl named Une occasionally took on the same light that dwelled within Hanyuu's."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154952,
 		"TextJPN": "確信する。この少女は……、自分や羽入側の存在。……人ならざる何者かなのだ。",
-		"TextENG": "I'm convinced. This girl...... her existence, is the same as Hanyuu. ......She must be a non-human."
+		"TextENG": "I was certain. This girl...... was someone like me and Hanyuu."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154953,
 		"TextJPN": "羽入はじっと采の瞳を見詰め、答えが返るのを待つ……。",
-		"TextENG": "Hanyuu stares into the eyes of Une, waiting for an answer to be returned......"
+		"TextENG": "......Some inhuman being. Hanyuu stared long into Une's eyes, waiting for her response......"
 	},
 	{
 		"type": "MSGSET",
@@ -324,7 +324,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0400.",
 		"TextJPN": "「我、……ウネ。……怖い、……です……」",
 		"NamesENG": "Une",
-		"TextENG": "``I'm...... Une. ......I'm scared............``"
+		"TextENG": "``I, am Une. ......I am, afraid......``"
 	},
 	{
 		"type": "MSGSET",
@@ -333,7 +333,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0480.",
 		"TextJPN": "「怯えることはない。我は何者とも争う気はない。そなたはどこの民か」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``You shouldn't be afraid. I'm not here to compete against you. You are one of my people.``"
+		"TextENG": "``There's nothing to fear. We have no intention of fighting anyone. What people do you come from?``"
 	},
 	{
 		"type": "MSGSET",
@@ -348,31 +348,31 @@
 		"type": "MSGSET",
 		"MessageID": 154957,
 		"TextJPN": "そこからは、言葉ではなく、テレパシーのようなもので行われる。",
-		"TextENG": "From then onwards, rather than words, they communicate using some form of telepathy."
+		"TextENG": "What followed in response wasn't words, but something conducted through telepathy."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154958,
 		"TextJPN": "梨花の頭の中にも、様々なイメージが、まるで強制的に白昼夢を見せられているかのように次々に流れ込んでくる。",
-		"TextENG": "In Rika's head various images flow in sequence as if a daydream is forced onto her."
+		"TextENG": "Various images were practically forced into Rika's head, like she was being compelled to daydream."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154959,
 		"TextJPN": "宇宙の星の海。……その向こうに輝く、青い地球。",
-		"TextENG": "A sea of stars and space. ......And shining into the beyond, our blue earth."
+		"TextENG": "The ocean of stars in space. ......Her blue Earth shining in the distance."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154960,
 		"TextJPN": "ウネはつい最近、地球に辿り着いたばかりの存在らしかった。",
-		"TextENG": "Une just recently seemed to have arrived at the earth."
+		"TextENG": "Apparently, Une was something that had only recently arrived on Earth."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154961,
 		"TextJPN": "かつての羽入の一族のように、長い旅路の果てに、ようやく大地に辿り着いたのだ。",
-		"TextENG": "Like many former clans of Hanyuu, their journey ended after a long route, finally arriving at earth."
+		"TextENG": "She had finally arrived at this land after a long journey, just as Hanyuu's people had."
 	},
 	{
 		"type": "MSGSET",
@@ -381,7 +381,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0490.",
 		"TextJPN": "「……そうであったか……。長き旅路の果てに、ようやく……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......You must be the same...... Finally arriving after a long journey......``"
+		"TextENG": "``......So that's the case...... After your long journey, you finally......``"
 	},
 	{
 		"type": "MSGSET",
@@ -390,121 +390,121 @@
 		"PreTextTags": "@vS25/50/NUNE_0420.",
 		"TextJPN": "「我、……漆黒の海にて凍え、……ようやく辿り着いた、……です……。……なのに………」",
 		"NamesENG": "Une",
-		"TextENG": "``I...... was frozen in the sea of jet black...... but eventually, I finally arrived...... ......and yet.........``"
+		"TextENG": "``I, was frozen in that pitch black ocean, and I finally reached, this land...... ......Yet.........``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154964,
 		"TextJPN": "梨花はようやく気付く。……彼女は怯えているのだ。",
-		"TextENG": "Rika finally notices. ......She is frightened."
+		"TextENG": "Rika finally realized it. ......She was terrified."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154965,
 		"TextJPN": "ようやく辿り着けたこの大地で、自分が無事に生きていけるか、不安がっているのだ。",
-		"TextENG": "Where on this earth did she finally arrive at, and can she even live safely, she must feel uneasy."
+		"TextENG": "She had finally arrived here, and now she was anxious as to whether she could live safely or not."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154966,
 		"TextJPN": "無理もあるまい。人ならざる者の彼女から見ても、今の興宮の騒ぎがあまりに物騒だ。",
-		"TextENG": "This is unreasonable, even if she is one of the non-humans, it's too dangerous for her to be present in Okinomiya with the current uproar."
+		"TextENG": "It wasn't unreasonable. From her perspective as an inhuman being, it was far too dangerous in Okinomiya with the current uproar."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154967,
 		"TextJPN": "η１７３により凶暴化した人々による殺し合いの地獄絵図。",
-		"TextENG": "Everywhere has turned into a picture of hell, since the people became ferocious by η-173."
+		"TextENG": "The people turned ferocious by η173 were killing each other in a sight out of hell."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154968,
 		"TextJPN": "凍えるような宇宙を長いこと旅して、やっと辿り着いた大地なのに、……その歓迎は余りに悲惨なものだった。",
-		"TextENG": "Her freezing trip throughout the universe must have been a long time, and even though she has finally arrived at the earth...... the welcome was something too tragic."
+		"TextENG": "It was far too sad for her to receive such a welcome ......after finally reaching this land after her long, frozen journey through space."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154969,
 		"TextJPN": "続いて、羽入もまた、自分の知ることをイメージにしてウネに送る。",
-		"TextENG": "Hanyuu then also sends an image of what she knows to Une."
+		"TextENG": "Hanyuu then followed up by sending Une images of what she knew."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154970,
 		"TextJPN": "しばらくの間、梨花の頭の中には、双方のイメージが、まるでチャンネルがガチャガチャと変え続けるテレビ画面が流れ続ける……。",
-		"TextENG": "For a while, in Rika's head, both images continue to flow as if they are television screens who keep changing the channel......"
+		"TextENG": "For a while, Rika's head was flooded with both of their passing images, her mind like a television screen flickering between channels......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154971,
 		"TextJPN": "そして、互いの生い立ちや事情、現状を理解し合う。",
-		"TextENG": "And, through this, they understand each other's personal history, situation, and present condition."
+		"TextENG": "Then they finally understood each other's upbringing, circumstances, and present situation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154972,
 		"TextJPN": "梨花も、人の子の言葉に概念を変え、おぼろげながら理解できるようになる。",
-		"TextENG": "As for Rika, she notices them change their words to child of man, she has a vague understanding of what they mean."
+		"TextENG": "Rika was also able to convert those concepts into human words and understand it vaguely."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154973,
 		"TextJPN": "まず、ウネもまた、羽入や田村と同じ、人ならざる者であることがわかる。",
-		"TextENG": "First, that Une, is the same as Hanyuu and Tamura, understanding that she is also a non-human."
+		"TextENG": "First off, she understood that Une was the same as Hanyuu and Tamura - an inhuman being."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154974,
 		"TextJPN": "人間が地球に住まうように、人間に住まう、宇宙よりの人ならざる民だ。",
-		"TextENG": "And that since humans live on the earth, they live as humans, the people from space, the non-humans."
+		"TextENG": "She was one of the inhuman people from space who lived within humans just as humans lived on Earth."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154975,
 		"TextJPN": "訪れたのはつい先日。……もっとも、人ならざる者たちの時間感覚の話なので、年単位での話だろうが。",
-		"TextENG": "It was just the other day when she visited. But since we're talking about the sense of time of non-humans, I guess we're talking about years."
+		"TextENG": "She reached this planet just the other day. ......However, that was according to said inhuman being's perception of time, so it might have been several years."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154976,
 		"TextJPN": "ようやく地上に体が馴染み、自我を取り戻したばかりだという。",
-		"TextENG": "Also, she said her body has finally become familiar with the ground, and that she has regained her ego."
+		"TextENG": "Her body had finally acclimated to Earth, and she had just regained self-awareness."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154977,
 		"TextJPN": "……彼女らは、種のような状態で宇宙を漂い、地上に降りて根付き、芽を出して自我を取り戻すらしい。",
-		"TextENG": "......They must be a species, who drifts through space in such a state like a seed, falling down to the ground and taking root, regaining their ego after sprouting."
+		"TextENG": "......She was more of a seed as she drifted through space, and only regained her self-awareness after taking root here on Earth and finally budding."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154978,
 		"TextJPN": "そして、ウネたちの特性もわかってくる。",
-		"TextENG": "And, I understand Une and the other's characteristics, too."
+		"TextENG": "Rika also understood the special nature of Une's people."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154979,
 		"TextJPN": "羽入の角の民の特性は、……不安定になった時、疑心暗鬼に駆り立て、その鬼に心を乗っ取らせてしまうというもの。",
-		"TextENG": "The characteristics of Hanyuu and the nation of horns...... is when they become unstable, they are driven to acts of paranoia, allowing the demon to occupy someone's heart."
+		"TextENG": "The special nature of Hanyuu's horned people... drove people to paranoia when they grew unstable, and caused their hearts to become possessed by those demons."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154980,
 		"TextJPN": "……これは、人類と共存するという意味においてはマイナスで、羽入もそして田村も、自他共に認める角の民の問題点だ。その問題点に興味を示したのが鷹野ということになる。",
-		"TextENG": "......This is negating the sense they want to coexist with humanity, both Hanyuu and Tamura, so it seems the nation of horns problems are generally accepted and recognized. Although, it seems Takano has taken an interest in their problems."
+		"TextENG": "......That was a disadvantage for them, when trying to coexist with humanity, and it was a problem both Hanyuu, Tamura, and the horned people recognized."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154981,
 		"TextJPN": "ウネには、何とその意味でのマイナス面がないというのだ。",
-		"TextENG": "Except Une seems to have no negative aspects in that sense."
+		"TextENG": "That problem is also the aspect that Takano showed interest in."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154982,
 		"TextJPN": "この地球で人類と共存する意味においては、羽入たち以上に適しているという。",
-		"TextENG": "So if they are to coexist with humans on this earth, she is probably more suitable than Hanyuu."
+		"TextENG": "In Une's case, her people carried no such disadvantage. They were much better adapted to coexisting with humanity than Hanyuu's people were."
 	},
 	{
 		"type": "MSGSET",
@@ -513,7 +513,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0740.",
 		"TextJPN": "「つまり、あんたと違って、あの田村ってヤツには歓迎されるタイプなわけね」",
 		"NamesENG": "Rika",
-		"TextENG": "``In other words, unlike you, she is a type which would be welcomed by Tamura.``"
+		"TextENG": "``So unlike you, they're the type that Tamura would have welcomed.``"
 	},
 	{
 		"type": "MSGSET",
@@ -522,13 +522,13 @@
 		"PreTextTags": "@vS25/12/NHAN_0500.",
 		"TextJPN": "「……田村媛命が、新たな来訪者を歓迎するわけもないのです。……そして、彼女にとってはウネもまた、我らと同じ恐るべき侵略者……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......Tamurahime no Mikoto would never welcome a new visitor. ......Myself and Une, we are both considered deplorable invaders......``"
+		"TextENG": "``......There's no way Tamurahime-no-Mikoto would welcome any new arrivals. ......To her, both Une and I are equally terrifying invaders......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154985,
 		"TextJPN": "ウネは、羽入とほぼ互角の“強さ”があるのだ。",
-		"TextENG": "Une is also almost evenly matched in ``strength`` with Hanyuu."
+		"TextENG": "Une's people possessed ``strength`` nearly equal to Hanyuu's."
 	},
 	{
 		"type": "MSGSET",
@@ -537,7 +537,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0750.",
 		"TextJPN": "「強さって？　……頭の中に流れ込んでくるイメージでは、根の強さという感じだわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``Strength? ......As for this image flowing through my head, it feels like the strength of your roots.``"
+		"TextENG": "``Strength? ......The image that's pouring into my head is the strength of a plant's roots.``"
 	},
 	{
 		"type": "MSGSET",
@@ -546,25 +546,25 @@
 		"PreTextTags": "@vS25/12/NHAN_0510.",
 		"TextJPN": "「花壇に咲き誇る美しくもか弱い花は、強い根を持つ野草に呑み込まれてしまうこともあるでしょう。……そういう強さのことです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``A weak flower may bloom beautifully in a flower bed, but without strong roots, it will be swallowed by the wild grass. ......That is such strength.``"
+		"TextENG": "``Fragile flowers that bloom beautifully in a flower garden will sometimes be overtaken by wildflowers with powerful roots. ......It's that same strength.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154988,
 		"TextJPN": "羽入たちの世界では、自分たちのことを、動物より植物の概念で捉えているようだった。",
-		"TextENG": "In Hanyuu's world, it seems, they perceive things from the concept of a plant, rather than an animal."
+		"TextENG": "In Hanyuu's world, their peoples were better described with the concept of plants than animals."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154989,
 		"TextJPN": "……そう。植物の世界にだって、弱肉強食はあるのだ。",
-		"TextENG": "......Yes. Even in the world of plants, there is the survival of the fittest."
+		"TextENG": "......Yes. Even in the world of plants, there was survival of the fittest."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154990,
 		"TextJPN": "羽入やウネは、この力がとても強い。根が強く、たくましい種族なのだ。",
-		"TextENG": "So Hanyuu and Une's power must be very strong. Strong roots, of a strong race."
+		"TextENG": "Hanyuu and Une had very strong power to survive. Their peoples were hardy species with strong roots."
 	},
 	{
 		"type": "MSGSET",
@@ -573,7 +573,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0760.",
 		"TextJPN": "「それを目の敵にするってことは、……あの田村ってヤツの一族は？」",
 		"NamesENG": "Rika",
-		"TextENG": "``You must hate the very sight of each other then...... even though Tamura is part of your clan, right?``"
+		"TextENG": "``So what about Tamura's people? ......The ones that view you as an enemy?``"
 	},
 	{
 		"type": "MSGSET",
@@ -582,73 +582,73 @@
 		"PreTextTags": "@vS25/12/NHAN_0520.",
 		"TextJPN": "「私たちと比べると、あまりにか弱い一族です。……しかし、それは誰かの責任でもなければ、運命でもない。ただ、……私たちが生まれ持った特性に過ぎないのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Comparing us to her, we are a weak clan. ......However, we are not without responsibility, nor destiny. But, these are the only characteristics we were born with.``"
+		"TextENG": "``Her people are much weaker than mine. ......However, that's no one's fault, nor is it fate. It's just ......the special nature we were born with.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154993,
 		"TextJPN": "人ならざる者たちにとって、地球は大きな花壇。",
-		"TextENG": "For the non-humans, earth is one big flower bed."
+		"TextENG": "To these inhuman beings, the Earth was a big flower bed."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154994,
 		"TextJPN": "そこに種を蒔き、自分の種族を繁栄させようとしている。",
-		"TextENG": "And there, they sow seeds, trying to allow their race to prosper."
+		"TextENG": "They were all trying to sow their seeds, and allow their species to flourish."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154995,
 		"TextJPN": "かつて、この地という巨大な花壇には、田村の一族の花しか咲いていなかった。",
-		"TextENG": "In the past, there was a huge flower bed that was this land, a land where only Tamura's clan of flowers could bloom."
+		"TextENG": "In the past, Tamura's people were the only flowers blooming in the flower bed of Earth."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154996,
 		"TextJPN": "そこに羽入たちという種が現れ、強い繁殖力で、みるみる内に田村の一族の花を枯らして、羽入たちの花を増やしていったのだ。",
-		"TextENG": "Then, the seeds of Hanyuu began to appear, and in strong fertility, they killed Tamura's clan of flowers within an instant, increasing the number of Hanyuu's flowers."
+		"TextENG": "Then Hanyuu's species showed up, and with their strong reproductive ability, they quickly dried up Tamura's people and increased their population."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154997,
 		"TextJPN": "……当然、田村媛命からすれば、侵略者だ。",
-		"TextENG": "......Naturally, from Tamurahime no Mikoto's point of view, she was an invader."
+		"TextENG": "......So of course, from Tamurahime-no-Mikoto's perspective, they were invaders."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154998,
 		"TextJPN": "その上、羽入の一族は、不安定になれば、花壇を壊してしまう危険性まである。",
-		"TextENG": "Furthermore, Hanyuu's clan is accustomed to instability, creating a danger in where the flower bed could be broken."
+		"TextENG": "On top of that, Hanyuu's species posed the risk of destroying the flower bed if they grew unstable."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154999,
 		"TextJPN": "花壇を失っては、何も残らない。",
-		"TextENG": "Therefore, to lose the flower bed, would mean the end of everything."
+		"TextENG": "Nothing could survive if the flower bed was destroyed."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155000,
 		"TextJPN": "そこで羽入たちの一族は、自分たちが花壇と共生できる力を身に付けるまで、もっとも自分たちに適した花壇、雛見沢に引き籠ることとしたのだ。",
-		"TextENG": "Therefore, Hanyuu's clan, until it acquire the power to coexist with the flower bed, the flower bed is only suitable for itself, thus Hanyuu was confined to Hinamizawa."
+		"TextENG": "So that's why Hanyuu's people agreed to confine themselves to Hinamizawa, the flower bed best suited for them, until they were able to gain the power to coexist with their flower bed."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155001,
 		"TextJPN": "そして、ウネという、同じくらいの強さの種が、再び花壇にやってきた。",
-		"TextENG": "Then, the one called Une appeared, with the same amount of strength and seeds, arriving to take over the flower bed once again."
+		"TextENG": "Yet now, this Une, a species with the same amount of strength, has once again entered the flower bed."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155002,
 		"TextJPN": "幸いにもウネの一族は花壇に害は為さない。",
-		"TextENG": "Although fortunately, it seems Une's clan hasn't done any harm to the flower bed."
+		"TextENG": "Fortunately, Une's people will not harm the flower bed."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155003,
 		"TextJPN": "しかし、田村の一族を易々と駆逐する強さがある……。",
-		"TextENG": "However, she has the strength to destroy Tamura's family easily......"
+		"TextENG": "However, they possess the strength to easily wipe out Tamura's people......"
 	},
 	{
 		"type": "MSGSET",
@@ -657,7 +657,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0430.",
 		"TextJPN": "「……我、……そんなつもり、ないです……。ほんの少し……、我の為に大地がもらえれば………」",
 		"NamesENG": "Une",
-		"TextENG": "``......I...... have no such intention...... Just a little...... I want to be on the earth.........``"
+		"TextENG": "``......We, have no such intentions...... We just want, a little bit of land for ourselves.........``"
 	},
 	{
 		"type": "MSGSET",
@@ -666,7 +666,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0530.",
 		"TextJPN": "「その気持ち、わかります。……私もあなたを応援しましょう。星の海を渡った、同じ仲間として」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``That feeling, I understand it. ......I will support you. You crossed the sea of stars, you are the same as me, friend.``"
+		"TextENG": "``I understand how you feel. ......I support you in this as well. As one who has also crossed the ocean of stars.``"
 	},
 	{
 		"type": "MSGSET",
@@ -675,7 +675,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0770.",
 		"TextJPN": "「……だとしたら、最高にツイてないタイミングでやって来たわね。羽入の民が大暴れしている今の状況では、田村が異民族を歓迎するとはとても思えないわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Well, there you have it. You really came in the best timing. In our current situation, the people of Hanyuu have gone on a rampage, and I don't think Tamura will welcome another different ethnic group.``"
+		"TextENG": "``......In that case, she's just arrived at the worst possible time. It's hard to imagine Tamura welcoming another species with Hanyuu's people running rampant like they are now.``"
 	},
 	{
 		"type": "MSGSET",
@@ -684,7 +684,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0440.",
 		"TextJPN": "「………怖い、……です……。……我、……ただ静かに、……咲きたい……のに………」",
 		"NamesENG": "Une",
-		"TextENG": "``.........I'm scared...... ......I...... just want to be quiet...... I want to bloom.........``"
+		"TextENG": "``.........I am, scared...... ......We, simply want to, bloom quietly, in peace.........``"
 	},
 	{
 		"type": "MSGSET",
@@ -693,7 +693,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0780.",
 		"TextJPN": "「田村の力の及ばない土地はないの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Is there any land beyond the power of Tamura?``"
+		"TextENG": "``Is there no land beyond Tamura's reach?``"
 	},
 	{
 		"type": "MSGSET",
@@ -702,7 +702,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0540.",
 		"TextJPN": "「日本の全土はほぼ全て、田村の民の土地です。……仮に日本を出たとしても、そこにはその土地の民がいます」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Throughtout almost all of Japan, the people and its land are Tamura's. ......But even if you left Japan, there would be people from her land there.``"
+		"TextENG": "``Nearly all the land of Japan belongs to Tamura's people. ......Even if she were to leave Japan, there are other peoples living in those lands too.``"
 	},
 	{
 		"type": "MSGSET",
@@ -711,7 +711,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0790.",
 		"TextJPN": "「地球は、空室なしの満員マンションってわけね……」",
 		"NamesENG": "Rika",
-		"TextENG": "``The Earth is just a crowded apartment without any vacancies......``"
+		"TextENG": "``So the Earth is like a full apartment complex with no vacancies......``"
 	},
 	{
 		"type": "MSGSET",
@@ -720,7 +720,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0550.",
 		"TextJPN": "「……でも、僕は田村媛命の民は、少し陣取り過ぎだと思っていますのです。先住民は敬わなければなりませんが、土地は分け合うべきなのです。それを独り占めする田村は意地悪なのですよ、あぅ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......But, I don't think the people of Tamurahime no Mikoto will like us playing prisoner's base. The indigenous people must be respected, we should share this land. But Tamura is maliciously monopolizing it, au.``"
+		"TextENG": "``......But I believe Tamurahime-no-Mikoto's people are claiming too much. We must respect those who lived here before us, but they should share the land. Tamura's a bully for monopolizing it, au.``"
 	},
 	{
 		"type": "MSGSET",
@@ -729,7 +729,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0800.",
 		"TextJPN": "「もう、戦国時代にして、徹底的に奪い合っちゃえば？　弱肉強食は自然の摂理でしょう？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Why don't we make it a warring states period and fight each other to the bitter end? It's the natural order of things, isn't it?``"
+		"TextENG": "``Why don't you just go all Sengoku Era and compete for the land? Survival of the fittest is the law of nature, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -738,7 +738,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0560.",
 		"TextJPN": "「それでは大変なことになってしまうのです。花壇もこの星もおしまいなのですよ、あぅあぅ！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Because of that, it will become a serious matter. The flowerbed is our star, we can't let it end, au au!``"
+		"TextENG": "``Because that would lead to something terrible. Our flower bed and this very planet would meet their end, auau!``"
 	},
 	{
 		"type": "MSGSET",
@@ -747,7 +747,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0810.",
 		"TextJPN": "「……そういえば、あんたとウネって、同じくらいの強さなのよね？　戦ったらどうなるの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......That reminds me, both you and Une have the same amount of strength, right? What would happen if you fought?``"
+		"TextENG": "``......Now that you mention it, you and Une are about equally strong, right? What would happen if you fought?``"
 	},
 	{
 		"type": "MSGSET",
@@ -756,7 +756,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0450.",
 		"TextJPN": "「わ、我……、た、戦いたくないのです……」",
 		"NamesENG": "Une",
-		"TextENG": "``I-I...... I d-don't want to fight......``"
+		"TextENG": "``I-I, don't want to fight......``"
 	},
 	{
 		"type": "MSGSET",
@@ -765,7 +765,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0570.",
 		"TextJPN": "「僕も戦いたくないし、戦うのも無意味なのです。僕と彼女の力は互角故に」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I don't want to fight either, it would be a meaningless battle. As my and her powers are evenly balanced.``"
+		"TextENG": "``I don't want to fight either, and there's no point in fighting her anyway. Because our strength is equal.``"
 	},
 	{
 		"type": "MSGSET",
@@ -774,7 +774,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0820.",
 		"TextJPN": "「つまりはどういうこと？」",
 		"NamesENG": "Rika",
-		"TextENG": "``I meant, what would happen?``"
+		"TextENG": "``Meaning what?``"
 	},
 	{
 		"type": "MSGSET",
@@ -783,7 +783,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0580.",
 		"TextJPN": "「僕たちの場合は、花壇は早い者勝ちになりますです、あぅ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``In our case, the flower bed would be first come, first served, au.``"
+		"TextENG": "``In our case, the flower bed would go to the fastest one, au.``"
 	},
 	{
 		"type": "MSGSET",
@@ -792,7 +792,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0460.",
 		"TextJPN": "「我、……戦いたく、ないのです……」",
 		"NamesENG": "Une",
-		"TextENG": "``I...... I don't want to fight......``"
+		"TextENG": "``I, don't want to fight......``"
 	},
 	{
 		"type": "MSGSET",
@@ -801,7 +801,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0830.",
 		"TextJPN": "「つまり、雛見沢の人間には、ウネは感染できないってことね？」",
 		"NamesENG": "Rika",
-		"TextENG": "``In other words, to the humans of Hinamizawa, Une cannot infect them, right?``"
+		"TextENG": "``So you're saying that the people of Hinamizawa can't be infected by Une, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -810,7 +810,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0590.",
 		"TextJPN": "「そうなりますのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``That may be so.``"
+		"TextENG": "``That's right.``"
 	},
 	{
 		"type": "MSGSET",
@@ -819,7 +819,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0840.",
 		"TextJPN": "「そして、ウネが寄生した人間は、雛見沢症候群にかからない」",
 		"NamesENG": "Rika",
-		"TextENG": "``And, if the humans of Hinamizawa get Une's parasite, the Hinamizawa Syndrome wouldn't take effect.``"
+		"TextENG": "``And likewise, the humans with Une's parasite can't come down with Hinamizawa Syndrome.``"
 	},
 	{
 		"type": "MSGSET",
@@ -828,19 +828,19 @@
 		"PreTextTags": "@vS25/50/NUNE_0470.",
 		"TextJPN": "「そうなります、……のです」",
 		"NamesENG": "Une",
-		"TextENG": "``That may be so......``"
+		"TextENG": "``That would be, correct.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155024,
 		"TextJPN": "私、なんか宇宙人の見破り方って覚えたかも。",
-		"TextENG": "I need to try harder to see through this space aliens thoughts."
+		"TextENG": "I think I might have figured out how to identify aliens."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155025,
 		"TextJPN": "とにかく、何か引っかかるわ……。つまり………。",
-		"TextENG": "Anyway, she may catch on...... In other words........."
+		"TextENG": "Anyway, something's nagging at me...... This means......"
 	},
 	{
 		"type": "MSGSET",
@@ -849,7 +849,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0850.",
 		"TextJPN": "「羽入。……私たちって、何をしてるんだっけ？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Hanyuu. ......What are we going to do?``"
+		"TextENG": "``Hanyuu. ......What were we doing, again?``"
 	},
 	{
 		"type": "MSGSET",
@@ -858,7 +858,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0600.",
 		"TextJPN": "「あぅ？　豆腐の角に頭でもぶつけたのですか？」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Au? Did you hit me on the head with a piece of tofu?``"
+		"TextENG": "``Au? Did you hit your head on tofu or something?``"
 	},
 	{
 		"type": "MSGSET",
@@ -867,7 +867,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0860.",
 		"TextJPN": "「鷹野の暴走を許さない為でしょう？　鷹野はη１７３を世界中にばら撒こうとしてる。それを阻止するのが目的でしょう？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Do you think it was because you're considering letting Takano go on a rampage? Remember, Takano is planning to spread η-173 throughout the world. So, don't you think it should be our objective to stop her?``"
+		"TextENG": "``We can't allow Takano to run wild, right? She's trying to spread η173 throughout the world. So our goal is to stop that, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -876,7 +876,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0610.",
 		"TextJPN": "「はいなのです……。それがどうしたというのですか？」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Yes...... Do you know what would happen if we didn't?``"
+		"TextENG": "``Yes, it is...... But what about it?``"
 	},
 	{
 		"type": "MSGSET",
@@ -885,7 +885,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0870.",
 		"TextJPN": "「あんた馬鹿ねっ、大馬鹿だわ！　何てこと！　一石二鳥じゃない！」",
 		"NamesENG": "Rika",
-		"TextENG": "``You're a fool, a big idiot! Such a thing! You shouldn't be allowed to kill two birds with one stone!``"
+		"TextENG": "``You're an idiot! A huge idiot! I can't believe it! It's two birds with one stone!``"
 	},
 	{
 		"type": "MSGSET",
@@ -894,7 +894,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0480.",
 		"TextJPN": "「……我、よくわからない、です……」",
 		"NamesENG": "Une",
-		"TextENG": "``......I-I don't know really understand......``"
+		"TextENG": "``......I don't really understand you......``"
 	},
 	{
 		"type": "MSGSET",
@@ -903,25 +903,25 @@
 		"PreTextTags": "@vS25/05/NRIK_0880.",
 		"TextJPN": "「この子に、田村なんか気にしないで自由にこの星に住んでもらえばいいのよ！　だって、田村の民が取り付いてる人間は、ウネには取り付けるんでしょう？　そしてウネが取り付いた人間には、羽入の民は取り付けない！」",
 		"NamesENG": "Rika",
-		"TextENG": "``This child, Tamura should let her live freely on this star without any problem! I mean, Tamura has clung to many humans, so what's wrong with attaching Une? Une can cling to humans, and it's not like your people aren't mounting, Hanyuu!``"
+		"TextENG": "``We just need to forget about Tamura and help this girl live freely on our planet! I mean, the humans possessed by Tamura's people can be taken over by Une, right? And the people Une's taken over can't be taken over by your people!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155033,
 		"TextJPN": "羽入とウネの馬鹿宇宙人コンビは小首を傾げる。",
-		"TextENG": "Hanyuu and Une, the stupid space alien duo lean their necks to one side."
+		"TextENG": "The pair of stupid aliens both tilted their heads in confusion."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155034,
 		"TextJPN": "なるほど、これで全てのピースが合わさった！",
-		"TextENG": "Indeed, all the pieces have been put together!"
+		"TextENG": "It makes sense! Now all the pieces are in place!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155035,
 		"TextJPN": "鷹野の言う、悪魔の正体もわかった！　つまりはこうすればいいのだ！",
-		"TextENG": "Takano spoke of a devil, this must be her identity! In other words, she is our only hope!"
+		"TextENG": "I know the identity of Takano's ``Devil``! This is all we have to do!"
 	},
 	{
 		"type": "MSGSET",
@@ -930,55 +930,55 @@
 		"PreTextTags": "@vS25/05/NRIK_0890.",
 		"TextJPN": "「鷹野より先に、ウネが日本中の人々に取り付けばいいわけ！　そうすれば、鷹野がη１７３をばら撒こうとも、誰にも感染しない！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Before Takano does, we should get Une to attach herself to the people of Japan! By doing so, if Takano spreads η-173, nobody would become infected!``"
+		"TextENG": "``So we just need to get Une into the people of Japan faster than Takano! Once we do that, no one will become infected, even if Takano spreads η173 everywhere!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155037,
 		"TextJPN": "まぁ、さすがに田村の民を一掃してしまったら気の毒だろうから、とりあえず、鷹野の行動範囲を封じるように、県全域くらいではどうか。",
-		"TextENG": "Well, it is expected, but I feel sorry for Tamura as her people will be wiped out, but for the time being, we should blockade Takano's field of activities, that is, every single prefecture."
+		"TextENG": "Well, I would feel kind of bad about clearing Tamura's people out, so why don't we stick to just the prefecture so we can block Takano in?"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155038,
 		"TextJPN": "４７都道府県もあるのだから、田村媛命も１つくらいくれてもいいだろう。",
-		"TextENG": "There are 47 prefectures though, so maybe we should leave Tamurahime no Mikoto with one."
+		"TextENG": "There's 47 different prefectures, so Tamurahime-no-Mikoto can spare at least one."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155039,
 		"TextJPN": "鷹野をウネで取り囲めば、鷹野が感染を広げることは不可能になる。",
-		"TextENG": "So if we surround Takano and use Une, it would become impossible for Takano to spread the infection."
+		"TextENG": "Once we've surrounded Takano with Une, she won't be able to spread the infection any further."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155040,
 		"TextJPN": "η１７３の拡大も封じ込められ、これ以上の被害を抑えることが可能になる！",
-		"TextENG": "Thus containing the expansion of η-173, and making it possible to supress any further damage!"
+		"TextENG": "We'll seal off the spread of η173 and be able to prevent further damage!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155041,
 		"TextJPN": "なるほど、この状況は鷹野側から見れば致命的だ。これが、鷹野が富竹に言うところの“悪魔”の正体に違いあるまい。",
-		"TextENG": "Indeed, seeing this from Takano's perspective, the situation is fatal. So this must be the real nature of this ``devil`` Takano spoke of to Tomitake."
+		"TextENG": "Now I get it! That development would prove fatal from Takano's perspective."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155042,
 		"TextJPN": "つまり、ウネこそが鷹野の悪魔。",
-		"TextENG": "In other words, Une is Takano's devil."
+		"TextENG": "Une has to be the true identity of the ``Devil`` she spoke to Tomitake about."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155043,
 		"TextJPN": "η１７３とウネは互角。つまり、勝てない。",
-		"TextENG": "η-173 and Une are equally matched. In other words, she cannot win."
+		"TextENG": "That's the only thing that makes sense."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155044,
 		"TextJPN": "ウネによる感染がη１７３より先んじることがあったら、鷹野の野望は水泡に帰してしまうというわけだ！",
-		"TextENG": "So, if we infect everyone with Une before η-173, Takano's ambition will end in vain!"
+		"TextENG": "Une and η173 are evenly matched. They can't beat each other. If we infect people with Une before they get η173, then we'll ruin all of Takano's plans!"
 	},
 	{
 		"type": "MSGSET",
@@ -987,7 +987,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0900.",
 		"TextJPN": "「と、言うわけっ」",
 		"NamesENG": "Rika",
-		"TextENG": "``What I said.``"
+		"TextENG": "``So there you have it!``"
 	},
 	{
 		"type": "MSGSET",
@@ -996,7 +996,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0620.",
 		"TextJPN": "「お、…おぉ！　それはすごいアイデアなのですよ、梨花！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``O-Oh! That's a great idea, Rika!!``"
+		"TextENG": "``Oh... Ohh! That's an incredible idea, Rika!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1005,7 +1005,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0490.",
 		"TextJPN": "「……わ、我、……よくわかった……、ような、わからないような……」",
 		"NamesENG": "Une",
-		"TextENG": "``......I-I...... understand well enough...... but, I don't know......``"
+		"TextENG": "``......I-I, kind of, understand, maybe......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1014,37 +1014,37 @@
 		"PreTextTags": "@vS25/12/NHAN_0630.",
 		"TextJPN": "「これはすごいグッドアイデアなのです！　ウネもこの星に住めて、さらにこれ以上の惨劇も防げて！　さらに田村もこの県から追っ払えて、一石三鳥なのですよ！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``This is a great great idea! Une will be able to live on this planet, furthermore, preventing this tragedy any further, too! And also, sending Tamura away from this prefecture, we're hitting three birds with one stone!!``"
+		"TextENG": "``This is an incredibly good idea! Une will get to live on our planet, and we'll be able to prevent any more tragedy! Plus we'll drive Tamura out of this prefecture, so it's two birds with one stone!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155049,
 		"TextJPN": "ウネが県全域を陣取れば、田村の民は県から駆逐される。",
-		"TextENG": "Une herself will then become the whole prefecture, as the people of Tamura are expelled from the prefecture."
+		"TextENG": "If Une occupies the entire prefecture, then Tamura's people will be driven out of here."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155050,
 		"TextJPN": "となれば、県を出ない限り、もう二度と、田村媛命に会わなくて済むし、嫌味を言われることもなくなる。",
-		"TextENG": "I'm happy with anything, as long as I don't have to leave the prefecture, but never again I don't want to encounter Tamurahime no Mikoto, she needs to cease her gaudiness."
+		"TextENG": "That would mean we'd never see Tamurahime-no-Mikoto again unless we left the prefecture, and we wouldn't have to listen to her complaints."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155051,
 		"TextJPN": "日本全土を我が物にして、そこに一歩でも踏み出そうとすると口やかましかった田村に、千年ぶりに一泡吹かせてやることが出来る！",
-		"TextENG": "The whole land of Japan is in her possession, and even when I tried to step forward even one foot into it, Tamura gave a good nagging, not even after an interval of one thousands years has she changed!"
+		"TextENG": "For the first time in a thousand years, we could strike a blow against the ``god`` who claimed all of Japan for herself and nagged us any time we set even a foot upon her land!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155052,
 		"TextJPN": "羽入は小躍りして喜ぶ。田村とは、徹底的に不仲のようだ。",
-		"TextENG": "I'm pleased Hanyuu is dancing with joy. As when Tamura was here, she was very much discord with her."
+		"TextENG": "Hanyuu was dancing with joy. She must be thoroughly at odds with Tamura."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155053,
 		"TextJPN": "……まぁ、あれだけ横柄な態度で上から目線で威張られたら、初対面の梨花であっても一泡吹かせてやりたくなるというものだ。",
-		"TextENG": "......Well, I will give her a top score for glancing in an insolent manner, and even though this is my first time meeting with Rika, I'll give her a top score, too."
+		"TextENG": "......Well, with such an arrogant attitude and condescending posturing, even Rika wanted strike her after only meeting her once."
 	},
 	{
 		"type": "MSGSET",
@@ -1053,7 +1053,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0500.",
 		"TextJPN": "「……我、……どうすれば……？」",
 		"NamesENG": "Une",
-		"TextENG": "``......Me ......how......?``"
+		"TextENG": "``......What .....should I do......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1062,7 +1062,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0910.",
 		"TextJPN": "「興宮じゃどうしようもないわね。何しろ、この街はすでにη１７３に感染してる。ここの人々にはあんたは感染できないんでしょ？」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's hopeless for Okinomiya. After all, this town has already become infected with η-173. So remember, the people you infect won't be able to get it, right?``"
+		"TextENG": "``There's nothing we can do about Okinomiya. After all, this city's already infected with η173. So you can't infect the people here, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1071,7 +1071,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0510.",
 		"TextJPN": "「………はい、……です」",
 		"NamesENG": "Une",
-		"TextENG": "``.........Yes. ......``"
+		"TextENG": "``......That's, right.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1080,7 +1080,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0640.",
 		"TextJPN": "「では、どうすればいいのでしょう……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``So what should we do......?``"
+		"TextENG": "``In that case, what should we do......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1089,61 +1089,61 @@
 		"PreTextTags": "@vS25/05/NRIK_0920.",
 		"TextJPN": "「……そう……ね……」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Well..... Let's see......``"
+		"TextENG": "``......Well ......hmm......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155059,
 		"TextJPN": "富竹の話によると、感染拡大を防ぐ為に、市外への交通手段は全て遮断されているらしい。",
-		"TextENG": "According to Tomitake's story, to prevent spread of the infection, all means of transportation has been cut off."
+		"TextENG": "According to Tomitake, all means of transit out of the city had been cut off to prevent the spread of infection."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155060,
 		"TextJPN": "つまり、このままではウネは、η１７３の感染地域を出られない。",
-		"TextENG": "In other words, Une in this situation cannot escape from the area infected with η-173."
+		"TextENG": "In other words, we couldn't get Une out of η173's infected region."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155061,
 		"TextJPN": "鷹野より先に市外へ脱出して、ウネの民を広げなくてはならない。",
-		"TextENG": "So we should get her to the suburbs before Takano does, and spread Une to the people."
+		"TextENG": "We would have to escape this city before Takano does, and spread Une's people."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155062,
 		"TextJPN": "富竹に話して助力を得るべきだろう。",
-		"TextENG": "But first, we should talk to Tomitake and get some help."
+		"TextENG": "We should probably talk to Tomitake and gain his support."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155063,
 		"TextJPN": "脳内寄生ウィルスの存在を理解する富竹なら、事情を理解してくれるはずだ。",
-		"TextENG": "Tomitake knows about the brain virus parasites affection on the brain, so he should be able to understand the situation."
+		"TextENG": "Since Tomitake knows about the parasitic neurovirus, he should understand our situation too."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155064,
 		"TextJPN": "仮に、ウネの拡大が却下されるとしても、そこから新たな治療薬や予防薬を発見する切っ掛けになるかもしれない。",
-		"TextENG": "But assuming that he rejects the spreading of Une, we may still be able to discover a new therapeutic drug and prophylactic medicine using her as a starting point."
+		"TextENG": "Even if he does reject the idea of spreading Une, the information could lead to the discovery of a new treatment or even a vaccine."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155065,
 		"TextJPN": "梨花は富竹を呼び、事情を説明する。",
-		"TextENG": "Rika calls Tomitake over, and explains the situation."
+		"TextENG": "Rika called Tomitake over and explained the situation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155066,
 		"TextJPN": "もちろん、理解を得る為には、夜が白み始めるほどの時間を必要としなければならなかったが。",
-		"TextENG": "Of course, to gain some understanding, he needed some time before the night began."
+		"TextENG": "Of course, gaining his understanding took until dawn."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155067,
 		"TextJPN": "しかしそれでも、最後には状況を理解してくれた。",
-		"TextENG": "However, he finally understood the situation."
+		"TextENG": "Yet even so, he ultimately understood."
 	},
 	{
 		"type": "MSGSET",
@@ -1152,7 +1152,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0440.",
 		"TextJPN": "「なるほどね、わかったよ。……判断を東京に委ねなければならないけど、彼女の存在は大きい。采ちゃんが協力してくれるなら、僕たちも快適な待遇を用意できるさ」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``I see, I understand. ......Although I have to leave this decision with Tokyo, their presence is big. But if Une-chan is willing to co-operate, we will provide a comfortable service.``"
+		"TextENG": "``Interesting. All right. ......We'll have to leave the decision up to Tokyo, but her existence is... it's a huge deal. If Une-chan's willing to cooperate, then we can prepare comfortable accommodations for her as well.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1161,7 +1161,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0520.",
 		"TextJPN": "「わ、私も快適なのは嫌い……、……じゃないのです……」",
 		"NamesENG": "Une",
-		"TextENG": "``I-I hate to be comfortable...... there isn't a reason............``"
+		"TextENG": "``I-I wouldn't be opposed, to being comfortable......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1170,7 +1170,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0930.",
 		"TextJPN": "「富竹は話せる男なのですよ。きっと采に良くしてくれますのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``Tomitake isn't just a man of talk. Surely he will take good care of you, Une.``"
+		"TextENG": "``Tomitake's an understanding man. I'm sure he'll treat you well, Une.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1179,7 +1179,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0530.",
 		"TextJPN": "「……うれしい……、のです……」",
 		"NamesENG": "Une",
-		"TextENG": "``......I'm glad......``"
+		"TextENG": "``......I'm, happy......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1188,7 +1188,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0650.",
 		"TextJPN": "「ようやく、この惨劇にも終わりが見えてきたようです……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Finally, it seems the end of this tragedy can now be seen......``"
+		"TextENG": "``The end of this tragedy is finally in our sights......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1197,31 +1197,31 @@
 		"PreTextTags": "@vS25/05/NRIK_0940.",
 		"TextJPN": "「ウネが市外に脱出するまでは何とも言えないけれど、……一応は一件落着なのかしら？」",
 		"NamesENG": "Rika",
-		"TextENG": "``We have to get Une to the escape zone outside the city area first...... don't you think that should be our number one priority?``"
+		"TextENG": "``Well, we can't claim that until we get Une outside of the city, ......but it's at least one problem solved, I suppose?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155074,
 		"TextJPN": "興宮で最も安全な園崎組事務所にて厳重に守られている。",
-		"TextENG": "This is the most secure and severely protected Sonozaki family office in Okinomiya after all."
+		"TextENG": "The Sonozaki Group office was the safest and most tightly guarded place in Okinomiya."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155075,
 		"TextJPN": "ここには食料も資材も武器も、何でもある。富竹は状況を理解し協力的。キーパーソンであるウネも協力的。",
-		"TextENG": "Here, there is food, raw materials and weapons, anything you could want. Even Tomitake's cooperative and understands the situation. He is also the key person in protecting Une."
+		"TextENG": "It had food, resources, weapons, everything. They had Tomitake's understanding and cooperation. They had Une's cooperation as well."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155076,
 		"TextJPN": "状況をチェスに見立てるなら、あと数手でチェックメイトという状態。相手が投了しても十分な段階だ。",
-		"TextENG": "So this situation is like chess, we can call checkmate after several more moves in our present state. Then our opponent will have no choice other than to resign."
+		"TextENG": "In terms of chess, they were now a few moves away from checkmate. It was the perfect time for their opponent to give up."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155077,
 		"TextJPN": "……鷹野というジョーカーさえ、何か騒ぎを起こさない限り。",
-		"TextENG": "......Unless this joker called Takano causes another uproar."
+		"TextENG": "......Unless the Joker, Takano, caused some kind of uproar."
 	},
 	{
 		"type": "MSGSET",
@@ -1230,7 +1230,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0950.",
 		"TextJPN": "「あと、……あのいけ好かない、田村媛の何とやらもね」",
 		"NamesENG": "Rika",
-		"TextENG": "``Anyway...... what Tamurahime no Mikoto's doing is disgusting.``"
+		"TextENG": "``Plus...... there's that obnoxious Tamurahime-no-Whatever.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1239,19 +1239,19 @@
 		"PreTextTags": "@vS25/12/NHAN_0660.",
 		"TextJPN": "「……あいつが、……僕たちがこれからしようとすることを、歓迎するとは思えませんのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``......She...... even after we do this, I still don't think she will welcome us.``"
+		"TextENG": "``......She's...... not likely to welcome what we're trying to do now.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155080,
 		"TextJPN": "その時、音叉の鳴り響くようなあの音が聞こえ出し、梨花と羽入の二人は眩い白い光に包まれていく。",
-		"TextENG": "At that moment, two sounds resonating like tuning forks are heard, then Rika and Hanyuu become wrapped in a dazzling white light."
+		"TextENG": "That was when they heard the ringing of a tuning fork, and bright, white light enveloped both Rika and Hanyuu."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155081,
 		"TextJPN": "……来た。田村媛命だ。",
-		"TextENG": "......She has come. Tamurahime no Mikoto."
+		"TextENG": "......She's here. Tamurahime-no-Mikoto."
 	},
 	{
 		"type": "MSGSET",
@@ -1260,7 +1260,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0960.",
 		"TextJPN": "「噂をすれば何とやらね」",
 		"NamesENG": "Rika",
-		"TextENG": "``I wonder if you heard our gossip.``"
+		"TextENG": "``Speak of the devil.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1269,7 +1269,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0080.",
 		"TextJPN": "「………おのれ、角の民の長。やはりは、汚らわしくもその土足で我らが大地を穢すつもりだった也や」",
 		"NamesENG": "Tamura",
-		"TextENG": "``.........You, leader of the nation of horns, are as I thought, still trying to defile this earth with your filthy shoes.``"
+		"TextENG": "``.........How dare you, leader of the horned people! Truly, you have been plotting to taint our land with your filthy shoes!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1278,7 +1278,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0670.",
 		"TextJPN": "「新たな友人であるウネを受け入れるのです。何もあなたの土地の全てを奪うわけではありません」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I have accepted Une as a new friend. Nothing else, so nobody is trying to take your entire land.``"
+		"TextENG": "``We will welcome our new friend, Une. Yet that does not mean we will steal all of your land.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1287,7 +1287,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0090.",
 		"TextJPN": "「黙り給え、不浄の民め。結託して大地を汚そうとするその試み、我輩が許すわけもなきと知り奉れっ」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Silence, your people are impurities. And you are conspiring an attempt to pollute this earth, I know of it, and it is something I cannot permit.``"
+		"TextENG": "``Be quiet, tainted one! Know that we shall not permit your conspiracy to corrupt our land!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1296,7 +1296,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0970.",
 		"TextJPN": "「あのねぇ、鷹野って悪党がいて、そいつはあんたの言うところの角の民を日本中、いえ、世界中にばら撒こうと目論んでるのよ。そうしたら、あんたたちは全滅しちゃうのよ？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Can't you see, Takano is the villain, she's the one spreading the nation of horns across Japan... No, she schemes to spread it throughout the world. And if she does, you will be exterminated, don't you know that?``"
+		"TextENG": "``Listen, there's this villain, Takano, and she's plotting to spread what you call the horned people to all of Japan, no, the entire world! If she does, then your people will be exterminated.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1305,7 +1305,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0980.",
 		"TextJPN": "「そしてそれは、あんたが逆立ちしたって防げやしない。ウネに少し土地を分けてやれば、ウネは地球に住めて、あんたもこれ以上の土地を失わず、羽入は二度とあんたの顔を見ずに済んで、三方が丸く収まるってもんでしょうが」",
 		"NamesENG": "Rika",
-		"TextENG": "``So, you cannot prevent this handstand. All you have to do is separate some land for Une, then Une will be able to live on this earth, and you won't lose any more land. Even Hanyuu, who doesn't even want to look at your face, knows this solution fits all three sides.``"
+		"TextENG": "``Getting angry at us isn't going to prevent that from happening. If you're willing to cede a bit of land to Une, then Une's people can live on this planet, and you won't lose any more land. Hanyuu won't have to see your face ever again either, and this can all be settled quietly between you three.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1314,7 +1314,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0100.",
 		"TextJPN": "「黙り給え、人の子め。不浄なる言葉を喚き立てること許されざること也と知り奉れ」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Silence, human child. Do not yell and name the impure, you cannot force me to permit anything.``"
+		"TextENG": "``Be quiet, child of man. Know that you are not permitted to use your tainted words.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1323,7 +1323,7 @@
 		"PreTextTags": "@vS25/05/NRIK_0990.",
 		"TextJPN": "「痛たたたた……、その頭痛の神通力、止めなさいよね……」",
 		"NamesENG": "Rika",
-		"TextENG": "``It hurts...... you're giving me a headache with those supernatural powers, please stop......``"
+		"TextENG": "``Owwww...... Stop using that headache power......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1332,7 +1332,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0680.",
 		"TextJPN": "「元からわからず屋の聞かん坊です。何を話したって通じるわけはないのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``It is because she is a naughty and obstinate child. She won't listen, no matter what you say.``"
+		"TextENG": "``She has always been stubborn and refuses to listen. Nothing you say will ever get through to her.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1341,7 +1341,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0110.",
 		"TextJPN": "「そなたこそ聞かん坊の分際也や！　不浄の民、角の民！　千年経ってもまだ怒りが収まらぬ也！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``It is thou who are the naughty child! You and your filthy people, the nation of horns! Even after a thousand years, you still haven't managed to maintain that rage!!``"
+		"TextENG": "``You are the one who never listens! You tainted people, you horned people! My anger has not abated, even after a thousand years!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1350,25 +1350,25 @@
 		"PreTextTags": "@vS25/12/NHAN_0690.",
 		"TextJPN": "「それを言ったら、こちらこそっ。あなたの嫌がらせの数々、僕であっても千年の怒りが収まらないのですっ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Even so, you are still that. Because you harass us many times, even my rage hasn't settled after a thousand years.``"
+		"TextENG": "``I could say the same to you! I haven't lost any of my anger either, for all of your harassment!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155093,
 		"TextJPN": "二人にどんな因縁があるのかはわからないが、千年経っても恨みが忘れられないとは、……対立の根は深い様子だ。",
-		"TextENG": "I don't know what fates these two people share, but even so, it is unforgivable to hold a grudge after a thousand years...... as that conflict is the root of today's situation."
+		"TextENG": "I didn't know what kind of history those two shared, but if they held onto their grudges for a millennium...... then the cause of their antagonism ran deep."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155094,
 		"TextJPN": "なるほど、百年も生きぬ人の子風情には、とても仲介できる因縁ではないらしい。",
-		"TextENG": "I see, even my childish appearance hasn't changed after living one hundred years, it seems my fate need some intermediation."
+		"TextENG": "Apparently their history really isn't something humans, who only live for around a century, could moderate."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155095,
 		"TextJPN": "まぁ、神様なんてそんなものだ。人間が勝手に敬っているだけで、当の本人たちは人間以上に人間臭い。神様同士がいがみ合って喧嘩など、どこの国の神話にもいくらでもある。",
-		"TextENG": "Well, God may be such a thing. But, we humans worship them without question, as we human beings reek of it. And among God's fighting one another, there are plenty in myths."
+		"TextENG": "Well, that's just how gods are. Humans worship them all on their own, and yet the gods themselves are more human than humans. There are plenty of myths in every country about gods arguing and fighting with each other."
 	},
 	{
 		"type": "MSGSET",
@@ -1377,7 +1377,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1000.",
 		"TextJPN": "「あんたたちの喧嘩はどうでもいいわ。田村の何とやらが話を聞かなくても別に結構よ。でもね、人の世の惨劇を食い止めるにはこれしか方法がないの！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Your quarrel doesn't matter. You should consider what we have to say, Tamura. Because as you know, there is no other way to stem this tragedy on the human world!``"
+		"TextENG": "``I don't care about the fight between you two. Tamura-no-Whatever, if you don't want to listen, that's fine. But this is the only way to stop the tragedy happening in the human world!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1386,7 +1386,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0120.",
 		"TextJPN": "「愚かなる角の民の巫女には言ってもわかりはせぬ也や。無論、吾輩も不浄なる巫女と言葉を交わすつもりなど毛頭なしと知り給え」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Shrine maiden of the nation of horns, you are as foolish as they say. Naturally, know that I had no intention to exchange words with such a filthy shrine maiden in the first place.``"
+		"TextENG": "``You wouldn't understand anything I said anyway, foolish priestess of the horned people. Know that I have no intentions of exchanging words with a tainted priestess either.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1395,7 +1395,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1010.",
 		"TextJPN": "「いちいちカチンと来る神サマだわ。県１個なんて自重しないで、中部をもらっちゃえば？」",
 		"NamesENG": "Rika",
-		"TextENG": "``One by one, you Gods come and ka-ching. So don't be so prudent about one prefecture, why don't you give up Toyama or Gifu?``"
+		"TextENG": "``You're a god, okay, but you really tick me off. Maybe we shouldn't stop at one prefecture and just take Toyama and Gifu while we're at it too?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1404,31 +1404,31 @@
 		"PreTextTags": "@vS25/51/NTAM_0130.",
 		"TextJPN": "「させぬ也や！　再び我が民の土地を穢させはせぬものと知り給え！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``I cannot do that! I could never allow such an impurity to plague my people and their land again!!``"
+		"TextENG": "``I will not allow it! Know that I shall not allow you to corrupt the land of my people once more!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155100,
 		"TextJPN": "ガラスが割れる音が聞こえた、と同時に怒号の喧騒が轟くのが聞こえた。",
-		"TextENG": "A glass cracking sound is heard, and at the same time, the roar of a tumult is also heard."
+		"TextENG": "There was the sound of glass shattering followed by an angry, bellowing roar."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155101,
 		"TextJPN": "何が起こった？！　タイミング的に考えて、田村が何かをしたのは明白だった。",
-		"TextENG": "What happened?! In terms of timing, and when I think about it, it's obvious that Tamura did something."
+		"TextENG": "What happened?! Considering the timing, it was obvious Tamura had done something."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155102,
 		"TextJPN": "しかし、羽入と同様に、田村媛命もまた人ならざる者。",
-		"TextENG": "However, like Hanyuu, Tamurahime no Mikoto is also a non-human."
+		"TextENG": "Yet Tamurahime-no-Mikoto was an inhuman being like Hanyuu."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155103,
 		"TextJPN": "人の世に直接の干渉をすることは出来ないはず……。",
-		"TextENG": "So she shouldn't be able to directly interfere in the human world......"
+		"TextENG": "She shouldn't be able to interfere with the world of man directly......"
 	},
 	{
 		"type": "MSGSET",
@@ -1437,7 +1437,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0450.",
 		"TextJPN": "「た、鷹野さん？！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Ta-Takano-san?!``"
+		"TextENG": "``T-Takano-san?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1446,79 +1446,79 @@
 		"PreTextTags": "@vS25/09/NTAK_0190.",
 		"TextJPN": "「ハイ、ジロウさん。やっぱりあなたとは再会できると信じてたわ。くすくす」",
 		"NamesENG": "Takano",
-		"TextENG": "``Hi, Jirou-san. After all, I believed we would meet again. Heh heh.``"
+		"TextENG": "``Hello, Jirou-san. I had faith you and I would meet again. Heehee.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155106,
 		"TextJPN": "鷹野は窓を破り、事務所の中に飛び込んできたのだ。",
-		"TextENG": "Takano must have broke through a window, and jumped into the office."
+		"TextENG": "Takano had broken through the window and flew into the office."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155107,
 		"TextJPN": "まるで、映画の中のワンシーンのような派手さを目の当たりにし、男たちは仰天している……。",
-		"TextENG": "Just like witnessing such a flashy scene from a movie, all the men are astonished......"
+		"TextENG": "The whole spectacle was as flashy as a scene from a movie, and the men were all taken aback......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155108,
 		"TextJPN": "もちろん、富竹も仰天せずにはいられない。",
-		"TextENG": "Naturally, Tomitake cannot help but feel astonished, too."
+		"TextENG": "Of course even Tomitake couldn't avoid being dumbstruck."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155109,
 		"TextJPN": "確かに彼女には破天荒なところもあるが、それは性格においてだけだ。こんなことが出来るような身体能力はないはず……。",
-		"TextENG": "It's true that she has her fair share of mavericks, but that's just in her personality. She shouldn't have the physical ability to do something like this."
+		"TextENG": "She was always unpredictable, but that was only in personality. She never had the physical ability to accomplish something like that......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155110,
 		"TextJPN": "園崎組の男たちも、彼女の浮かべる好戦的な笑みに、敵対的であることは理解する。",
-		"TextENG": "As for men of the Sonozaki family, they wear a warlike smile, understanding she is hostile."
+		"TextENG": "The men of the Sonozaki group understood she was hostile from the aggressive smile on her face."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155111,
 		"TextJPN": "しかし、暴徒とも様子が違い、どう対応すればいいか、戸惑っていた。",
-		"TextENG": "However, this situation is different than with the mob, so how will they correspond, they must be puzzled."
+		"TextENG": "Yet unlike with the rioters, they were unsure of how to respond."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155112,
 		"TextJPN": "一方の鷹野は違う。ここで、自分が何をすればいいか、はっきりと理解している。",
-		"TextENG": "But there's only one Takano. Although here, on what she will do, I understand that clearly."
+		"TextENG": "Meanwhile, Takano was different. She understood exactly what she needed to be doing."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155113,
 		"TextJPN": "そして富竹も理解する。……彼女の狙いは、采だ。",
-		"TextENG": "Tomitake also understands. ......Her aim is Une."
+		"TextENG": "Tomitake soon understood too. ......Her target was Une."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155114,
 		"TextJPN": "ウネの感染が先に日本を覆えば、η１７３は無用の長物となる。もう鷹野に出来ることは何もなくなるのだ。",
-		"TextENG": "We should use Une's infection and cover all of Japan before Takano does, making η-173 useless. If we do that, there will be nothing Takano can do."
+		"TextENG": "If we spread Une's infection throughout Japan first, then η173 will become useless. There won't be anything Takano can do then."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155115,
 		"TextJPN": "それを最初から知っているから、采を狙ってくる。",
-		"TextENG": "Because we knew from the beginning that her aim is Une."
+		"TextENG": "But since she knew that from the start, she's targeting Une."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155116,
 		"TextJPN": "興宮のどこかに潜む彼女を探すのは効率が悪い。園崎組が人々を匿い出した時、鷹野は思ったのだ。",
-		"TextENG": "It must have been inefficient for her to search around Okinomiya to find where she was hidden. So, when the Sonozaki family began to shelter people, Takano had an idea where she was."
+		"TextENG": "Trying to uncover where she was hiding out in Okinomiya was inefficient. But once the Sonozaki group started sheltering people, Takano realized something."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155117,
 		"TextJPN": "ここで待っていれば、必ず采がやってくると！",
-		"TextENG": "So, Takano wanted to wait here, and see if Une would come!"
+		"TextENG": "She just had to wait here, and Une would come to her!"
 	},
 	{
 		"type": "MSGSET",
@@ -1527,7 +1527,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0200.",
 		"TextJPN": "「ウネという女の子に用があるだけなの。……連れてきては下さらないかしら？」",
 		"NamesENG": "Takano",
-		"TextENG": "``I only have business with a girl called Une. ......Could you please bring her to me?``"
+		"TextENG": "``I only have business with that girl Une. ......Could you bring her out for me, by chance?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1536,7 +1536,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0460.",
 		"TextJPN": "「何の話だかわからないね」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``I don't know who you're talking about.``"
+		"TextENG": "``I don't know what you're talking about.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1545,7 +1545,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0210.",
 		"TextJPN": "「惚けなくてもいいのよ。だって、ずっと見ていたんだから。くすくすくす……」",
 		"NamesENG": "Takano",
-		"TextENG": "``Don't be silly. I mean, I have already seen her here. Hee hee hee hee hee hee......``"
+		"TextENG": "``You don't need to play dumb. I've been watching you this whole time, after all. Heeheehee......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1554,7 +1554,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0470.",
 		"TextJPN": "「…………させないよ。彼女は東京で保護させてもらう」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``............I won't let you. She's to be protected by Tokyo.``"
+		"TextENG": "``.........I won't let you. We're going to contact Tokyo.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1563,7 +1563,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0080.",
 		"TextJPN": "「お取り込み中、失礼します！　園崎組事務所へようこそ、三四さん！」",
 		"NamesENG": "Shion",
-		"TextENG": "``Thank you for sharing your busy time with us! Welcome to the Sonozaki family office, Miyo-san!``"
+		"TextENG": "``Pardon me for interrupting! Welcome to the Sonozaki group's office, Miyo-san!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1572,19 +1572,19 @@
 		"PreTextTags": "@vS25/09/NTAK_0220.",
 		"TextJPN": "「あらあら、ぞろぞろと」",
 		"NamesENG": "Takano",
-		"TextENG": "``Well, well. They're all here.``"
+		"TextENG": "``My, my, quite the procession.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155124,
 		"TextJPN": "詩音が強面を連れてぞろりと現れる。",
-		"TextENG": "Shion appears with a very fierce look on her face."
+		"TextENG": "Shion appeared with an array of tough men in tow."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155125,
 		"TextJPN": "鷹野が招かれざる客であることは、もう説明の必要もないのだから。",
-		"TextENG": "Takano must have been invited by a non-human, I don't think we need any other explanation."
+		"TextENG": "It went without explanation that Takano was an uninvited guest."
 	},
 	{
 		"type": "MSGSET",
@@ -1593,7 +1593,7 @@
 		"PreTextTags": "@vS25/15/NKAS_0040.",
 		"TextJPN": "「勇ましい方ですが、さすがに無茶が過ぎるのでは？」",
 		"NamesENG": "Kasai",
-		"TextENG": "``You're a brave person, but don't you think this is absurd?``"
+		"TextENG": "``You're a tough woman, but I think you've gone too far now.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1602,7 +1602,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0230.",
 		"TextJPN": "「勇ましいかどうかは、今からわかると思うわよ」",
 		"NamesENG": "Takano",
-		"TextENG": "``Whether or not I'm brave, I think I understand now.``"
+		"TextENG": "``I think you're about to understand just how strong I am.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1611,7 +1611,7 @@
 		"PreTextTags": "@vS25/00/NKUA_0000.",
 		"TextJPN": "「ぐえっ？！」",
 		"NamesENG": "Gangster",
-		"TextENG": "``Guh?!``"
+		"TextENG": "``Gh?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1620,31 +1620,31 @@
 		"PreTextTags": "@vS25/00/NKUB_0000.",
 		"TextJPN": "「むぐッ！」",
 		"NamesENG": "Gangster",
-		"TextENG": "``Mhhhh!``"
+		"TextENG": "``Gah!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155130,
 		"TextJPN": "鷹野の右腕がひとり、左腕がもうひとりの頭を掴み上げて、それぞれ逆の壁に投げつける。",
-		"TextENG": "Takano's right arm doesn't move, she instead raises her left arm and grabs one of the men's head, and hurls it against the nearest wall."
+		"TextENG": "Takano grabbed one head each in both her right and left hands, slamming them against opposite walls."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155131,
 		"TextJPN": "そんな怪力が、あんな細身の体のどこから？！　いいや、どんな大男だって、あんな怪力は出せない。",
-		"TextENG": "Such superhuman strength, how can she do that with such a slender body?! No, even a great man, of superhuman strength couldn't do something like that."
+		"TextENG": "Where did such monstrous strength come from in that slender frame?! No, even someone huge couldn't have produced such strength."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155132,
 		"TextJPN": "それを言ったら、そもそも力学的におかしい。仮にあの細身に怪力が宿っていたとしても、あんな姿勢で軽々と大の男を掴み上げ、放り投げられるわけがない。",
-		"TextENG": "When I think about it, she appeared very mechanically and strange in the first place. And even if such superhuman strength dwelled in that slender body, to effortlessly raise and throw a large man like that shouldn't be possible."
+		"TextENG": "The physics of it were all wrong. Even if her slender frame did house monstrous strength, she couldn't have picked those big men up and thrown them so easily from that particular stance."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155133,
 		"TextJPN": "詩音も葛西も男たちも、絶句して目を見開き、この世のものと思えぬ鷹野の暴力を凝視することしか出来ないのだ。",
-		"TextENG": "Shion, Kasai and all the men are speechless and widely open their eyes. They can only stare at the unexpected violence Takano has brought to this world."
+		"TextENG": "Shion, Kasai, and the other men watched in shock, and all they could do was stare at Takano's otherworldly power."
 	},
 	{
 		"type": "MSGSET",
@@ -1653,7 +1653,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0240.",
 		"TextJPN": "「詩音ちゃん、ぼんやりしてると……、その頭の中身が、ぶちまけられちゃうわよ～？」",
 		"NamesENG": "Takano",
-		"TextENG": "``Shion-chan, you sure are absentminded...... Have the contents of your head become thrown out?``"
+		"TextENG": "``Shion-chan, if you don't pay attention... then your head will get splattered everywhere.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1662,25 +1662,25 @@
 		"PreTextTags": "@vS25/06/NSHI_0090.",
 		"TextJPN": "「ひぇッ？！」",
 		"NamesENG": "Shion",
-		"TextENG": "``Ah?!``"
+		"TextENG": "``Hii?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155136,
 		"TextJPN": "茫然としていた詩音は、鷹野と目が合い、らしくもなく竦み上がる。",
-		"TextENG": "Shion is stunned, her eyes match Takano's, she steps back in fear."
+		"TextENG": "Shion's dumbstruck eyes met Takano's, and for once she cringed with fear."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155137,
 		"TextJPN": "無理もない。人は理解不能な光景を目の当たりにした時、それが解釈できるまで、一切の行動が出来ないのだから。",
-		"TextENG": "It is understandable. Anyone would have done the same after witnessing such an incomprehensible sight, but until she can interrupt her, she cannot take any action."
+		"TextENG": "I couldn't blame her. When a human witnesses something beyond their understanding, they're completely unable to act until they can explain it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155138,
 		"TextJPN": "鷹野の腕が、まるで熊手のように巨大に見え、……あっと思った次の瞬間には、詩音の眼前に、猛然と振るわれた鷹野の腕が……。",
-		"TextENG": "Takano's arms looks as huge as a bamboo rake...... Then, in the next moment, before the eyes of Shion, Takano wields her arm fiercely......"
+		"TextENG": "Takano's arms looked like huge bear paws to her...... and before she could blink, those arms were swinging ferociously toward Shion......"
 	},
 	{
 		"type": "MSGSET",
@@ -1695,7 +1695,7 @@
 		"type": "MSGSET",
 		"MessageID": 155140,
 		"TextJPN": "葛西が詩音を弾き飛ばしながら、振るわれた鷹野の腕を、その力を活かしながら後ろ手に極め、体を床に押し潰す。",
-		"TextENG": "Kasai pushes Shion out of the way, and takes the full brunt of Takano's arm, but utilizing all his strength, he crushes her body onto the floor."
+		"TextENG": "As Kasai shoved Shion out of the way he grabbed Takano's swinging arm and used her own force to capture her arm behind her and shove her body onto the floor."
 	},
 	{
 		"type": "MSGSET",
@@ -1704,7 +1704,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0250.",
 		"TextJPN": "「あらあら……」",
 		"NamesENG": "Takano",
-		"TextENG": "``Oh my......``"
+		"TextENG": "``My, my......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1713,7 +1713,7 @@
 		"PreTextTags": "@vS25/15/NKAS_0060.",
 		"TextJPN": "「恐ろしい御仁です……。一体、どこからそのような力が……」",
 		"NamesENG": "Kasai",
-		"TextENG": "``What a frightening personage...... Where on earth did she get such power......``"
+		"TextENG": "``What a frightening person...... Where on earth did you obtain such strength......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1722,19 +1722,19 @@
 		"PreTextTags": "@vS25/06/NSHI_0100.",
 		"TextJPN": "「葛西ッ、さすがですっ」",
 		"NamesENG": "Shion",
-		"TextENG": "``Kasai, as expected.``"
+		"TextENG": "``Kasai! Way to go!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155144,
 		"TextJPN": "見事に関節を決め、地面に押し潰している。いくら怪力であっても、こうなっては足掻きようもあるまい。",
-		"TextENG": "That joint attack was beautiful, he crushed Takano onto the ground. So even if she does have superhuman strength, she will no doubt struggle against him."
+		"TextENG": "He got a good lock on her joints and pressed her into the ground. No matter how much strength she had, she shouldn't be able to struggle any longer."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155145,
 		"TextJPN": "鷹野は逃れようともがいてみるが、ひっくり返った昆虫のような無様を見せるだけだった。",
-		"TextENG": "Takano struggles to escape, but she can only be seen crawling away like an overturned insect."
+		"TextENG": "Takano wriggled in an effort to escape, but she just looked like a pathetic bug pinned on its back."
 	},
 	{
 		"type": "MSGSET",
@@ -1743,7 +1743,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0110.",
 		"TextJPN": "「無駄な抵抗は止めた方がいいです。葛西はコワーイ人だから、あんまり暴れると、腕、折っちゃうかもですよ？」",
 		"NamesENG": "Shion",
-		"TextENG": "``You should stop this useless resistance. Because when Kasai gets violent, he could break your arm, right?``"
+		"TextENG": "``You should cease your futile resistance. Kasai's a scary man, so if you struggle too much, he might break your arm?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1752,7 +1752,7 @@
 		"PreTextTags": "@vS25/15/NKAS_0070.",
 		"TextJPN": "「その必要がない限りはしませんが、……紳士でもありませんので、万一の際は悪しからずです」",
 		"NamesENG": "Kasai",
-		"TextENG": "``Only if it's necessary...... I'm not a gentleman, so during an event like this, I beg you to understand my position.``"
+		"TextENG": "``I won't do it unless it's necessary... but I'm no gentleman, so forgive me if it comes to that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1761,19 +1761,19 @@
 		"PreTextTags": "@vS25/09/NTAK_0260.",
 		"TextJPN": "「あら嫌だ、本当に動けないわ。くすくす……」",
 		"NamesENG": "Takano",
-		"TextENG": "``Oh, how unpleasant, I really wouldn't want that to happen. Heh heh......``"
+		"TextENG": "``My, oh no. I really can't move. Heehee......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155149,
 		"TextJPN": "ああもがっちりと関節を決められたら、顔を歪めずにはいられないくらいに痛いはずだ。",
-		"TextENG": "I think we can all agree that bending a firm joint like that would seriously hurt."
+		"TextENG": "With her joints locked so securely, it should hurt enough for her face to twist in pain."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155150,
 		"TextJPN": "しかし、鷹野は涼しそうな表情で、身動きできないことを面白がっているように見える。",
-		"TextENG": "However, Takano's expression is cool, she seems to be amused instead of paralyzed."
+		"TextENG": "Yet Takano remained collected, and seemed amused at her inability to move."
 	},
 	{
 		"type": "MSGSET",
@@ -1782,7 +1782,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0270.",
 		"TextJPN": "「この程度なのかしら？　私に与えられた力というのは……？　……違うわよねぇ？　くす……、くすくすくすくす……！」",
 		"NamesENG": "Takano",
-		"TextENG": "``Is this what I'm supposed to do? Is this the extent of the power I've been given? It's not, is it?``"
+		"TextENG": "``Is this the full extent? Of the power you're granting me......? ......It's not, is it? Hee...... Heeheeheehee......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1791,37 +1791,37 @@
 		"PreTextTags": "@vS25/15/NKAS_0080.",
 		"TextJPN": "「んぬ、………むおッ…！」",
 		"NamesENG": "Kasai",
-		"TextENG": "``Hah... Gha...!``"
+		"TextENG": "``Nnngh! ......Nngoh...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155153,
 		"TextJPN": "鷹野のもう片方の腕が、……たった一本で、自分と組み伏せている葛西の、二人分の体をゆっくりと持ち上げだす。",
-		"TextENG": "With just one arm, Takano begins to slowly lift the bodies of both himself and Kasai from the ground."
+		"TextENG": "Takano used her other arm...... and with just that single arm, lifted both herself and her grappler, Kasai."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155154,
 		"TextJPN": "まるで、雑技団か何かの演技を見ているような錯覚。",
-		"TextENG": "It's like watching some kind of optical illusion performance from an acrobatic troupe."
+		"TextENG": "It was like we were watching some kind of circus performance."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155155,
 		"TextJPN": "違う。鷹野の逸脱した怪力が、たった一本の腕で、葛西ごと自分の体を浮かせてしまったのだ。",
-		"TextENG": "No, this is different. Takano has such superhuman strength, but even then she only needs one arm to suspend Kasai's body in mid-air."
+		"TextENG": "No. Takano's irregular, monstrous strength allowed her, with just one arm, to lift both herself and Kasai into the air."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155156,
 		"TextJPN": "さすがの葛西も仰天せずにはいられない。",
-		"TextENG": "Even Kasai cannot help but feel astonished, too."
+		"TextENG": "Even Kasai couldn't avoid being shocked."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155157,
 		"TextJPN": "その次の瞬間、戒めは解かれ、つむじ風のように葛西を振り回し、壁に投げ付ける。",
-		"TextENG": "The next moment, the commandment is released, and like a whirlwind, Kasai is swung around and thrown against the wall."
+		"TextENG": "In the next moment, he lost his hold on her, and she spun Kasai like a blender, throwing him against the wall."
 	},
 	{
 		"type": "MSGSET",
@@ -1830,25 +1830,25 @@
 		"PreTextTags": "@vS25/06/NSHI_0120.",
 		"TextJPN": "「あんた、はしゃぎ過ぎですッ！！」",
 		"NamesENG": "Shion",
-		"TextENG": "``You're getting carried away!!``"
+		"TextENG": "``You're having too much fun!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155159,
 		"TextJPN": "詩音が鷹野に背後より迫った瞬間、青白い火花が飛び散る。切り札のスタンガンを鷹野に食らわせたのだ。",
-		"TextENG": "At that moment, Shion approaches Takano from behind, and bluish-white sparks scatter. She uses her trump card, a stun gun and sticks it to Takano."
+		"TextENG": "Shion got behind Takano, and pale blue sparks could be seen. She had driven her trump card - her stun gun - into Takano's body."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155160,
 		"TextJPN": "電撃は、怪力だろうと非力だろうと食らえば堪えられるものではない。",
-		"TextENG": "The electric shock is not something that can be endured by anyone, monstrous or not."
+		"TextENG": "No matter how strong you are, nobody can withstand electric jolts."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155161,
 		"TextJPN": "しかし、鷹野は悠然と振り返るのだ……。",
-		"TextENG": "However, Takano looks back in a grand manner......"
+		"TextENG": "Yet Takano just calmly turned around......"
 	},
 	{
 		"type": "MSGSET",
@@ -1857,7 +1857,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0280.",
 		"TextJPN": "「あらあら。……それはなぁに？」",
 		"NamesENG": "Takano",
-		"TextENG": "``Oh my. ......Did something go wrong?``"
+		"TextENG": "``My, my. ......What is that?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1866,7 +1866,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0130.",
 		"TextJPN": "「そ、そんなはずは……ッ！！」",
 		"NamesENG": "Shion",
-		"TextENG": "``That's not possible......!!``"
+		"TextENG": "``T-That's impossible......!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1875,19 +1875,19 @@
 		"PreTextTags": "@vS25/09/NTAK_0290.",
 		"TextJPN": "「人の子の分際で、神の御使いの私にそんなことをするなんて……。悪い子ねぇ……」",
 		"NamesENG": "Takano",
-		"TextENG": "``How dare you do such a thing to me, a messenger of God, when you are just a human child? Bad girl...``"
+		"TextENG": "``To think a mere child would do such a thing to the priestess of a god...... What a bad girl......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155165,
 		"TextJPN": "鷹野の手が、片腕で詩音の顔面を掴み上げる。",
-		"TextENG": "Takano grasps Shion's face with only one of her hands."
+		"TextENG": "Takano's hand seized hold of Shion's face."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155166,
 		"TextJPN": "頭蓋骨が軋むような苦痛に詩音は呻きながら抗うが、鷹野の万力のような力に対しては、まるで赤子が抵抗するようなものだ。",
-		"TextENG": "Shion groans in pain, as her skull is being crushed, but against such force of Takano's vice, she is seemly a baby attempting to resist."
+		"TextENG": "Shion groaned and fought back, and we heard her skull grating, her resistance like a baby's against Takano's vice-like strength."
 	},
 	{
 		"type": "MSGSET",
@@ -1896,31 +1896,31 @@
 		"PreTextTags": "@vS25/09/NTAK_0300.",
 		"TextJPN": "「くす。これはお仕置きだからね？」",
 		"NamesENG": "Takano",
-		"TextENG": "``Hee hee. That's your punishment, got it?``"
+		"TextENG": "``Heehee. This is your punishment, okay?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155168,
 		"TextJPN": "次の瞬間、詩音の体は、大の字に壁に叩きつけられていた。",
-		"TextENG": "The next moment Shion's body is slammed against the wall with her legs spread wide."
+		"TextENG": "The next moment Shion's body was splayed out against the wall."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155169,
 		"TextJPN": "詩音にとって、打ち付けられた壁は大地も同然。２階から突き落とされ、コンクリートの大地に打ち付けられたも同然だった。",
-		"TextENG": "Shion is slammed against the wall and then the ground. She is thrown from the second floor, and falls against the concrete, slamming the ground."
+		"TextENG": "For Shion, it was no different than her body being slammed into the ground. It felt just like she had been thrown out of the second story and slammed onto the hard, concrete ground."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155170,
 		"TextJPN": "そして、ずるりと床に崩れ落ち、呻く。",
-		"TextENG": "Then, she collapses onto the floor and groans."
+		"TextENG": "Then her body slid down and crumpled onto the floor with a groan."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155171,
 		"TextJPN": "しかし鷹野は、さらなる何かを求め、詩音になおも歩み寄ろうとする……。",
-		"TextENG": "However, Takano demands something further, and slowly approaches Shion......"
+		"TextENG": "Yet Takano was about to walk toward Shion again looking for something else from her......"
 	},
 	{
 		"type": "MSGSET",
@@ -1929,7 +1929,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0480.",
 		"TextJPN": "「もう、よすんだ、鷹野さんッ！　君を撃ちたくない！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``Stop it already, Takano-san! I don't want to shoot you!``"
+		"TextENG": "``Stop this now, Takano-san! I don't want to shoot you!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1938,31 +1938,31 @@
 		"PreTextTags": "@vS25/09/NTAK_0310.",
 		"TextJPN": "「あら、ジロウさん。……くす、それはとても興味深いわね。人の子の武器が、私に傷を付けられるかどうか、とても興味深いわ。くすくすくす……」",
 		"NamesENG": "Takano",
-		"TextENG": "``Oh, Jirou-san. ......Hee hee, very interesting. A child of man holding a weapon, I wonder if it will hurt me. Very interesting. Heh heh heh......``"
+		"TextENG": "``Oh my, Jirou-san. ......Heehee, that's a very interesting idea. I'm very curious to find out if a human weapon can injure me now. Heeheehee......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155174,
 		"TextJPN": "富竹が向けるサブマシンガンを、鷹野は面白そうに眺めている。",
-		"TextENG": "Takano looks at the submachine gun that Tomitake points at him with amusement."
+		"TextENG": "Takano gazed at Tomitake's submachine gun with amusement."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155175,
 		"TextJPN": "日本人特有の、どうせモデルガンだろうという嘲りではない。",
-		"TextENG": "This is not the typical Japanese mockery of a model gun anyway."
+		"TextENG": "It didn't seem to be the uniquely Japanese scorn of assuming it was just a model gun either."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155176,
 		"TextJPN": "心の底から、……それを撃ち掛けられたら、どうなるのか見てみたいという好奇心から笑みを浮かべているのだ。",
-		"TextENG": "From the bottom of her heart...... she knows he will shoot, but she smiles out of curiosity to see what will happen."
+		"TextENG": "She was truly smiling, keenly curious as to what it would happen if she were shot by it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155177,
 		"TextJPN": "富竹も理解せざるを得ない。……今の鷹野には、何か超常の力が備わっている。",
-		"TextENG": "Tomitake knows he cannot avoid it. ......As the Takano of now possesses some form of paranormal power."
+		"TextENG": "Tomitake failed to understand that too. ......Right now, Takano had to be gifted with some form of supernatural power."
 	},
 	{
 		"type": "MSGSET",
@@ -1971,7 +1971,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0700.",
 		"TextJPN": "「鷹野を巫女にしたのですか、田村媛命…ッ！！　何と愚かなことをッ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Did you make Takano your shrine maiden?! Tamurahime no Mikoto...!! What a foolish thing.``"
+		"TextENG": "``You made Takano your priestess, Tamurahime-no-Mikoto...!! How could you be such a fool?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1980,7 +1980,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0140.",
 		"TextJPN": "「黙り給え、吾輩はそなたの指図など受けぬと知り奉れッ。神聖なる大地を穢そうとする新たなる輩を成敗する也ッ。邪魔は無用と知り給え！！　そこに直れ、ウネッ！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Shut up, and know that I will not take orders from you. I will defeat the newcomers who seek to defile the sacred earth. Know that you are not to be disturbed! Stay where you are, Une!!``"
+		"TextENG": "``Be quiet! Know that I shall not listen to you! I shall punish all peoples who dare to taint our sacred land! Know that your hindrance is useless!! Prepare yourself, Une!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1989,7 +1989,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0540.",
 		"TextJPN": "「……我、な、何もしてないのです……」",
 		"NamesENG": "Une",
-		"TextENG": "``......Me, I-I haven't done anything......``"
+		"TextENG": "``......I h-haven't done anything......``"
 	},
 	{
 		"type": "MSGSET",
@@ -1998,7 +1998,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0150.",
 		"TextJPN": "「白々しい！　貴様の汚らわしさなど、吾輩の眼力の前には全てお見通しであると知り給え！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Barefaced! Your intention is repulsive and different, I know of it using the insight of my people!``"
+		"TextENG": "``Insolence! Know that all your corruption lies bare before my eyes!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2007,7 +2007,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0550.",
 		"TextJPN": "「……我、そんなつもり……ないのに………」",
 		"NamesENG": "Une",
-		"TextENG": "``......I-I have no such intention...... I don't.........``"
+		"TextENG": "``......It, was never...... my intention to......``"
 	},
 	{
 		"type": "MSGSET",
@@ -2016,7 +2016,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0710.",
 		"TextJPN": "「僕が来た時にもそう言って酷くいじめたのです。あいつは意地悪なヤツなのですっ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``When I first came here, she said the same thing and severely bullied me. She is malicious.``"
+		"TextENG": "``She said the same thing when I arrived here, and tormented me badly. She's just a bully!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2025,7 +2025,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1020.",
 		"TextJPN": "「田村の何とか。あんたに恨みはないけれど、あんたの巫女は個人的に気に入らないの。悪いけど、あんたが右って言うなら、私たちは左にさせてもらうわ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Tamura's something. I have nothing against you, but I personally don't like your maiden. I'm sorry, but if you're going to be on the one side, we're going to be on the another side!``"
+		"TextENG": "``Tamura-no-Whatever. I hold no grudge against you, but I personally dislike your priestess. So sorry, but if you're choosing right, then we're choosing left!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2034,7 +2034,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0160.",
 		"TextJPN": "「我が巫女よ、……悪魔ウネはここ也や！　今こそ誅する時ッ！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``My shrine maiden...... the devil Une is here! Kill her now!!``"
+		"TextENG": "``Priestess of mine! ......The devil Une stands here! Now is the moment to slay her!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2043,19 +2043,19 @@
 		"PreTextTags": "@vS25/09/NTAK_0320.",
 		"TextJPN": "「……そこにいるのね、ウネちゃん」",
 		"NamesENG": "Takano",
-		"TextENG": "``......So that's where you where, Une-chan.``"
+		"TextENG": "``......So that's where you are, Une-chan.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155187,
 		"TextJPN": "鷹野は壁を見る。彼女には、その向こうにいるウネの姿が見えているのだ。",
-		"TextENG": "Takano sees through the wall. She can see the visible appearance of Une on the other side."
+		"TextENG": "Takano looked at the wall. She could see Une's figure through it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155188,
 		"TextJPN": "采もまた、自分が凝視されていることに気付き、震え上がる。",
-		"TextENG": "Une notices she is staring, and trembles violently."
+		"TextENG": "Une also noticed she was being stared at and shuddered."
 	},
 	{
 		"type": "MSGSET",
@@ -2064,19 +2064,19 @@
 		"PreTextTags": "@vS25/08/NTOM_0490.",
 		"TextJPN": "「に、逃げろ…！！　僕たちには止められない！！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``E-Escape...!! We won't be able to stop her!!``"
+		"TextENG": "``R-Run...!! We can't stop her!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155190,
 		"TextJPN": "鷹野は右手の握り拳を確かめると、それをゆっくりと壁に押し当てる。",
-		"TextENG": "Takano checks her right hand clenched in a fist, and slowly presses it against the wall."
+		"TextENG": "Once Takano checked her right fist, she slowly pressed it into the wall."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155191,
 		"TextJPN": "すると、……ゆっくりとそこから放射状にひび割れが広がっていく……。",
-		"TextENG": "Then...... cracks begin to spread slowly and radially......"
+		"TextENG": "Then...... cracks began to spread through the wall, radiating slowly out from her fist......"
 	},
 	{
 		"type": "MSGSET",
@@ -2085,7 +2085,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1430.",
 		"TextJPN": "「な、何が起こってんの…！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Wh-What's happening...!!``"
+		"TextENG": "``W-What's happening...?!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2094,7 +2094,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1410.",
 		"TextJPN": "「富竹さんは逃げろって言ってる！　逃げるんだ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Tomitake said to escape! So let's escape!!``"
+		"TextENG": "``Tomitake-san said run! So run!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2103,7 +2103,7 @@
 		"PreTextTags": "@vS25/02/NREN_1270.",
 		"TextJPN": "「采ちゃんッ、早くこっちに！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Une-chan, over here, quickly!!``"
+		"TextENG": "``Une-chan, hurry, this way!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2112,19 +2112,19 @@
 		"PreTextTags": "@vS25/50/NUNE_0560.",
 		"TextJPN": "「……に、……逃げ……、ひい………、」",
 		"NamesENG": "Une",
-		"TextENG": "``......E-Escape...... Hii.........``"
+		"TextENG": "``......R...... Run...... Hiii.........``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155196,
 		"TextJPN": "目の前の壁のひび割れはどんどん深く広がっていき、地鳴りのようなものまで聞こえ出す。",
-		"TextENG": "The cracks in the wall right before our eyes deepen rapidly, until something like a rumbling sound can be heard."
+		"TextENG": "The cracks in the wall spread even deeper before their eyes, and they could hear the ground quaking."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155197,
 		"TextJPN": "もはや疑う余地はない。鷹野は壁を砕いてやって来るつもりだ…！",
-		"TextENG": "There's no doubt about it. Takano's trying to crush the wall and bust through...!"
+		"TextENG": "There was no room left for doubts. Takano was planning to smash right through the wall...!"
 	},
 	{
 		"type": "MSGSET",
@@ -2133,7 +2133,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1030.",
 		"TextJPN": "「何で田村の巫女にはあんなすごい力が宿るのに、あんたの巫女には何もないのよ！」",
 		"NamesENG": "Rika",
-		"TextENG": "``What kind of great power dwells inside a shrine maiden of Tamura, and why can't I as your shrine maiden do that!``"
+		"TextENG": "``Why does Tamura's priestess have such incredible power, when your priestess gets nothing?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2142,7 +2142,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0720.",
 		"TextJPN": "「梨花ぁ、それを言っちゃあ！　それを言っちゃあおしまいなのですよ、あうあうあう！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Rika, don't say that! The end of it, I don't want to talk about it, au au au!!``"
+		"TextENG": "``Rika, don't say that! If you say that, it's over! Auauau!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2151,19 +2151,19 @@
 		"PreTextTags": "@vS25/03/NMIO_1440.",
 		"TextJPN": "「梨花ちゃん、何やってんの！！　逃げるよ！！　うわあッ！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Rika-chan, what are you doing!! Run away!! Uwaa!!``"
+		"TextENG": "``Rika-chan, what are you doing?!! Run!! Uwaah!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155201,
 		"TextJPN": "この程度の壁など、今の鷹野を、いや、田村媛命の巫女を阻むことなど出来るわけもない。",
-		"TextENG": "There was no way that a wall of this magnitude now would be able to stop Takano, the priestess of Tamurahime no Mikoto."
+		"TextENG": "Such a simple wall couldn't stop Takano― no, the priestess of Tamurahime-no-Mikoto."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155202,
 		"TextJPN": "砂場で作った城を崩すより易々と、壁は打ち壊され、巨大な口を開ける。",
-		"TextENG": "She destroys it easily as if it were a castle made in a sandbox, and smashes through the wall. We open our mouths wide in shock."
+		"TextENG": "She smashed through the wall as easily as crushing a sand castle."
 	},
 	{
 		"type": "MSGSET",
@@ -2172,7 +2172,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0330.",
 		"TextJPN": "「見つけたわよ、ウネちゃ～ん、くすくすくすくす！！」",
 		"NamesENG": "Takano",
-		"TextENG": "``Found you, Une-chan, heh heh heh heh!!``"
+		"TextENG": "``I found you, Une-chaaan! Heeheeheehee!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2181,7 +2181,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0570.",
 		"TextJPN": "「ひ、……ひいっ、……ひいっ……！　あッ！」",
 		"NamesENG": "Une",
-		"TextENG": "``H-Hiii...... Hiiii......! Ah!``"
+		"TextENG": "``Hii...... Hiiii! ......Hiii......! Ah!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2196,13 +2196,13 @@
 		"type": "MSGSET",
 		"MessageID": 155206,
 		"TextJPN": "采が滑って転び、逃げ損ねる。",
-		"TextENG": "Une slips and falls, failing to escape."
+		"TextENG": "Une slipped and fell, failing to escape."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155207,
 		"TextJPN": "それを見逃すほど鷹野が間抜けなわけもない。ずかずかと歩み寄り、采の襟首を掴み上げる。",
-		"TextENG": "Takano cannot be so foolish to miss this chance. She walks slowly towards her making a rude entrance, and grabs Une by the nape of her neck."
+		"TextENG": "Takano wasn't foolish enough to let that chance slip by. She strode right in and seized Une by her collar."
 	},
 	{
 		"type": "MSGSET",
@@ -2211,7 +2211,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0340.",
 		"TextJPN": "「さぁ、捕まえた…！！」",
 		"NamesENG": "Takano",
-		"TextENG": "``Now, I've caught you...!!``"
+		"TextENG": "``Now I've got you......!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2220,7 +2220,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0620.",
 		"TextJPN": "「残念！　薄幸の美少女、沙都子ちゃんでしてよ！　采さんだと思いまして？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``You must be disappointed! To find such an unfortunate beautiful girl, called Satoko-chan! What, did you think I was Une-san?``"
+		"TextENG": "``Sorry! It was the pretty, misfortunate girl, Satoko-chan! Did you think it was Une-san?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2229,31 +2229,31 @@
 		"PreTextTags": "@vS25/04/NSAT_0630.",
 		"TextJPN": "「残念ですわねぇ、おーっほっほっほっほ！！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``How unfortunate, right, oh ho ho ho ho!!``"
+		"TextENG": "``Too bad for you! Ohhohohoho!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155211,
 		"TextJPN": "銃を向けられても涼しげだった鷹野も、一瞬、頭が真っ白になる。",
-		"TextENG": "Takano, who looked cool even when a gun was pointed at her, for a moment, her head becomes pure white."
+		"TextENG": "While she had kept her composure with a gun pointed at her, Takano's mind went blank for a moment after that."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155212,
 		"TextJPN": "梨花に采の秘密を打ち明けられた彼らは、采を守る為に最大の罠を直ちに用意したのだ。",
-		"TextENG": "Satoko was told by Rika to pretend she was Une, and immediately she prepared the greatest trap in order to protect Une."
+		"TextENG": "After Rika shared Une's secret with them, they prepared the ultimate trap to protect her."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155213,
 		"TextJPN": "背格好の近い沙都子と采の服を着替えさせ、入れ替えたのだ。もちろん、滑って転び、鷹野の目を引きつけるのも計算の上だ。",
-		"TextENG": "They made sure Satoko was the same height as Une, and then beside one other they changed clothes. Naturally, even the slip and fall, was calculated in order to attract Takano's eyes."
+		"TextENG": "They had Satoko, who was close to her height, change into her clothes and take her place. Of course, the slip and fall was all a calculated move to draw Takano's eyes toward her."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155214,
 		"TextJPN": "壁を打ち破ってくるというこの世ならざる衝撃も、まさにトラップに今、引っ掛けてやろうという高揚感には及ばなかったのだ。",
-		"TextENG": "And now, her world has begun to break down, even though she just defeated a wall with the power of a non-human, and with this trap, her uplifted feeling has been brought down, too."
+		"TextENG": "The shock of seeing her otherworldly power smash through the wall wasn't enough to overcome the thrill of trying to catch her in a trap."
 	},
 	{
 		"type": "MSGSET",
@@ -2262,7 +2262,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0350.",
 		"TextJPN": "「さ、沙都子ぉおおおぉおおおぉッ！！」",
 		"NamesENG": "Takano",
-		"TextENG": "``Hhh... Satokoooooooooo!!``"
+		"TextENG": "``S-Satokoooooooooo!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2271,19 +2271,19 @@
 		"PreTextTags": "@vS25/04/NSAT_0640.",
 		"TextJPN": "「をっほほほほほ！　おマヌケさんにはプレゼントですわ！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Oh ho ho ho ho ho! My present to an idiot like you!``"
+		"TextENG": "``Ohhohohohohoho! And here's a present for our fool!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155217,
 		"TextJPN": "鷹野の虚を突き、沙都子は何かをがばっと鷹野に被せる。",
-		"TextENG": "Thrusted into the imagination of Takano, Satoko suddenly appears dazzled in light before her."
+		"TextENG": "Satoko took advantage of Takano's stupor to place something onto her head."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155218,
 		"TextJPN": "それは、……白くてフワフワの、@k@|@yウサ耳？！",
-		"TextENG": "With something...... white and fluffy,@k@|@y ...Bunny ears?!"
+		"TextENG": "It was a...... pair of white, fluffy@k@|@y bunny ears?!"
 	},
 	{
 		"type": "MSGSET",
@@ -2301,7 +2301,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0730.",
 		"TextJPN": "「行きますですよ、ピカーッ！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Let's go. Beaaaam!!``"
+		"TextENG": "``Here I go! Flash!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2310,7 +2310,7 @@
 		"PreTextTags": "@vS25/09/NTAK_0360.",
 		"TextJPN": "「は？　何よこれ……？！　ウ、ウサギの耳…？！」",
 		"NamesENG": "Takano",
-		"TextENG": "``Huh? What is this......?! B-Bunny ears...?!``"
+		"TextENG": "``Huh? What's this......?! B-Bunny ears...?!``"
 	},
 	{
 		"type": "LOGSET",
@@ -2327,25 +2327,25 @@
 		"PreTextTags": "@vS25/09/NTAK_0370.",
 		"TextJPN": "「えッ、」",
 		"NamesENG": "Takano",
-		"TextENG": "``Eh?``"
+		"TextENG": "``Huh?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155223,
 		"TextJPN": "羽入は人ならざる者の力で、一瞬だけ田村の力に干渉し、鷹野への巫女としての加護に隙を作る。",
-		"TextENG": "Hanyuu used the powers of a non-human, and interfered with Tamura's power for an instant, dropping Takano's divine protection as a shrine maiden, creating an opening."
+		"TextENG": "Hanyuu had used her inhuman powers to interfere with Tamura's own power for a moment, creating a break in the protection Takano received as her priestess."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155224,
 		"TextJPN": "もちろん、広大な土地を統べる強力な田村の力を破るなど、一瞬だけしか出来ない。",
-		"TextENG": "Naturally, she can only break Tamura's powerful strength for only an instant, since she controls such a vast land."
+		"TextENG": "Of course, since Tamura was very powerful due to ruling over vast regions of land, Hanyuu could only break her power for a moment."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155225,
 		"TextJPN": "しかし……、その一瞬で充分……！",
-		"TextENG": "However...... an instant is enough......!"
+		"TextENG": "However...... That moment was plenty......!"
 	},
 	{
 		"type": "LOGSET",
@@ -2359,31 +2359,31 @@
 		"type": "MSGSET",
 		"MessageID": 155226,
 		"TextJPN": "レナの猛打が鷹野の顔面に集中し、そして圭一が鷹野の足をその逆方向に掬う。",
-		"TextENG": "Rena deals a heavy concentrated blow on Takano's face, while Keiichi scoops her foot from the opposite direction."
+		"TextENG": "Rena's heavy blow was concentrated on Takano's face, and Keiichi swept her feet in the opposite direction."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155227,
 		"TextJPN": "鷹野の体は、ぐるんと空中で一回転してから、自らが積み上げた瓦礫の山にうつ伏せに叩き付けられる。",
-		"TextENG": "Takano's body, performs a full rotation in the air, and is slammed against the heap of debris she herself created."
+		"TextENG": "Takano's body spun in the air and then slammed face-down onto the mountain of rubble she'd created herself."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155228,
 		"TextJPN": "田村媛命の加護があったなら、レナの攻撃など猫がじゃれ付く程度にもならなかったろう。",
-		"TextENG": "But, if she had the divine protection of Tamurahime-no-Mikoto, Rena might as well have been a playfully attacking cat."
+		"TextENG": "If she had Tamurahime-no-Mikoto's protection, then Rena's attack would've been little more than the toying of a housecat."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155229,
 		"TextJPN": "しかし、今の一瞬だけは、生身の鷹野に戻っていた。……ということはつまり、致命傷というわけだ。",
-		"TextENG": "However, only for this moment, Takano was back to a flesh-and-blood human. ......In other words that means, she can be fatally wounded."
+		"TextENG": "But in that one moment, she had reverted to the ordinary Takano. ......Which meant that it was a finishing blow."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155230,
 		"TextJPN": "鷹野は脳震盪を起こし、失神してしまう。",
-		"TextENG": "Takano is given a brain concussion, which leads to her fainting."
+		"TextENG": "Takano suffered a concussion and passed out."
 	},
 	{
 		"type": "MSGSET",
@@ -2392,7 +2392,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0140.",
 		"TextJPN": "「ど、どういうわけですか……。レナさんって、……本当に人間？」",
 		"NamesENG": "Shion",
-		"TextENG": "``H-How did you do that...... Rena-san...... are you really human?``"
+		"TextENG": "``W-What's going on......? Is Rena-san...... really human?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2401,19 +2401,19 @@
 		"PreTextTags": "@vS25/08/NTOM_0500.",
 		"TextJPN": "「……お、……驚いたね、……ははははは」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``......I-I'm surprised...... ha ha ha ha ha.``"
+		"TextENG": "``......I...... I'm surprised...... Hahahahaha.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155233,
 		"TextJPN": "ほんの直前まで、鷹野の異常な力を目の当たりにしていた詩音たちは、仰天を越え、苦笑いを浮かべる他はない。",
-		"TextENG": "Just before, Shion witnessed the abnormal powers of Takano, so she is beyond amazement, and cannot help but wear a bitter smile."
+		"TextENG": "After witnessing Takano's supernatural power just a moment ago, Shion and the others could replace their shock with strained smiles."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155234,
 		"TextJPN": "当然だ。人外の強さの鷹野を、部活メンバーは秒殺して見せたのだから……。",
-		"TextENG": "Naturally. The inhuman strength of Takano would have killed any club member within a second......"
+		"TextENG": "Of course. Because they just witnessed a club member instantly beat her and her superhuman strength......"
 	},
 	{
 		"type": "MSGSET",
@@ -2422,7 +2422,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1450.",
 		"TextJPN": "「あー、おじさんだけ何もしてないとか言わないよーにねぇ？　状況とメンバー全員の特性を考えての、おじさんの作戦勝ちなんだからね～？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Oh, do you need this Old Man to do anything? Because considering the characteristic's of all the members and our situation, don't you think Old Man should be part of the winning strategy?``"
+		"TextENG": "``Uhh, don't go saying I did nothing, okay? This was my strategy, and I devised it after considering our situation and all our members' abilities.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2431,7 +2431,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0150.",
 		"TextJPN": "「……おや、お姉。いたんですか、気付きませんでした」",
 		"NamesENG": "Shion",
-		"TextENG": "``......Oh, Sis. I didn't notice you there.``"
+		"TextENG": "``......Oh, Sis. You're here? I didn't notice.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2440,7 +2440,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0510.",
 		"TextJPN": "「まさか、あの怪物のような鷹野さんを、……こんなにもあっさりと、ね……」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``No way, Takano-san was like a monster...... But she was so quick......``"
+		"TextENG": "``I can't believe she took down that monstrous version of Takano-san...... so effortlessly......``"
 	},
 	{
 		"type": "MSGSET",
@@ -2449,7 +2449,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0650.",
 		"TextJPN": "「采さん、もう怖くありませんですわよ、出ていらっしゃいですわ！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Une-san, you don't need to be scared anymore, you can go out!``"
+		"TextENG": "``Une-san, there's nothing to fear anymore. You can come out now!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2458,31 +2458,31 @@
 		"PreTextTags": "@vS25/50/NUNE_0580.",
 		"TextJPN": "「………怖くない……、のですか………」",
 		"NamesENG": "Une",
-		"TextENG": "``.........I'm not scared......``"
+		"TextENG": "``......It's not scary, anymore......?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155240,
 		"TextJPN": "物陰に隠れていた、沙都子の服を着た采がおずおずと姿を見せる。",
-		"TextENG": "Coming out of the shadows, Une appears timidly wearing Satoko's clothes."
+		"TextENG": "Une timidly emerged from the shadows where she hid wearing Satoko's clothes."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155241,
 		"TextJPN": "……本来なら、服を変えた程度で、田村媛命の目を誤魔化せるはずもない。",
-		"TextENG": "......However, even to the extent of changing her clothes, she could not deceive the eyes of Tamurahime no Mikoto."
+		"TextENG": "......Normally we wouldn't have been able to fool Tamurahime-no-Mikoto's eyes with just a change of clothes."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155242,
 		"TextJPN": "彼女の神通力により、確かに鷹野は、壁越しではあっても、ウネを見ることが出来たのだ。",
-		"TextENG": "Thanks to her divine power, Takano was indeed able to see Une, even if it was through a wall."
+		"TextENG": "Takano was certainly able to see Une, even through a wall, with her divine power."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155243,
 		"TextJPN": "しかし、壁を打ち砕いて、鷹野の生身の目でそれを確認した時、人としての感覚が優先してしまい、采の服を着た沙都子を誤認してしまった。だから、部活メンバーの罠に引っ掛かってしまったのだ。",
-		"TextENG": "However, after she smashed the wall, we could confirm it was a flesh-and-blood Takano with our own eyes, so making her feel like a human became our top priority, and thus we placed Satoko in Une's clothes so she would mistake her for Une. Therefore, she was caught in the club members trap."
+		"TextENG": "Yet when Takano broke through the wall and saw her with her own eyes, her human perception took priority, and she mistook Une for Satoko because of her clothes. That's why she fell for the club members' trap."
 	},
 	{
 		"type": "MSGSET",
@@ -2491,7 +2491,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0170.",
 		"TextJPN": "「吾輩の巫女が……、何ということ也やっ」",
 		"NamesENG": "Tamura",
-		"TextENG": "``My shrine maiden...... What a mess.``"
+		"TextENG": "``My priestess...... How could you!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2500,19 +2500,19 @@
 		"PreTextTags": "@vS25/12/NHAN_0740.",
 		"TextJPN": "「鷹野は失神してしまったのですよ！　もう力は貸せないのです！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Takano has fainted! You can't lend her anymore power!``"
+		"TextENG": "``Takano's passed out! You can't lend her your power anymore!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155246,
 		"TextJPN": "気を失うことを失神とも言うが、神を失うと書くとは面白い。",
-		"TextENG": "Fainting is also said to be one losing their mind, but it's amusing to write that God lost."
+		"TextENG": "It's amusing that the Japanese word for ``passing out`` is written as ``losing god``."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155247,
 		"TextJPN": "巫女に強力な力を与える田村も、鷹野が失神していては何の力も与えられない。",
-		"TextENG": "Tamura gave Takano a powerful force as her shrine maiden, but Takano cannot be given that power since she has fainted."
+		"TextENG": "Tamura may have been granting Takano powerful strength as her priestess, but she couldn't give her anything while she was unconscious."
 	},
 	{
 		"type": "MSGSET",
@@ -2521,7 +2521,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1050.",
 		"TextJPN": "「お生憎だったわね。こちとら、鷹野の相手は一度や二度じゃないのよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``How unfortunate. We took down your partner Takano more than twice.``"
+		"TextENG": "``It's unfortunate for you. This wasn't our first or second time dealing with Takano.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2530,7 +2530,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0750.",
 		"TextJPN": "「僕の巫女たちの力を侮るからなのですよ！　さぁ、田村媛命！　お前はしばらく静かにしているのですッ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``And that is because you underestimated the power of my shrine maiden! Well, Tamurahime no Mikoto! You've been quiet for some time now."
+		"TextENG": "``This happened because you underestimated the power of my priestess! Now, Tamurahime-no-Mikoto! You shall be silent for a while!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2539,7 +2539,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0760.",
 		"TextJPN": "「羽入フラーッシュ！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "...Hanyuu flash!!``"
+		"TextENG": "``Hanyuu Flash!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2548,25 +2548,25 @@
 		"PreTextTags": "@vS25/51/NTAM_0180.",
 		"TextJPN": "「んむわぁあああああぁああぁ……ッ！！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Muwaaaaaaaaaaa......!!!``"
+		"TextENG": "``Nmwaaaaaaaaahh......!!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155252,
 		"TextJPN": "羽入が両手でチョキを作り額に当てると、眩い光が迸り、田村媛命の姿を掻き消す。",
-		"TextENG": "Hanyuu, makes a pair of scissors with both hands and puts it to her forehead, causing a dazzling light to gush out, erasing the appearance of Tamurahime no Mikoto."
+		"TextENG": "Hanyuu made scissor symbols with both her hands and placed them near her horns, causing a bright light to rush forth and banish the sight of Tamurahime-no-Mikoto."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155253,
 		"TextJPN": "田村の像を消し去っただけで、田村本人を倒したわけではないそうだ。しかし、しばらくの間でも、あのムカつく顔を見ずに済むのはありがたい。",
-		"TextENG": "But erasing only the image of Tamura did not seem to defeat her. However, if even for a short while, we should be thankful she can't stare at us with her face."
+		"TextENG": "Apparently erasing the image of Tamura didn't mean defeating her, though. But I'm still grateful we won't have to see that annoying face for a while."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155254,
 		"TextJPN": "田村は、ぎゃわーッと、戦隊物の悪役のやられポーズをしながら掻き消える。",
-		"TextENG": "Tamura disappeared like a villian from a Power Rangers, so all we need to do is strike a pose."
+		"TextENG": "Tamura let out a scream and a pose like a defeated Sentai villain before disappearing."
 	},
 	{
 		"type": "MSGSET",
@@ -2575,7 +2575,7 @@
 		"PreTextTags": "@vS25/15/NKAS_0090.",
 		"TextJPN": "「さぁ、今の内に鷹野さんをふん縛ってしまいましょう」",
 		"NamesENG": "Kasai",
-		"TextENG": "``Now, let's tie up Takano-san before it's too late.``"
+		"TextENG": "``Now, let's get Takano-san all tied up while we can.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2584,19 +2584,19 @@
 		"PreTextTags": "@vS25/06/NSHI_0160.",
 		"TextJPN": "「とんでもない馬鹿力でしたからね！　鎖でも巻いておかなきゃです」",
 		"NamesENG": "Shion",
-		"TextENG": "``She used such outrageous great physical power! We should keep her wrapped in chains.``"
+		"TextENG": "``She was incredibly strong too! We'll need to bind her with chains.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155257,
 		"TextJPN": "気の毒に。もはや鷹野はか弱い女なのに、とんでもなく厳重に縛られている。",
-		"TextENG": "Regrettably. We shouldn't tie her up severely, Takano is a weak woman."
+		"TextENG": "I felt sorry for her. Takano was just a frail woman without Tamura's power, but her bonds were ridiculously secure."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155258,
 		"TextJPN": "これで、一件落着だった。",
-		"TextENG": "And that is, case closed."
+		"TextENG": "Well, that settles that."
 	},
 	{
 		"type": "MSGSET",
@@ -2605,7 +2605,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0590.",
 		"TextJPN": "「……我……、一件落着……、なのですか……」",
 		"NamesENG": "Une",
-		"TextENG": "``......Ca-Case closed...... is it really......``"
+		"TextENG": "``......Is, everything settled, for us......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2614,7 +2614,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0770.",
 		"TextJPN": "「そうなのですよ！　これでもう、意地悪な邪魔者の田村はいないのです！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Yes! Already, that malicious nuisance Tamura has disappeared!``"
+		"TextENG": "``It is! That mean old nuisance Tamura is gone now!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2632,7 +2632,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0520.",
 		"TextJPN": "「そりゃ本当かい、魅音ちゃん！　すごいね、ここには何でもあるね！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``It's the real thing, Mion-chan! This is amazing, you have everything here!``"
+		"TextENG": "``Is that true, Mion-chan?! Amazing! You have everything here!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2641,7 +2641,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1460.",
 		"TextJPN": "「まぁ、園崎家に用意できないものはありませんからねぇ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Well, there isn't anything that can't be provided by the Sonozaki family.``"
+		"TextENG": "``Well, there's nothing we Sonozakis can't get ahold of.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2650,7 +2650,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1070.",
 		"TextJPN": "「どうしたの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``What's wrong?``"
+		"TextENG": "``What's going on?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2659,19 +2659,19 @@
 		"PreTextTags": "@vS25/01/NKEI_1420.",
 		"TextJPN": "「ここに、強力な無線機があるらしい！　どうも、富竹さんが使えば外部と連絡が取れるみたいだ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``There seems a to be powerful radio here! Please, use it and try to contact the outside, Tomitake-san!``"
+		"TextENG": "``Apparently there's a powerful radio here! Sounds like Tomitake-san can use it to make contact with the outside!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155266,
 		"TextJPN": "園崎家自慢の改造無線機だ。",
-		"TextENG": "It's an illegally remodelled radio, something the Sonozaki family is proud of."
+		"TextENG": "It was the Sonozakis' illegally modified radio."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155267,
 		"TextJPN": "富竹によると、無線妨害の影響を受けずに外部に発信することが可能らしい。",
-		"TextENG": "According to Tomitake, it seems it's able to send a signal to the outside without being affect by the radio interference."
+		"TextENG": "According to Tomitake, it could send signals out without being affected by the radio interference."
 	},
 	{
 		"type": "MSGSET",
@@ -2680,25 +2680,25 @@
 		"PreTextTags": "@vS25/08/NTOM_0530.",
 		"TextJPN": "「東京にコンタクトが取れるかどうか、試してみるよ。采ちゃんが、ひょっとしたら救世主になるかもしれないんだからね！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``I'll try and see if I can get in contact with Tokyo. Une-chan, you may possibly become our savior!``"
+		"TextENG": "``I'll test it to see if I can contact Tokyo. Une-chan might be the savior we need, after all!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155269,
 		"TextJPN": "脳内寄生虫を兵器として使う為には、それに対する免疫が不可欠となる。",
-		"TextENG": "In order to use the brain parasite as a weapon, it is necessary to first create an immunity."
+		"TextENG": "In order to use the neuroparasite as a weapon, it was essential to have a vaccine for it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155270,
 		"TextJPN": "ウネの根の強さは、η１７３も含め、並大抵の同類の感染に強力な免疫となり得るのだ。",
-		"TextENG": "So, using the strengthened roots of Une, and η-173, creating the likes of a powerful immunity will be an easy matter."
+		"TextENG": "So the strength of Une's roots would prove a powerful vaccine against the infection of η173 and most other viruses like it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155271,
 		"TextJPN": "東京は絶対に関心を示すだろう。",
-		"TextENG": "Tokyo will certainly show interest."
+		"TextENG": "Tokyo would definitely be interested in that."
 	},
 	{
 		"type": "MSGSET",
@@ -2707,7 +2707,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0660.",
 		"TextJPN": "「富竹さんってすごいんですのね。何でも出来ちゃいますのね」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Tomitake-san, you're amazing. You can do anything.``"
+		"TextENG": "``You're incredible, Tomitake-san. You can do anything.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2716,7 +2716,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0540.",
 		"TextJPN": "「いやぁ、はっはっは…、ちょ、ちょっと趣味でかじったことがあってねぇ……！」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``No, ha ha ha... it's just a little hobby of mine......!``"
+		"TextENG": "``Well, hahaha... I-I just studied it a bit as a hobby......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -2725,7 +2725,7 @@
 		"PreTextTags": "@vS25/02/NREN_1300.",
 		"TextJPN": "「これで、私たちの大冒険はおしまい、……かな？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Now, has our great adventure come to an end...... I wonder?``"
+		"TextENG": "``That's the end of our grand adventure... ...I suppose?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2734,7 +2734,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1430.",
 		"TextJPN": "「だといいな。俺、もう疲れてヘトヘトだぜ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I hope so. I'm already exhausted and tired out.``"
+		"TextENG": "``I hope so. I'm already exhausted.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2743,7 +2743,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0600.",
 		"TextJPN": "「……もう、……出られる……？　この街を……？」",
 		"NamesENG": "Une",
-		"TextENG": "``......Already...... I can escape......? From this town......?``"
+		"TextENG": "``......I can, leave......? This town now......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -2752,7 +2752,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1080.",
 		"TextJPN": "「えぇ。出られるわ。まぁ、しばらくは虜にされるだろうけれどね。あんたの協力がないと連中は何も出来ないんだから、待遇はマシなものになるとは思うわよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``Yeah. Soon enough. Well, then you'll just have to be a captive for a short while. But remember, you have to cooperate with those people so don't talk back, I think you'll be treated a little better that way.``"
+		"TextENG": "``Yes, you can get out. Well, you'll probably be held prisoner for a while, though. But they can't do anything without your cooperation, so you'll be treated well, I think.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2761,7 +2761,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0780.",
 		"TextJPN": "「ウネ。地球へようこそなのです。この地で、一緒に仲良く花を咲かせましょうです。……もちろん、田村媛命とも仲良く」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Une. Welcome to Earth. In this land, we can become good friends and bloom together. ......Naturally, peacefully alongside Tamurahime no Mikoto, too.``"
+		"TextENG": "``Une. Welcome to Earth. Let's both bloom together here on this planet. ......With Tamurahime-no-Mikoto as well, of course.``"
 	},
 	{
 		"type": "MSGSET",
@@ -2770,6 +2770,6 @@
 		"PreTextTags": "@vS25/50/NUNE_0610.",
 		"TextJPN": "「……我、……嬉しいです……。感謝……、羽入……」",
 		"NamesENG": "Une",
-		"TextENG": "``......I'm...... I'm glad...... Thanks...... Hanyuu......``"
+		"TextENG": "``......I'm, so happy...... Thank you, Hanyuu......``"
 	}
 ]

--- a/kamikashimashi_7.json
+++ b/kamikashimashi_7.json
@@ -9,19 +9,19 @@
 		"type": "MSGSET",
 		"MessageID": 155280,
 		"TextJPN": "翌日、早朝。采たちの姿は、無線によって指示された学校の校庭にあった。",
-		"TextENG": "The next day, early in the morning, Une and the others went to the schoolyard, directed by radio."
+		"TextENG": "Early the next morning. Une and the others were in the school courtyard designated over the radio."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155281,
 		"TextJPN": "園崎組の強面たちが３０人ほども囲み、四方に睨みを利かせる。",
-		"TextENG": "About thirty strong men of the Sonozaki clan surrounded us, glaring at us."
+		"TextENG": "Roughly 30 of the Sonozaki Group's toughest men were surrounding them and glaring in all directions."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155282,
 		"TextJPN": "ヘリコプターが近付いてくる。采だけが救出されることになっている。",
-		"TextENG": "A helicopter is approaching. Only Une is supposed to be rescued."
+		"TextENG": "A helicopter was approaching. Une was the only one being extracted."
 	},
 	{
 		"type": "MSGSET",
@@ -30,7 +30,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1470.",
 		"TextJPN": "「達者でね！　これで助けてもらった恩が返せたよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Good luck! So I was able to return you that favor for when you helped us.``"
+		"TextENG": "``Take care! We've paid you back for saving us now!``"
 	},
 	{
 		"type": "MSGSET",
@@ -39,7 +39,7 @@
 		"PreTextTags": "@vS25/02/NREN_1310.",
 		"TextJPN": "「あなたの体の秘密で、みんなが救われるといいねっ」",
 		"NamesENG": "Rena",
-		"TextENG": "``I hope that secret inside your body will save everyone.``"
+		"TextENG": "``I hope you manage to save everyone with your body's secret.``"
 	},
 	{
 		"type": "MSGSET",
@@ -48,13 +48,13 @@
 		"PreTextTags": "@vS25/50/NUNE_0620.",
 		"TextJPN": "「……お世話に……、なりましたのです……」",
 		"NamesENG": "Une",
-		"TextENG": "``......Thank you...... for taking care of me......``"
+		"TextENG": "``......Thank you, for taking care of me......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155286,
 		"TextJPN": "采は気密服を着せられる。ヘリに乗ってきた自衛隊員たちも皆、気密服を着ていた。",
-		"TextENG": "Une is plated in airtight clothing. And, all of the Self-Defense Forces personnel riding on the helicopter are also wearing airtight clothing."
+		"TextENG": "Une was forced to wear airtight clothes. All the JSDF men riding in the helicopter were in them too."
 	},
 	{
 		"type": "MSGSET",
@@ -63,7 +63,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0670.",
 		"TextJPN": "「私たちだけ置いてけぼりなんて、ちょっと残念ですわね」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Leaving us behind, that's kinda disappointing.``"
+		"TextENG": "``It's a slight shame how we're being left behind, though.``"
 	},
 	{
 		"type": "MSGSET",
@@ -72,7 +72,7 @@
 		"PreTextTags": "@vS25/08/NTOM_0550.",
 		"TextJPN": "「申し訳ないね。η１７……、じゃない、この病気の正体がわかるまで、僕たちは外に出るわけにはいかないんだ」",
 		"NamesENG": "Tomitake",
-		"TextENG": "``I'm sorry. η-17...... until we can understand the true nature of this disease, nobody can leave.``"
+		"TextENG": "``I'm sorry. η17...... No, until we understand the cause of this illness, we can't be allowed to leave.``"
 	},
 	{
 		"type": "MSGSET",
@@ -81,7 +81,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1440.",
 		"TextJPN": "「采ちゃんは一件落着でも、俺たちはまだまだサバイバルが続きそうだぜ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Even if it's case closed for Une-chan, there's still a good chance we'll continue to survive.``"
+		"TextENG": "``So even though everything's settled with Une-chan, we're still stuck in survival mode for now.``"
 	},
 	{
 		"type": "MSGSET",
@@ -90,7 +90,7 @@
 		"PreTextTags": "@vS25/06/NSHI_0170.",
 		"TextJPN": "「ま、ここにいる限りは安全です。おかしな病気も、どんどん鎮まっていくと思いますし」",
 		"NamesENG": "Shion",
-		"TextENG": "``Well, we're safe as long as we're here. And as for this ridiculous disease, I'm sure it'll steadily subside.``"
+		"TextENG": "``Well, you'll be safe as long you stay here. I think this strange illness will settle down over time.``"
 	},
 	{
 		"type": "MSGSET",
@@ -99,37 +99,37 @@
 		"PreTextTags": "@vS25/15/NKAS_0100.",
 		"TextJPN": "「イカレた連中は頭数を減らしています。直に、街も静寂を取り戻すでしょう」",
 		"NamesENG": "Kasai",
-		"TextENG": "``Also, the number of those crazy people has been severely reduced. So not before long, the town will regain its silence.``"
+		"TextENG": "``There's fewer of those crazy people already. Peace will soon return to this city.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155292,
 		"TextJPN": "心を鬼に明け渡した暴徒たちは、飽きもせずに殺し合いを続けている。",
-		"TextENG": "The mobs who surrendered their hearts to the demon have continued to kill each other restlessly."
+		"TextENG": "The rioters who handed their hearts over to demons continued to kill each other without getting tired of it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155293,
 		"TextJPN": "しかし、やがては葛西の言う通り、互いを殺し尽くして静かになるだろう。",
-		"TextENG": "However, not before long, everything Kasai said will soon come to pass, as they will exhaustively kill each other allowing the town to become quiet very soon."
+		"TextENG": "But like Kasai said, eventually they'd kill themselves off and things would quiet down."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155294,
 		"TextJPN": "富竹が無線で聞いたところでは、鹿骨市への援助の準備が整い、食料や生活必需品の空輸なども始まるという。",
-		"TextENG": "Tomitake heard over the radio that the aid to Shishibone City was being prepared and that the airlift of food and daily necessities would begin."
+		"TextENG": "From what Tomitake heard over the radio, they were already preparing to send aid to Shishibone City, and food, water, and other necessities would be transported by air."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155295,
 		"TextJPN": "……この途方もない規模の大騒ぎは、簡単には収束しないだろう。",
-		"TextENG": "......However, this uproar was on an extraordinary scale, it will not easily return to normal."
+		"TextENG": "......Such an incredibly large uproar couldn't be wrapped up that easily."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155296,
 		"TextJPN": "でも、希望の光は灯った。采は、その鍵だ。",
-		"TextENG": "But, a light of hope is shining. Une is the key."
+		"TextENG": "But we had our light of hope.Une was the key."
 	},
 	{
 		"type": "MSGSET",
@@ -138,7 +138,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0630.",
 		"TextJPN": "「……ありがとう、……なのです……」",
 		"NamesENG": "Une",
-		"TextENG": "``......Thank you......``"
+		"TextENG": "``......Thank, you......``"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0790.",
 		"TextJPN": "「しっかり頑張るのですよ。あなたをこの星に迎えられて嬉しいのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I'll firmly do my best. I'm glad that I met you on this star.``"
+		"TextENG": "``Do your best out there. I'm happy to welcome you to this planet.``"
 	},
 	{
 		"type": "MSGSET",
@@ -156,61 +156,61 @@
 		"PreTextTags": "@vS25/50/NUNE_0640.",
 		"TextJPN": "「……我も、……嬉しいのです。……チョー嬉しいのです。くっふふふふふふふふふ……」",
 		"NamesENG": "Une",
-		"TextENG": "``......As for me...... I'm also glad. ......Super glad. Hee hee hee hee hee hee hee hee hee hee......``"
+		"TextENG": "``......I'm, happy too. ......I'm super happy. Kfufufufufufufufufu......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155300,
 		"TextJPN": "飛び去るヘリから、采が手を振る。",
-		"TextENG": "From the helicopter flying away, Une waves her hand."
+		"TextENG": "Une waved her hand from the helicopter flying away."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155301,
 		"TextJPN": "部活メンバーたちは無邪気に手を振っている。",
-		"TextENG": "The club members innocently wave their hands, too."
+		"TextENG": "The club members all waved innocently back at her."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155302,
 		"TextJPN": "梨花だけは、ぼんやりと見送っていた。",
-		"TextENG": "Rika was the only one who looked away in a daze."
+		"TextENG": "Only Rika absent-mindedly watched her go."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155303,
 		"TextJPN": "別れ際の采の笑みに、自分でも説明の出来ぬ何かを噛み締めているのだった……。",
-		"TextENG": "And on the smile Une parted with, she deeply thinks to herself trying to come up with an explanation for it......"
+		"TextENG": "She was pondering something she couldn't explain in Une's smile as she left......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155304,
 		"TextJPN": "その後、「東京」の施設である、国立感染症研究所に移送された。",
-		"TextENG": "And then, she was transferred to the National Institute of Infectious Diseases, a facility of ``Tokyo``."
+		"TextENG": "Afterward, she was transferred to Tokyo's facility, the National Institute of Infectious Diseases."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155305,
 		"TextJPN": "すでに数十万人規模の大災害となってしまった現在、雛見沢症候群は隠蔽できる段階にはない。",
-		"TextENG": "Currently, the scale of this catastrophe has already reached hundreds of thousands of people, so we are not at the stage where the Hinamizawa Syndrome can yet be suppressed."
+		"TextENG": "With the disaster already reaching several hundred thousand people, it was no longer possible to cover up the existence of Hinamizawa Syndrome."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155306,
 		"TextJPN": "人間を凶暴化させる未知のウィルスの存在に、世間は大騒ぎになっていた。",
-		"TextENG": "The presence of this unknown virus allowed humans to become ferocious, creating an uproar in the world."
+		"TextENG": "The world was in an uproar over this mysterious virus, capable of making humans randomly go violent."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155307,
 		"TextJPN": "無論、脳内寄生虫を理解する主要各国の秘密研究機関は、現在進行形の脳内寄生虫バイオハザードとして注目。大勢の研究員を「協力」に寄越していた。もうここに至っては、日本だけの問題で済む保証はないのだから。",
-		"TextENG": "Of course, the secret research organizations of each major country understand this brain parasite, as the ongoing brain parasite biohazard has attracted their attention. And so, a large number of researchers have come together under ``cooperation``. As for one thing, there isn't a guarantee this is a problem only Japan will face."
+		"TextENG": "Of course, the secret research institutions of the major nations that knew about neuroparasites were paying attention to the progress of the current neuroparasite biohazard. They dispatched many researchers to ``help``. Because there was no guarantee it would remain solely Japan's problem once it reached that point."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155308,
 		"TextJPN": "采の脳脊髄液が採取され、世界各国の最高機密研究所へ送られた……。",
-		"TextENG": "Une's cerebrospinal fluid is collected, and sent to a top top-secret research institute of all the countries of the world......"
+		"TextENG": "Samples of Une's cerebrospinal fluid were taken and transported to the most classified research labs of each nation......"
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0650.",
 		"TextJPN": "「……我の種が、……この青い花壇の隅々にまで行き届いたのです。……くっふふふふ、……嬉しい。……チョー嬉しいのです。くふふふふふふふふっふっふっふ……」",
 		"NamesENG": "Une",
-		"TextENG": "``......My seeds...... will be spread to every corner of this blue flower bed. ......Hee hee hee hee hee...... I'm glad. ......Very glad. Hee hee hee hee hee hee hee hee hee hee hee hee......``"
+		"TextENG": "``......My seeds... have reached every corner of this blue flower bed. ......Kfufufufu, I'm happy. ......I'm super happy. Kfufufufufufufufufufufufu......``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,7 +228,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0190.",
 		"TextJPN": "「愚かなる角の民の長よ……。あの恐ろしき不浄なる民を世界に解き放つことの罪深さに慄く也や」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Now, because of you, the foolish leader of the nation of horns...... An impurity has been let loose on the people of this world, your sin.``"
+		"TextENG": "``Foolish leader of the horned people...... Tremble in fear at your sin of unleashing that terrifyingly corrupt people upon our world.``"
 	},
 	{
 		"type": "MSGSET",
@@ -237,7 +237,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0800.",
 		"TextJPN": "「もう手遅れなのですよ。鷹野と田村の悪い目論見は、もうおしまいなのです。あうあうあう！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``It's not too late, we are still attempting to create a cure. And this was all caused by you and Takano's plan, Tamura, understand that. Au au au!``"
+		"TextENG": "``It's already too late. Your and Takano's evil plot is finished now. Auauau!``"
 	},
 	{
 		"type": "MSGSET",
@@ -246,7 +246,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1090.",
 		"TextJPN": "「…………………。……田村媛命。言いたいことがあるなら言ったら？　あんたは一体、何がしたかったの。鷹野はあんたの巫女だった。鷹野は、あんたの命令に従って何かをしようとしていた。それは何なの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``..................... ......Tamurahime no Mikoto. Why don't you say what you want to say? What on earth did you want to do? Takano was your shrine maiden. And Takano was attempting to do something under your instructions. What was it?``"
+		"TextENG": "``..................... ......Tamurahime-no-Mikoto. If you have something you want to say, why not say it? What was it you were trying to achieve? Takano was your priestess. So Takano was following your orders and trying to accomplish some specific task. What was it?``"
 	},
 	{
 		"type": "MSGSET",
@@ -255,7 +255,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0810.",
 		"TextJPN": "「聞くまでもないことなのです。ウネに意地悪して、その上、雛見沢症候群を撒き散らして、世界を大混乱にさせることだったのですよ、あう！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I don't want to hear it. She was unkind to Une, and furthermore, was attempting to spread the Hinamizawa Syndrome, which would have caused chaos in the world, au!``"
+		"TextENG": "``That's not even worth asking. She was bullying Une and trying to spread Hinamizawa Syndrome everywhere to sow chaos! Au!``"
 	},
 	{
 		"type": "MSGSET",
@@ -264,7 +264,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1100.",
 		"TextJPN": "「そこが意味わかんないのよ。……羽入たち雛見沢症候群は、不浄の民なんでしょ？　それをどうして田村が、鷹野にばら撒かせるわけよ？」",
 		"NamesENG": "Rika",
-		"TextENG": "``I don't understand the significance of this. ......Hanyuu, you and your people are the Hinamizawa Syndrome, and they are impurities, right? So why would Tamura have any reason to let Takano spread it?``"
+		"TextENG": "``That doesn't make sense, though. ......Hanyuu, the Syndrome is a tainted people to her, right? So why would Tamura have Takano spread them elsewhere?``"
 	},
 	{
 		"type": "MSGSET",
@@ -282,7 +282,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1110.",
 		"TextJPN": "「富竹が言うには、鷹野は人類を救う為に悪魔を倒すと言っていた。そして、η１７３をばら撒こうとしてた」",
 		"NamesENG": "Rika",
-		"TextENG": "``Tomitake said, that Takano was going to defeat this devil in order to save humanity. And, spread η-173 in the process.``"
+		"TextENG": "``Tomitake said that Takano was going to defeat a 'devil' and in doing so, save humanity. Then she started spreading η173.``"
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1120.",
 		"TextJPN": "「……人類を救おうとしてみたり、滅ぼそうとしてみたり。矛盾してはいるけど、どうせイカレた鷹野の妄想に違いないからと気にはしなかったけど……。それが全て、田村の命令だとすると、意味がないわけがない」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Was she trying to save humanity, or destroy it? It isn't consistent, and I don't know, but maybe Takano wasn't delusional or crazy at all...... Especially since she was ordered by Tamura, so there has to be some meaning to it.``"
+		"TextENG": "``......She's both trying to save humanity, and trying to destroy it. These goals contradict each other, but I didn't pay it any mind because I was sure it was just one of Takano's crazy delusions...... but if it was all as Tamura ordered, then none of it was meaningless.``"
 	},
 	{
 		"type": "MSGSET",
@@ -300,7 +300,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0200.",
 		"TextJPN": "「愚かなる角の民の巫女如きに、それも人の子風情に話したところでわからぬ也や。……あぁ、愚かしいことを」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Priestess of the foolish Horned People will not understand. Oh, what a disgrace.``"
+		"TextENG": "``A mere child of man, let alone the priestess of the foolish horned people wouldn't understand, even if I were to tell you. ......Ahh, how foolish you are.``"
 	},
 	{
 		"type": "MSGSET",
@@ -309,7 +309,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1130.",
 		"TextJPN": "「私を見くびらないでちょうだい。こいつと違って、私の頭の中身はシュークリームじゃないのよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``Don't underestimate me. Unlike she, I don't have a cream puff inside my head.``"
+		"TextENG": "``Please don't look down on me. Unlike her, my head isn't filled with cream puffs.``"
 	},
 	{
 		"type": "MSGSET",
@@ -318,7 +318,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0830.",
 		"TextJPN": "「梨花、僕には何のことかさっぱりわからないのですよ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Rika, I have no idea what you're talking about.``"
+		"TextENG": "``Rika, I don't understand what you're getting at at all.``"
 	},
 	{
 		"type": "MSGSET",
@@ -327,25 +327,25 @@
 		"PreTextTags": "@vS25/05/NRIK_1140.",
 		"TextJPN": "「角の民のことを毛嫌いする田村が、なぜ角の民を拡散させようとしたのか。…………まさか……」",
 		"NamesENG": "Rika",
-		"TextENG": "``Tamura, I know you feel antipathy towards the nation of horns, but why were you trying to scatter them? ............No way......``"
+		"TextENG": "``Tamura loathes the horned people, so why would she try to spread them outside of Hinamizawa? .........It can't be......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155322,
 		"TextJPN": "角の民とウネの民の根の強さは互角。",
-		"TextENG": "The strength of the roots of the nation of horns and the people of Une are equal."
+		"TextENG": "The horned people and Une's people had equally strong roots."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155323,
 		"TextJPN": "そして、ウネを悪魔呼ばわりする田村。",
-		"TextENG": "Also, Tamura calls Une this devil."
+		"TextENG": "On top of that, Tamura called Une a devil."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155324,
 		"TextJPN": "その行為を、鷹野は人類を救う為と称した……。",
-		"TextENG": "So Takano performed such an act in order to save humanity......"
+		"TextENG": "And she told Takano that she would save humanity......"
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1150.",
 		"TextJPN": "「……あんたは、ウネを拡散させない為に、……鷹野にη１７３をばら撒かせた……？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......You, in order to stop Une scattering...... told Takano to spread η-173......?``"
+		"TextENG": "``......You had Takano spread η173 ......so Une couldn't spread herself......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -363,7 +363,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1160.",
 		"TextJPN": "「そうよね、だって、ウネに感染すればη１７３に感染しないように、逆も然り。η１７３に感染すればウネには感染しないっ」",
 		"NamesENG": "Rika",
-		"TextENG": "``Yes, I mean, we wanted to infect everyone with Une so they wouldn't be infected with η-173, but that was the opposite of you. You wanted to infect people with η-173 so they wouldn't be infected with Une.``"
+		"TextENG": "``Yes, after all, just as those infected by Une couldn't be infected by η173, the reverse was also true. If you infected them with η173, they couldn't be infected by Une!``"
 	},
 	{
 		"type": "MSGSET",
@@ -372,7 +372,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0840.",
 		"TextJPN": "「でも、僕たちに感染すると、心の弱い者は大変なことになってしまいますのですよ。でも、ウネならその心配はないのです」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``But, if she infected everyone with me, they would become weak of heart, and that would be a serious matter. But, we don't have to worry about Une.``"
+		"TextENG": "``But if she infects them with us, then those with weak minds will be in big trouble. There's no worry about that with Une, though.``"
 	},
 	{
 		"type": "MSGSET",
@@ -381,7 +381,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1170.",
 		"TextJPN": "「どうしてその心配がないってわかるのよ？　あんたがウネと交信して、勝手にそうだと確信しただけでしょ？　つまり、ウネの言い分を鵜呑みにしただけじゃないの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Why do you say we don't have to worry? You communicated with Une, so are you convinced she won't do anything without your permission? In other words, did you actually swallow Une's story?``"
+		"TextENG": "``How do you know that? You've just convinced yourself that's the case after communicating with Une, right? In other words, you've just accepted Une's claims without question, haven't you?``"
 	},
 	{
 		"type": "MSGSET",
@@ -399,7 +399,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0210.",
 		"TextJPN": "「なるほど。……長の愚かさまでは巫女に感染せなんだと見えるもの也や」",
 		"NamesENG": "Tamura",
-		"TextENG": "``I see. ......It seems even the infected shrine maiden can see the stupidity of her leader.``"
+		"TextENG": "``I see. ......It appears the leader's foolishness has not infected her priestess.``"
 	},
 	{
 		"type": "MSGSET",
@@ -408,7 +408,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1180.",
 		"TextJPN": "「つまり、あんたは背を腹には変えられない決断をしたわけだわ。……あんたの土地の一部、つまり鹿骨市を丸ごと不浄の民に汚染されても、その方がまだマシだという判断をしたわけだわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``You've made a decision that you can't turn your back on. You'd rather have a piece of your land, the entire Shishibone City, contaminated by the Impure People.``"
+		"TextENG": "``That means that you made a hard choice. ......You decided that handing over a portion of your land - the entirety of Shishibone City - to the tainted people was at least preferable to that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -417,7 +417,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1190.",
 		"TextJPN": "「そうよね…？！　……じゃあつまり……、あんたは、あいつの、……ウネのことを知ってるのね……？」",
 		"NamesENG": "Rika",
-		"TextENG": "``Isn't that right...?! So you and Une known each other......?``"
+		"TextENG": "``Isn't that right...?! ......Which means..... that you knew... about Une, didn't you......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -426,7 +426,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0220.",
 		"TextJPN": "「……あれは母なる大地に大いなる災いを呼ぶ、呪われし種の一族也や……」",
 		"NamesENG": "Tamura",
-		"TextENG": "``......You have caused a great calamity to mother earth, you and your clan of cursed seeds......``"
+		"TextENG": "``......Hers is an accursed race which brought forth great catastrophe upon her mother land......``"
 	},
 	{
 		"type": "MSGSET",
@@ -435,7 +435,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0660.",
 		"TextJPN": "「くっふふふふふふふふふ…ッ！！　チョー愉快っ、……なのですよ、くっふふふふふふふふ！」",
 		"NamesENG": "Une",
-		"TextENG": "``Hee hee hee hee hee hee hee hee hee hee...!! I'm very happy...... hee hee hee hee hee hee hee hee hee!``"
+		"TextENG": "``Kfufufufufufufufufu...!! This is, super fun! Kfufufufufufufufu!``"
 	},
 	{
 		"type": "MSGSET",
@@ -453,7 +453,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0230.",
 		"TextJPN": "「愚かなりし、羽入よ。そやつの本性を知り、己が罪に恐れおののき奉れっ！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``You are a fool, Hanyuu. Do you not know the true nature of this person, fear she brings, she is the cause of such sins!``"
+		"TextENG": "``Foolish Hanyuu. Know her true nature, and tremble with terror at your sin!``"
 	},
 	{
 		"type": "MSGSET",
@@ -462,7 +462,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0670.",
 		"TextJPN": "「田村媛命……。汝にはチョーやられましたのですよ。我、目覚めて開花しようとしたら、……すでに花壇は、そこのマヌケ面の花でいっぱいだったとは」",
 		"NamesENG": "Une",
-		"TextENG": "``Tamurahime no Mikoto...... I'm sorry you had to go through that. When I woke up and tried to bloom, the flowerbed was already filled with the flowers of that idiot face.``"
+		"TextENG": "``Tamurahime-no-Mikoto...... You totally pulled a fast one on me. The moment I awoke and tried to bloom...... the flower bed around me was already filled with that fool's flowers.``"
 	},
 	{
 		"type": "MSGSET",
@@ -471,7 +471,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1200.",
 		"TextJPN": "「そうでしょうね。そこのシュークリーム頭は、何の役にも立たない雑草だけど、あんたでも倒せないくらいに、その根は強い」",
 		"NamesENG": "Rika",
-		"TextENG": "``That may be so. Even cream puff head over here is a useless weed, not even strong enough to defeat you, whose roots are strong.``"
+		"TextENG": "``I'm sure she did get you good. This cream puff for brains is a useless weed, but her roots are strong enough that you couldn't beat them.``"
 	},
 	{
 		"type": "MSGSET",
@@ -480,7 +480,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1210.",
 		"TextJPN": "「……あんたはさっそく感染を爆発させようとしたけれど、鷹野が事前にη１７３をばら撒いていたので、それが出来なかったわけだわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Although, you were trying to erupt your infection without delay, so if Takano were to spread η-173 in advance, you would have never been able to.``"
+		"TextENG": "``......You tried to make your infection explode through the population, but since Takano had already spread η173, you couldn't do that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -489,31 +489,31 @@
 		"PreTextTags": "@vS25/50/NUNE_0680.",
 		"TextJPN": "「我、チョー途方に暮れていたのです。そこへノコノコと、我の話を信じてくれそうな、マヌケな民の長が現れたのです。……くっふふふふふふふふ……！！」",
 		"NamesENG": "Une",
-		"TextENG": "``Then, I would have really lost. But blindly, I needed someone to believe my story, and so the leader of a foolish people appeared. ......Hee hee hee hee hee hee hee hee hee......!!``"
+		"TextENG": "``I was at a total loss. But then a dumbass who believed my story just happened to show up. ......Kfufufufufufufufu......!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155341,
 		"TextJPN": "……クリームさえ詰まっていない、空っぽのシュークリーム頭でも、そろそろ自分が騙されたことに気付いたらしい。",
-		"TextENG": "......Even the empty cream puff head seemed to have realized that it had been tricked by now."
+		"TextENG": "......Even though her brain was an empty cream puff, lacking even in cream, she finally realized that she'd been tricked."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155342,
 		"TextJPN": "羽入はウネとの交信でお互いの全てを分かり合えたつもりでいた。",
-		"TextENG": "Hanyu thought that she and Une had understood everything about each other through their communication."
+		"TextENG": "Hanyuu had believed that they understood everything about each other after her communication with Une."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155343,
 		"TextJPN": "羽入は単純だから、己の全てを明け透けに伝えただろうが、ウネはそうではなかった。",
-		"TextENG": "Hanyu was simple and told her everything about herself, but Une didn't."
+		"TextENG": "Hanyuu had openly shared everything about herself because she was so simple, but that wasn't the case for Une."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155344,
 		"TextJPN": "……彼女は、自分の本性と恐るべき企みだけを、巧みに隠し、羽入を騙したのだ。",
-		"TextENG": "She had deceived Hanyuu by cleverly hiding only her true nature and her horrible scheme."
+		"TextENG": "......She cleverly hid her true nature and her terrifying plot to deceive Hanyuu."
 	},
 	{
 		"type": "MSGSET",
@@ -522,7 +522,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1220.",
 		"TextJPN": "「ということは、……田村媛命。あんたは見破ってたのね」",
 		"NamesENG": "Rika",
-		"TextENG": "``That is...... Tamurahime no Mikoto. You saw through her thoughts.``"
+		"TextENG": "``Which means...... Tamurahime-no-Mikoto. You saw through her, didn't you?``"
 	},
 	{
 		"type": "MSGSET",
@@ -531,19 +531,19 @@
 		"PreTextTags": "@vS25/51/NTAM_0240.",
 		"TextJPN": "「その呪われた民の長の企みなど、我が眼力を騙せはせぬもの也と知り給えっ」",
 		"NamesENG": "Tamura",
-		"TextENG": "``The leader of such a cursed people scheming such a plot, I'd be a fool not to foresee such a thing.``"
+		"TextENG": "``Know that the plot from the leader of such accursed people could never deceive my insight.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155347,
 		"TextJPN": "田村はウネの狙いを知っていた。",
-		"TextENG": "Tamura knew the aim of Une."
+		"TextENG": "Tamura had known what Une was after."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155348,
 		"TextJPN": "ウネの目的は、……この青い星の巨大な花壇に、際限なく自分たちを繁殖させることだ。",
-		"TextENG": "The objective of Une...... to find a huge flower bed on this blue star, and breed there endlessly."
+		"TextENG": "Une's goal... was to propagate herself throughout every corner of this blue planet's huge flower bed."
 	},
 	{
 		"type": "MSGSET",
@@ -552,25 +552,25 @@
 		"PreTextTags": "@vS25/05/NRIK_1230.",
 		"TextJPN": "「それじゃあ、あんたたちが滅びちゃうもんね。だから、戦わなければならない。……かつて、羽入たちと戦ったようにね」",
 		"NamesENG": "Rika",
-		"TextENG": "``Well then, it seems we're going to perish. Therefore, we must fight. ......Once again, we must go to battle, Hanyuu.``"
+		"TextENG": "``If she did that, then you all would perish, huh? So you had to fight. ......Just like you once fought Hanyuu's people.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155350,
 		"TextJPN": "羽入は、かつて田村に嫌がらせを受けたと言うが、それは恐らく、嫌がらせではなく、田村にとってみれば、自分たちを守る為の戦いだったのだろう。",
-		"TextENG": "Hanyuu said that Tamura once harassed her, but it was probably not harassment, but a fight to protect themselves from Tamura's point of view."
+		"TextENG": "Hanyuu said Tamura was once mean to her, but that probably wasn't her just being mean. From Tamura's perspective, she was likely fighting to protect herself."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155351,
 		"TextJPN": "幸いにも、羽入の民は雛見沢以外には住めないことがわかり、互いは離縁することで千年の平和が続いた。",
-		"TextENG": "Fortunately, the people of Hanyuu understand that they cannot live anywhere else other than Hinamizawa, so another thousand years of peace should follow this divorce."
+		"TextENG": "Fortunately, they learned Hanyuu's people couldn't live outside of Hinamizawa, so they managed to maintain a thousand years of peace by avoiding each other."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155352,
 		"TextJPN": "しかし、もし、狭い土地の縛りを受けない新しい民が訪れたなら……。",
-		"TextENG": "However, if these new people do not become binded in this narrow land they have visited, then......"
+		"TextENG": "However, if a new people that weren't bound to such a small area came here......"
 	},
 	{
 		"type": "MSGSET",
@@ -579,7 +579,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1240.",
 		"TextJPN": "「なるほど、あんたにとっては、確かに悪魔というわけだわ。……そして、それを食い止める為に鷹野を使った」",
 		"NamesENG": "Rika",
-		"TextENG": "``I see, for you, she surely is this devil indeed. Thus, you employed Takano in order to stave her off.``"
+		"TextENG": "``I see. To you, she certainly would be a devil. ......And so you used Takano to stop her.``"
 	},
 	{
 		"type": "MSGSET",
@@ -588,7 +588,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1250.",
 		"TextJPN": "「……でも、人類を滅ぼす悪魔は言い過ぎね。あんたを滅ぼす悪魔かもしれないけど、人間たちは自分の頭に誰が寄生してるかなんて、知りもしないし関心もないわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......But demon to destroy mankind is an exaggeration. It may be the devil that destroys you, but people don't know or care who's living in their heads.``"
+		"TextENG": "``......But calling her a devil that'll destroy humanity is going too far. She might be a devil that would destroy you, but the humans don't know or care which parasite is living in their heads.``"
 	},
 	{
 		"type": "MSGSET",
@@ -597,7 +597,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0250.",
 		"TextJPN": "「……やはり角の民の巫女ではその程度の理解までが限界也や。愚か也」",
 		"NamesENG": "Tamura",
-		"TextENG": "``......After all, you have a limit to understanding as a shrine maiden of the nation of horns. Foolishness.``"
+		"TextENG": "``......I suppose that's the limit of the understanding of the horned people's priestess. Foolish.``"
 	},
 	{
 		"type": "MSGSET",
@@ -606,7 +606,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0690.",
 		"TextJPN": "「くっふふふふふふふふ……。もうチョー手遅れなのですよ、愚かなる民たちよ。この星は我らがチョー食い尽くすのです」",
 		"NamesENG": "Une",
-		"TextENG": "``Hee hee hee hee hee hee hee hee hee...... It is already too late, foolish people. I will devour this star.``"
+		"TextENG": "``Kfufufufufufufufu...... It's super too late now, you idiots! We're totally consuming this whole planet!``"
 	},
 	{
 		"type": "MSGSET",
@@ -615,181 +615,181 @@
 		"PreTextTags": "@vS25/50/NUNE_0700.",
 		"TextJPN": "「さぁ、目覚めなさい、我が子らよ、我が種子よ…！！　その根を世界中に下ろし、咲き誇り、花開きて種を飛ばすがよい……！！」",
 		"NamesENG": "Une",
-		"TextENG": "``Now, wake up, my children, my seeds...!! Lower your roots across this world, and bloom in full, from seeds to flowers......!!``"
+		"TextENG": "``Now, awaken, my children! My seeds...!! Sink your roots into this world and bloom, bloom and spread yourselves wide......!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155358,
 		"TextJPN": "ウネが羽ばたくように両手を広げ、……全世界に散ったウネの子らにそれを命ずる。",
-		"TextENG": "Une unfolds both her hands and flaps her wings...... ordering her children which she had scattered across the world."
+		"TextENG": "Une spread her arms like she was spreading a pair of wings...... and issued her orders to all of her children scattered throughout the whole world."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155359,
 		"TextJPN": "人の子の防疫概念如きで、ウネの種子を隔離することなど出来ない。",
-		"TextENG": "The quarantine concept of the human child is not enough to quarantine the seeds of Une."
+		"TextENG": "The children of man couldn't quarantine Une's seeds with their mere concept of disease prevention."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155360,
 		"TextJPN": "世界中の研究所の人間たちが、すでにウネに感染しているのだ……。",
-		"TextENG": "As all the human begins in every research institute across the world have already became infected with Une......"
+		"TextENG": "The humans researching her across the world were already infected......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155361,
 		"TextJPN": "アメリカ、ジョージア州、アトランタ。",
-		"TextENG": "America, Georgia, Atlanta."
+		"TextENG": "America, Georgia State, Atlanta."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155362,
 		"TextJPN": "アメリカ疾病予防管理センターは、ウィルス感染症から人類を守る最前線の砦であり、同時に、世界最高の権威でもある。",
-		"TextENG": "The American Center for Disease Control and Prevention has now become the fortress of the forefront in order to protect the human race from this virus infection, and at the same time, the highest authority in the world."
+		"TextENG": "America's Centers for Disease Control and Prevention was the fortress on the frontlines protecting humanity from viral infections, and also the highest world authority on the subject."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155363,
 		"TextJPN": "その機密区画にある、脳内寄生虫研究部門にて、ウネの子らはウネウィルスと呼ばれて研究が進められていた。",
-		"TextENG": "But now, in a secret division, in the brain parasite research department, research into the children of Une is underway, which is now referred to as the Une virus."
+		"TextENG": "Yet in a secret ward, the neuroparasite research division, they were researching her children."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155364,
 		"TextJPN": "細心の注意と設備で研究が進められていたはずだったが、……神の子らの拡散を、人の子の術で止められるわけもない……。",
-		"TextENG": "It is being researched and advanced under scrupulous attention and facilities...... but even the diffusion of the children of God cannot be stopped by the techniques of the children of man......"
+		"TextENG": "They were researching it with the greatest precautions and most modern equipment... but the techniques of mere mortals were unable to stop the spread of the children of a god......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155365,
 		"TextJPN": "主任研究員が倒れたのは、休日のバスの中だった。",
-		"TextENG": "The chief scientist collapses in a bus on his day off."
+		"TextENG": "The head researcher first collapsed on a bus on his day off."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155366,
 		"TextJPN": "彼を助けようと駆け寄った人々も次々に倒れ、運転手も意識を失った。",
-		"TextENG": "Then, the people who ran up to help him fell down in sequence, even the driver lost consciousness."
+		"TextENG": "People rushed to his aid one after another and collapsed as well until the driver also lost consciousness."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155367,
 		"TextJPN": "バスが停車中であったのは幸いだったろう。……しかし、不幸中の幸いとは呼べまい。",
-		"TextENG": "It was probably fortunate that the bus was stopped. ......However, I would not call it a blessing in disguise."
+		"TextENG": "Fortunately the bus was already stopped. ......Yet that wasn't a silver lining."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155368,
 		"TextJPN": "もう、ウネの子らの拡散を止める術は、人類はおろか、人ならざる者たちにもないのだから。",
-		"TextENG": "As already, their plans to stop the children of Une have failed, humans are foolish, they do not understand the non-humans."
+		"TextENG": "Because neither humanity or even inhuman beings possessed the means to stop the spread of Une's children."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155369,
 		"TextJPN": "同じことは、ロシア連邦、スヴェルドロフスク州、エカテリンブルクの生物兵器秘密研究所でも起こった。",
-		"TextENG": "The same thing happened in the Russian Federation, Sverdlovsk Oblast, in the biological weapons secret research institute of Yekaterinburg."
+		"TextENG": "The same thing happened in Sverdlovsk Oblast, within the Russian Federation, right in Yekaterinburg's secret biological weapon research center."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155370,
 		"TextJPN": "無論、日本国、東京都新宿区の国立感染症研究所でも、イギリスでもフランスでも中国でも韓国でも、世界各国の研究所周辺で起こった。",
-		"TextENG": "Next in Japan, at the National Institute of Infectious Diseases in Tokyo, Shinjuku, and England, France, China, Korea, until it hit every single research institute in every country across the world."
+		"TextENG": "Of course it also happened in Japan's National Institute of Infectious Diseases within Shinjuku, Tokyo, as well as in other research centers in England, France, China, Korea, and other nations too."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155371,
 		"TextJPN": "そして、愚かにも過剰に発達させた人類の様々な交通機関を経て……、地球全土に広がっていく……。",
-		"TextENG": "Then, through the various means of transportation humanity stupidly developed excessively...... it spread throughout the world......"
+		"TextENG": "And then they traveled through the transportation technology that humanity had foolishly over-developed...... spreading to all lands throughout the world......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155372,
 		"TextJPN": "しかし、人類にはそれに気付く術さえなかった。",
-		"TextENG": "However, humanity never had means to notice this."
+		"TextENG": "However, humanity lacked the means to notice it at all."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155373,
 		"TextJPN": "最初の感染拡大から約２週間後。ウネの子らが世界の隅々まで行き渡った頃、最初の症状が出た。",
-		"TextENG": "Approximately 2 weeks after the initial infection spread. The children of Une reached every corner of the globe, and then, the first symptoms began to appear."
+		"TextENG": "Roughly two weeks after the initial spread of infection, when Une's children had spread throughout every corner of the globe, the first symptoms developed."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155374,
 		"TextJPN": "感染者たち（この時点においては、感染者と人類は、もはや同義語とさえ言えるのだが……）は、そこで初めて、未知の何かに感染していたことを知る。",
-		"TextENG": "Infected people (At this point in time, for infected people and humanity, we can no longer say if they are even not synonymous anymore......) for the first time, know they have been infected with something unknown."
+		"TextENG": "The infected (Though, at this point ``the infected`` and ``all humanity`` were synonymous......) then learned for the very first time that they were all infected with something unknown to them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155375,
 		"TextJPN": "人々は、……猛烈な睡魔に襲われ、その場に崩れるように次々と眠っていった。",
-		"TextENG": "The people...... are attacked by a ferocious sleepiness, and sleep in sequence, collapsing on the spot."
+		"TextENG": "People were afflicted with intense drowsiness... and one after another they crumpled and fell asleep on the spot."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155376,
 		"TextJPN": "それは、苗床。",
-		"TextENG": "They have now become a seedbed."
+		"TextENG": "They had become a seed bed."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155377,
 		"TextJPN": "やがては宿主の養分を全て吸い尽くし、その体を内より破って、再び種子を飛ばし、地球人類の全てを食い尽くす。",
-		"TextENG": "Sucking all kinds of nourishment out of the host not before long, and then beating themselves out of the inner body, they transfer into a seed once again, devouring the earth and all of humanity."
+		"TextENG": "Once they finished consuming all of the nutrients of their host, they broke out through the host's body, spread more seeds, and consumed all of humanity."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155378,
 		"TextJPN": "ウネたちに人類と共生しようなどという意思はなかったのだ。",
-		"TextENG": "Symbiosis with humanity was never Une's intention."
+		"TextENG": "Because Une's people had no intention of coexisting with humanity at all."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155379,
 		"TextJPN": "花壇の全てを吸い尽くし、そして次なる花壇を求めて再び宇宙に旅立っていく、呪われた種子の民……。",
-		"TextENG": "She wanted to exhaustively drain every single flower bed, then leave and again traverse the universe in search of the next flower bed, she is a nation of cursed seeds......"
+		"TextENG": "Once they had consumed their flower bed, they would travel through space once more in search of the next. An accursed people indeed......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155380,
 		"TextJPN": "人類は、最初の感染拡大から７週間後には、その数を２０％にまで減らしていた。",
-		"TextENG": "Humanity, after seven weeks since the initial infection spread, had their numbers reduced to 20％."
+		"TextENG": "Seven weeks after the initial infection, humanity's population was reduced to 20% of its former size."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155381,
 		"TextJPN": "無論、その２０％さえも確実に刈り取る。",
-		"TextENG": "Naturally, this 20％ will be certainty harvested."
+		"TextENG": "Of course, even that 20% was being culled as well."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155382,
 		"TextJPN": "そして再び、自分たちを宿せる脳を持つ生物を探し求め宇宙へ帰るのだ。",
-		"TextENG": "And then she will return once again to space in search of another organism with a brain to leech off."
+		"TextENG": "Then they would once more return to space in search of an organism with a brain to host them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155383,
 		"TextJPN": "その後、地球に残るのは、呪われた種子の民にも侵せない角の民の宿主たちだけ。",
-		"TextENG": "Thereafter, leaving the remains of earth, and hosts of the nation of horns, whose bodies could not have been seeded upon."
+		"TextENG": "Afterward, only the hosts of the horned people who couldn't be infected by that accursed people would remain on Earth."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155384,
 		"TextJPN": "つまり、鷹野がη１７３を感染させた地域で、心に鬼を許さなかった者だけが生き残ることになる……。",
-		"TextENG": "In other words, the area where Takano transmitted η-173 to, and the people who did not surrender their hearts to the demon, will survive......"
+		"TextENG": "Which meant that only those people in this region, who Takano had infected with η173 and had not turned their hearts over to a demon managed to survive......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155385,
 		"TextJPN": "文明社会を維持できる人数は、到底満たせまい。",
-		"TextENG": "That number of people may be able to maintain a civilized society, but not in-full."
+		"TextENG": "There were far too few humans remaining to maintain civilized society."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155386,
 		"TextJPN": "やがては、完全に滅び去ることとなるだろう……。",
-		"TextENG": "As eventually, they would fall into ruin......"
+		"TextENG": "So eventually they too would perish completely......"
 	},
 	{
 		"type": "MSGSET",
@@ -798,7 +798,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0710.",
 		"TextJPN": "「くっふふふふふふふッ、くっははっはっはっはっはっはっは……！！」",
 		"NamesENG": "Une",
-		"TextENG": "``Hee hee hee hee hee hee hee hee, ahh ha ha ha ha ha ha ha ha......!!``"
+		"TextENG": "``Kfufufufufufufu! Khahahahahahahaha......!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -807,7 +807,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0720.",
 		"TextJPN": "「チョー愉快、チョー愉悦、チョー最高！　チョーチョーチョーなのですよ、チョーくっふふっはっはっはっはっはっはッ！！」",
 		"NamesENG": "Une",
-		"TextENG": "``Super pleasant, super joy, super supreme! Super super super, super hee hee hee ha ha ha ha ha ha!!``"
+		"TextENG": "``Super fun! Super happy! Super awesome! Super super duper! Super kfufuhahahahahaha!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -816,7 +816,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0870.",
 		"TextJPN": "「ウ、ウネ…………」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``U-Une............``"
+		"TextENG": "``U-Une.........``"
 	},
 	{
 		"type": "MSGSET",
@@ -825,7 +825,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0730.",
 		"TextJPN": "「我の民は食い尽くすことだけが唯一の楽しみなのです。だって、星を全て食い潰すのチョー楽しいです！」",
 		"NamesENG": "Une",
-		"TextENG": "``Me and my people only devour for pleasure. What I mean is, eating up stars is super fun!``"
+		"TextENG": "``Consuming everything is my people's only entertainment. And I mean, consuming an entire planet is super fun!``"
 	},
 	{
 		"type": "MSGSET",
@@ -834,7 +834,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0740.",
 		"TextJPN": "「我の民が覆い尽くした以上、もう誰も我の邪魔など出来ないのです。この星の弱々しい花どもなど、我の前には熱々のコーヒーに落とした氷砂糖よりもチョー儚い！！」",
 		"NamesENG": "Une",
-		"TextENG": "``And since my people have covered yours exhaustively, nobody can hinder me anymore. The feeble flowers of this star were like sugar candy dropped into burning hot coffee before me, they were ephemeral!!``"
+		"TextENG": "``Once my people have consumed them all, no one will be able to get in our way. When faced with me, the weak flowers of this planet are like sugar lumps before hot coffee!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -843,7 +843,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1260.",
 		"TextJPN": "「……やってくれるじゃない。弱々しい素振りを見せて、私たちをうまく使うなんて、上等じゃない」",
 		"NamesENG": "Rika",
-		"TextENG": "``You've done it. You're so good at pretending to be vulnerable and using us to your advantage.``"
+		"TextENG": "``......You've sure done it now. You pretended to be weak so you could use us to advance your plans. Well done.``"
 	},
 	{
 		"type": "MSGSET",
@@ -852,7 +852,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0750.",
 		"TextJPN": "「田村媛命は騙せなかった。……あいつは、賢い」",
 		"NamesENG": "Une",
-		"TextENG": "``Yes, I could not fool Tamurahime no Mikoto. ......She is smart.``"
+		"TextENG": "``I couldn't fool Tamurahime-no-Mikoto. ......She was clever.``"
 	},
 	{
 		"type": "MSGSET",
@@ -861,7 +861,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0260.",
 		"TextJPN": "「吾輩を侮るなかれ。これでも、この大和の国を統べる民の長と知り給え！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``I do not despise you. But know this, I am leader of this country of Yamato and ruler of its people!``"
+		"TextENG": "``Do not underestimate me. Know that I am the leader of the people ruling over this nation of Yamato!``"
 	},
 	{
 		"type": "MSGSET",
@@ -870,7 +870,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0760.",
 		"TextJPN": "「なれど、そこの角頭とその巫女！　お前らはチョーチョロイ！　くっふっふふふふふ！　神が愚かなら巫女も愚か！　二人まとめてチョー愚かなのです、くっふふふふふふふ！！」",
 		"NamesENG": "Une",
-		"TextENG": "``However, not horn head and that shrine maiden over there! They were super easy! Hee hee hee hee hee hee hee! God and her shrine maiden are both stupid and foolish! Making the both of them together super stupid, hee hee hee hee hee hee hee hee!!``"
+		"TextENG": "``Yet that horn head and her priestess! You two were super easy to fool! Kfufufufufufu! When the god's a fool, so is the priestess! You two were both super dumb. Kfufufufufufufu!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -879,7 +879,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0770.",
 		"TextJPN": "「神も無能で巫女も無能！　何の役にも立たず何の力も持たず、何の神通力も持たぬ役立たずの神なのです、チョーマヌケ！！　くっはははははははははははははははははッ！！！」",
 		"NamesENG": "Une",
-		"TextENG": "``But God is also incompetent, her shrine maiden, too! She is useless without any power, although what do you expect when she had a God with such useless divine powers, super foolish!! Ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha ha!!!``"
+		"TextENG": "``When the god's incompetent, so is the priestess! You're a useless god with nothing useful to your name! No power, and no supernatural power either! You're a super dumbo!! Khahahahahahahahahahahahahahahahaha!!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -888,7 +888,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1270.",
 		"TextJPN": "「……何コレ。田村より５倍くらいイラついて来たわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......What is this? You must have insulted Tamura at least five times already.``"
+		"TextENG": "``......What is this? She's ticking me off five times as much as Tamura.``"
 	},
 	{
 		"type": "MSGSET",
@@ -897,7 +897,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0880.",
 		"TextJPN": "「めっちゃ同感なのですよ……。僕たちのことを無能呼ばわりとはチョー腹が立ちますですよ……」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I agree...... She must be very angry after being insulted so many times......``"
+		"TextENG": "``I really agree...... It's really annoying to hear us called incompetent.....``"
 	},
 	{
 		"type": "MSGSET",
@@ -906,7 +906,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0270.",
 		"TextJPN": "「まったくにもって無能と知り奉れっ、不浄の民改め間抜けの民めっ。お前など饅頭の角に頭をぶつけて死んでしまえ也！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``I know you are incompetent, you impure people, you stupid people. ...You should die by hitting your head on the corner of a bun!``"
+		"TextENG": "``Know that you are indeed incompetent! You are tainted people, and now foolish people! You should hit your head on a steamed bun and die!``"
 	},
 	{
 		"type": "MSGSET",
@@ -915,7 +915,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0890.",
 		"TextJPN": "「だって僕はウネが世界を滅ぼすなんて知らなかったのです！　僕は悪くないのです！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I didn't know Une was here to destroy the world! I didn't think she was bad!``"
+		"TextENG": "``Well I never knew that Une was going to destroy the world! It's not my fault!``"
 	},
 	{
 		"type": "MSGSET",
@@ -924,7 +924,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0280.",
 		"TextJPN": "「異民族は全て敵と知り給え！！　なのにそなたはほいほいと！　愚かにもほどがある！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Know that all other ethnic groups are your enemy!! It is what you should have done! But you are too stupid for that!!``"
+		"TextENG": "``You know that all other races are enemies!! Yet you just handed it over to her! There is a limit to how stupid one can be!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -933,7 +933,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0900.",
 		"TextJPN": "「あうあぅあぅ！！　なら田村がそれを教えてくれれば良かったのです！　だから田村が悪いのですッ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Au au au!! You should have told me, Tamura! So it's your fault.``"
+		"TextENG": "``Auauau!! You could've just told us that, Tamura! So it's your fault, Tamura!``"
 	},
 	{
 		"type": "MSGSET",
@@ -942,7 +942,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0290.",
 		"TextJPN": "「黙り給え、不浄の民と聞く口など持ち合わせておらぬ也！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Silence, I do not want to hear this from the mouth of an impurity!!``"
+		"TextENG": "``Be quiet! I will not listen to you tainted people!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -951,7 +951,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0780.",
 		"TextJPN": "「くっふふふふははははははは、チョー愉快なのです、くっはははははは！！」",
 		"NamesENG": "Une",
-		"TextENG": "``Hee hee hee hee hee ha ha ha ha ha ha ha, I am super happy, ahh ha ha ha ha ha ha!!"
+		"TextENG": "``Kfufufufuhahahahahahahaha! This is super fun! Khahahahahaha!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -960,25 +960,25 @@
 		"PreTextTags": "@vS25/50/NUNE_0790.",
 		"TextJPN": "「滅びよ、青き花壇の愚かなる神々！　そして、愚かなる人間、無能なる巫女！」",
 		"NamesENG": "Une",
-		"TextENG": "Perish, foolish Gods of this blue flower bed! And, foolish humans, and your incompetent shrine maidens, too!``"
+		"TextENG": "``Perish, you stupid gods of this blue flower bed! Your stupid humans, your incompetent priestesses too!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155406,
 		"TextJPN": "高笑いするウネ。互いを子供レベルで罵り合う羽入と田村。",
-		"TextENG": "Une laughs very loudly. As Hanyuu and Tamura curse one another at the level of children."
+		"TextENG": "Une laughed loudly while Hanyuu and Tamura insulted each other like children."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155407,
 		"TextJPN": "……これが人類の終焉を告げる最後の神々の喧嘩だとは、つくづく情けない。",
-		"TextENG": "......Seeing this fight between the last Gods amidst the end of humanity is severely shameful."
+		"TextENG": "......It seemed quite pathetic that this was a fight between gods who had brought about the extinction of humanity."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155408,
 		"TextJPN": "梨花は頭痛を堪えるように額に手を当てるが、今は腹立たしさの方が勝る。",
-		"TextENG": "Rika places her hand on her forehead in an attempt to bear the headache, but its irritation has now exceed that."
+		"TextENG": "Rika placed a hand on her forehead like she was enduring a headache, but her frustration was winning at that particular moment."
 	},
 	{
 		"type": "MSGSET",
@@ -987,7 +987,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1280.",
 		"TextJPN": "「私はね、自分のこと人間だとか思ってないし、別に世界が滅ぶとかどうでもいいの。ただどうしても許せないことはただ一つ」",
 		"NamesENG": "Rika",
-		"TextENG": "``I don't consider myself a human, and I don't care if this world perishes. But there is one thing that I can never permit.``"
+		"TextENG": "``Listen, I don't consider myself a human, and I don't care if our world is destroyed. But there's one thing I just can't forgive.``"
 	},
 	{
 		"type": "MSGSET",
@@ -996,7 +996,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1290.",
 		"TextJPN": "「……この、幾百の死の山々を越えてきた古手梨花に向かって、無能呼ばわりしてくれたことよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......That is, calling Rika Furude incompetent after I had crossed hundreds of mountains of death.``"
+		"TextENG": "``......The fact you looked at me, Rika Furude, who has overcome the mountain that is hundreds of deaths, and called me incompetent.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1005,7 +1005,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1300.",
 		"TextJPN": "「……無能って言葉はね、肝心な時に温泉行ってるような男に使うものよ…！」",
 		"NamesENG": "Rika",
-		"TextENG": "``The word 'incompetent' is used to describe a man who goes to the spa at the most critical moment.``"
+		"TextENG": "``......The term incompetent is what you use for a man who goes off to the hot spring at a critical moment...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1014,13 +1014,13 @@
 		"PreTextTags": "@vS25/50/NUNE_0800.",
 		"TextJPN": "「我に立ち向かうつもりか、人の子風情が。我、チョー笑えるのです。くっふふふふふふ！」",
 		"NamesENG": "Une",
-		"TextENG": "``You intend to confront me, with the childish appearance of a human? You're super funny. Hee hee hee hee hee hee hee!``"
+		"TextENG": "``You intend to oppose me? You, a mere child of man? That's super funny. Kfufufufufufu!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155413,
 		"TextJPN": "梨花はどこからともなく、ぎらりと銀色の光を見せるものを取り出す。",
-		"TextENG": "Rika, out of nowhere, pulls out something shining in a silvery light."
+		"TextENG": "Rika pulled something out of nowhere that glinted with a silver light."
 	},
 	{
 		"type": "MSGSET",
@@ -1038,7 +1038,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1310.",
 		"TextJPN": "「……知らないの？　包丁よ。調理器具よ。料理といけ好かないヤツを切り刻むのに最適な道具よ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Don't you know it? It's a kitchen knife. A kitchen utensil. A tool most suited to cut dishes and disgusting people.``"
+		"TextENG": "``......Don't you know? It's a kitchen knife. A cooking tool. The perfect instrument for chopping up food... and detestable people.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1047,31 +1047,31 @@
 		"PreTextTags": "@vS25/50/NUNE_0820.",
 		"TextJPN": "「くっふふふふふ！　我、チョー笑えるのです。人の子の道具で、この我に立ち向かうつもりなのですか。チョー笑えるです。チョーくっふっふっふっふっふ…！！」",
 		"NamesENG": "Une",
-		"TextENG": "``Hee hee hee hee hee hee! You're super funny. A tool of the children of man, and you intent to confront me with it. That's super funny. Super hee hee hee hee hee hee...!!``"
+		"TextENG": "``Kfufufufufu! I'm super laughing right now! How do you plan on fighting me with a tool of mankind? That's super funny. Super kfufufufufu...!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155417,
 		"TextJPN": "人ならざる存在は人にとって、水面の月も同然だ。",
-		"TextENG": "Non-human beings are like the moon on the surface of the water for people."
+		"TextENG": "From the perspective of humans, those inhuman beings were like a moon on the water's surface."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155418,
 		"TextJPN": "人の世の武器をいくら振りかざしたところで、水面を乱すことしか出来ないし、空に浮かぶ月を傷つけることなど出来はしない。",
-		"TextENG": "So now that I am wielding this weapon of the human world, it is possible to disturb the surface of the water, injuring the moon which floats in the sky."
+		"TextENG": "She could swing a weapon all she wanted in the world of man, but it wouldn't even disturb the water's surface, let alone harm the moon floating in the sky."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155419,
 		"TextJPN": "しかしながら、彼らは人の世に顕在するには、巫女を必要とする。人間たちの解釈で言うなら、宿主である女王感染者が必要となる。",
-		"TextENG": "However, for them to manifest as people in this world, they need a shrine maiden. So by the interpretation of human beings, a Queen contagion is necessary for a host."
+		"TextENG": "However, for them to manifest in the world of man, they required a priestess. To put it in human terms, they required a queen carrier as a host."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155420,
 		"TextJPN": "ウネの女王感染者（と言っていいのか、本人と言うべきなのか）である采を倒すことが出来れば、一矢を報いることは出来よう。",
-		"TextENG": "So if we find the Queen infected person of Une we will be able to defeat her, retaliating."
+		"TextENG": "If she defeated Une's queen carrier (was that correct to say? Or was it better to say 'Une herself'?) then she could at least deal a decisive blow to her."
 	},
 	{
 		"type": "MSGSET",
@@ -1080,7 +1080,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0830.",
 		"TextJPN": "「しかしながら、我の体は汝の手のチョー届かぬところなのです。鹿骨市を出ることさえ出来ぬ汝には指一本触れられはしないのです」",
 		"NamesENG": "Une",
-		"TextENG": "``However, my body is not a place you can reach with your hand. You can't even lay one finger on it, because you can't leave Shishibone City.``"
+		"TextENG": "``However, my body is super beyond your reach. You can't even leave Shishibone City, so you can't lay a finger on her.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1089,7 +1089,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0300.",
 		"TextJPN": "「吾輩の民もほとんどは討ち取られ……、あやつがどこにいるのかもわからぬ……。鹿骨に閉じ込められている内に討ち取ることが出来れば……。この不浄シュークリームのせいで！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Most of my people are already dead...... so I will not be able to find her either. But if we managed to confine her to Shishibone, we would have been able to kill her...... This is all your fault you impure cream puff!``"
+		"TextENG": "``Nearly all of my people have been taken captive...... I have no idea where she is at present...... If only I could've taken her down while she was trapped in Shishibone...... But thanks to this tainted cream puff!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1098,7 +1098,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0910.",
 		"TextJPN": "「やかましいのですッ、ご飯の１杯くらいで千年も恨むなど、本当に田村のナンチャラは心が狭いのですよー！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Why are you so annoying, you've even bore a grudge against me for a thousand years after I ate a cup of your rice. You really are narrow minded, Tamura!``"
+		"TextENG": "``That's enough! Honestly, it's your fault for being so petty, Tamura, and holding a thousand year grudge over a single meal!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1107,7 +1107,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0310.",
 		"TextJPN": "「吾輩に奉納された米は一粒であっても、くれてはやらぬ也やー！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Even so, every single grain of rice that my people offered was to me!!``"
+		"TextENG": "``I'll never give you a single grain of rice that has been dedicated to me!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1116,7 +1116,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0920.",
 		"TextJPN": "「僕はお腹がペコペコだったのですよー！！　少しくらい施せなのです！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I was starving!! I only took a little!!``"
+		"TextENG": "``I was starving!! You could've spared a little!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1125,7 +1125,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1320.",
 		"TextJPN": "「……よしなさいよ、あんたたち。それにね、戦いはまだ終わっちゃいないわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Quit it, the both of you. This fight isn't over yet.``"
+		"TextENG": "``......Stop it, you two. Besides, this battle isn't over yet.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1134,7 +1134,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0840.",
 		"TextJPN": "「ほう？　我が、世界をチョー覆い尽くした今、汝だけでどう刃向おうと言うのですか。チョー笑えることですっ。戦いはまだ終わっていない？　すでに完全にチョー終わった戦いだと言うのにです！」",
 		"NamesENG": "Une",
-		"TextENG": "``Huh? I have super exhaustively covered this entire world, and now your saying you will fight back with that blade. You're super funny. So, are you sure this fight isn't over yet? Because this fight has already ended superly!``"
+		"TextENG": "``Oh? And how are you going to face me by yourself when I've super enveloped your entire world? That's super funny! The battle isn't over? This battle is totally super over already!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1143,7 +1143,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1330.",
 		"TextJPN": "「そうね。確かに、戦いはすでに終わってるわ。あんたたちの概念ではね。でもね、私の概念では戦いはまだ終わってないの」",
 		"NamesENG": "Rika",
-		"TextENG": "``That may be so. Surely, this fight is already over, in your concept. But, this fight is not over in my concept.``"
+		"TextENG": "``You're right. This battle is over already. As far as you two can conceive. But from my perspective, it isn't over yet.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1152,7 +1152,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1340.",
 		"TextJPN": "「……いえ、正確には、あんたが本性を現してくれた時点で、戦いは終わったわけかしら？　私の勝利でね」",
 		"NamesENG": "Rika",
-		"TextENG": "``......No, technically, the fight was over when you showed your true colors, wasn't it? I won.``"
+		"TextENG": "``......No, perhaps it's more accurate to say this battle was over the moment you revealed your true nature? It's over... and it's my victory.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1170,7 +1170,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0320.",
 		"TextJPN": "「そなたの巫女は訳のわからぬことを申す也や。この状況からどうやって世界を救うと申す也や！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Shrine maiden of this monkey, I do not understand what you mean. How can we save the world from the situation this monkey caused!``"
+		"TextENG": "``What nonsense is your priestess spouting? How can she possibly save the world in this situation?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1179,7 +1179,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0850.",
 		"TextJPN": "「くっひひひひひ！　我こそ聞きたい、チョー聞きたい！」",
 		"NamesENG": "Une",
-		"TextENG": "``Hee hee hee hee hee hee! I want to hear it also, I superly want to hear it!``"
+		"TextENG": "``Khihihihihi! I want to know! I super want to know!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1188,7 +1188,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0940.",
 		"TextJPN": "「僕こそ聞きたいのです。もう手遅れなのですよ、世界は滅んでしまうのですよ！　どうやってここから世界を救うのですか…！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I want to hear it, too. It's already too late, the world is perishing! How can we save the world from here...!``"
+		"TextENG": "``I'm the one who wants to know! It's already too late. The world's ending! How are we going to save this world now...?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1197,7 +1197,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1350.",
 		"TextJPN": "「……あのね。あんたがわかってなくてどーすんのよ。あんた、こいつの使い方、忘れたの？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......Excuse me. It seems you have forgotten. Did you forget how to use it?``"
+		"TextENG": "``......Hey. How can you not understand? Have you forgotten how this is used?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1206,7 +1206,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0950.",
 		"TextJPN": "「あう？　包丁で、ウネのドタマをカチ割るのですか？」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Au? You mean the kitchen knife, do I have to cut Une with it?``"
+		"TextENG": "``Au? You're going to hack open Une's head with the knife?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1215,7 +1215,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0330.",
 		"TextJPN": "「仮にも神ならば、ウネの頭部を誅すると申し給えっ」",
 		"NamesENG": "Tamura",
-		"TextENG": "``If I would be a god, I would put a death sentence on Une's head!``"
+		"TextENG": "``If she were not a god, I would command you to behead Une, indeed!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1224,7 +1224,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1360.",
 		"TextJPN": "「あんたらは二人揃ってクリーム抜きシュークリーム頭ね。この包丁の使い方を、今、教えてあげるわ」",
 		"NamesENG": "Rika",
-		"TextENG": "``The two of you together are cream puff heads without the cream. I'll use the kitchen knife, now watch and learn.``"
+		"TextENG": "``You two both have your heads filled with cream-free cream puffs. I'll teach you how this knife is used... right now.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1233,7 +1233,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0860.",
 		"TextJPN": "「ほう？　それはチョー何の真似なのです？」",
 		"NamesENG": "Une",
-		"TextENG": "``Huh? What super imitation is this?``"
+		"TextENG": "``Oh? And what do you totally think you're doing?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1242,7 +1242,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1370.",
 		"TextJPN": "「あんたの敗因は、私に本体の正体と居場所を特定させたことよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``It will be the cause of your defeat, and allow me to identify the whereabouts of your true form.``"
+		"TextENG": "``The cause of your defeat was revealing to me your true identity and whereabouts.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1251,7 +1251,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0960.",
 		"TextJPN": "「えぇ？！　采が今、どこにいるのかわかるのですか？！　田村でさえわからないのに、どうやって！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Eh?! Do you know where Une is at present?! Even Tamura doesn't know that!``"
+		"TextENG": "``Huh?! You know where Une is right now?! How do you know when even Tamura doesn't?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1260,7 +1260,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0340.",
 		"TextJPN": "「し、しかし、仮にわかったとて、ここにいなければ打てる手は無きものと知り給え」",
 		"NamesENG": "Tamura",
-		"TextENG": "``H-However, as you know, we cannot raise our hands and defeat her from here.``"
+		"TextENG": "``S-Still, even if you did know, you've gotta know there's nothing you can do if she's not here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1269,7 +1269,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1380.",
 		"TextJPN": "「今どこにいるか、なんてどうでもいいの。あの時、興宮にいた。それだけがわかれば、私には充分なのよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``It doesn't matter where she is now. Because at that time, she was in Okinomiya. That's all you need to know, and it's sufficient for me, too.``"
+		"TextENG": "``It doesn't matter where she is right now. Back then, she was here in Okinomiya. That's all I need to know.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1278,7 +1278,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0870.",
 		"TextJPN": "「我には何を言ってるのか、チョーさっぱりなのです」",
 		"NamesENG": "Une",
-		"TextENG": "``It doesn't matter what you say, it's super useless.``"
+		"TextENG": "``What are you saying? I super don't get it.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1287,7 +1287,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1390.",
 		"TextJPN": "「一個だけ教えてあげるわ。あんたの敗因よ」",
 		"NamesENG": "Rika",
-		"TextENG": "``I'll tell you only one thing. The cause of your defeat.``"
+		"TextENG": "``Let me tell you something. You're going to lose...``"
 	},
 	{
 		"type": "MSGSET",
@@ -1296,67 +1296,67 @@
 		"PreTextTags": "@vS25/05/NRIK_1400.@z200.",
 		"TextJPN": "「テメーは私を怒らせた」",
 		"NamesENG": "Rika",
-		"TextENG": "``You angered me.``"
+		"TextENG": "``Because you made me mad.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155446,
 		"TextJPN": "時は遡る……。",
-		"TextENG": "Back in time......"
+		"TextENG": "Let's go back..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155447,
 		"TextJPN": "この星にて、采がウネを自覚し、目覚めた時に。",
-		"TextENG": "On this star, when Une became aware of Une and awoke."
+		"TextENG": "Back to the moment Une became aware of the other Une and awakened her on this planet."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155448,
 		"TextJPN": "それは、鷹野によるη１７３拡散の前日。",
-		"TextENG": "The day before Takano spread η-173."
+		"TextENG": "It was the day before Takano started spreading η173."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155449,
 		"TextJPN": "目覚めたばかりのウネの気配はまだ微弱。田村は采の所在を掴み切れずにいた。",
-		"TextENG": "Une has awoken, she is still feeling weak. Tamura hasn't been able to grasp the location of Une."
+		"TextENG": "Since Une had just awoken, her presence was still faint. Tamura had yet to grasp her whereabouts."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155450,
 		"TextJPN": "ウネは田村の根の弱さを知り、直ちに開花して、自分の民の感染爆発を準備する。",
-		"TextENG": "Une knows the weakness of the roots of Tamura, and promptly prepares her flowers to explode and infect all her people."
+		"TextENG": "Une had learned how weak Tamura's roots were, and she was making preparations to bloom at once and spread her people everywhere."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155451,
 		"TextJPN": "田村は采の所在を突き止めることを断念し、鷹野を巫女に迎え、彼女の感染爆発を防ぐ唯一の苦肉の策を取る。",
-		"TextENG": "Tamura abandons her search to locate the whereabouts of Une, and makes Takano her shrine maiden, a last resort in order to prevent Une exploding her infection."
+		"TextENG": "Tamura had given up on discovering Une's whereabouts and welcomed Takano as her priestess, to prepare her bitter plan of stopping Une's explosive spread."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155452,
 		"TextJPN": "それが、鷹野による、ウネより一足早い、η１７３の感染爆発だ。",
-		"TextENG": "Then, Takano must, before Une does, detonate and infection everyone with η-173."
+		"TextENG": "Her plan of having Takano spread η173 before Une could."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155453,
 		"TextJPN": "つまり、現時点ではまだ、ウネも鷹野も、何もばら撒いていない。まだ、世界は取り返しのつかない段階には至ってないのだ。",
-		"TextENG": "In other words, at this very moment, neither Une or Takano have spread their seeds. So as of yet, the world has not reached an irreparable stage."
+		"TextENG": "Which meant that at present, neither Une nor Takano had spread anything at all. The world had yet to reach the point of no return."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155454,
 		"TextJPN": "つまり、今日。ウネの野望が食い止められたなら……。",
-		"TextENG": "Today the ambition of Une will be halted......"
+		"TextENG": "In other words, if Une's ambition could be halted on this day, then it would all end before it started......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155455,
 		"TextJPN": "でもそんなことは無理だ。タイムマシンでもない限り！",
-		"TextENG": "But such a thing is impossible. As long as we don't have a time machine that is!"
+		"TextENG": "But that was impossible. Without a time machine!"
 	},
 	{
 		"type": "MSGSET",
@@ -1365,19 +1365,19 @@
 		"PreTextTags": "@vS25/50/NUNE_0880.",
 		"TextJPN": "「……くっひっひっひ。我、チョー目覚めたのです。……田村媛命は騙せなかったですが、どうでもいいこと。あんな根がチョー弱いヤツ、気にせず、思い切りこの星を乗っ取ってチョー食い尽くすのです。チョーくっひひひひひひひひ…！」",
 		"NamesENG": "Une",
-		"TextENG": "``......Hee hee hee hee. I have awoken superly. ......Tamurahime-no-Mikoto couldn't be fooled, but it doesn't matter. I'm sure I'll be able to find something that will help me out. Super hee hee hee hee hee hee hee hee hee...!``"
+		"TextENG": "``......Khihihi! I've super woken up. ......I couldn't fool Tamurahime-no-Mikoto, but that doesn't matter. I don't need to worry about someone with such weak roots as I move on to take over this planet and super consume it! Super khihihihihihihihi...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155457,
 		"TextJPN": "ウネの民による世界征服の野望は、日本の地方都市の、小さな興宮の街で生まれていたのだ。",
-		"TextENG": "The ambition of Une's people is world domination through the provincial cities of Japan, and the small town of Okinomiya where she was born."
+		"TextENG": "Une's ambition of conquering the world with her people was born here in this small town of Okinomiya in rural Japan."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155458,
 		"TextJPN": "誰も、世界も、その恐るべき決意に気付けるわけがない。しかし。",
-		"TextENG": "But nobody, not even in the entire world has noticed her dreadful determination. However."
+		"TextENG": "No one in the world had noticed this terrifying resolve just yet. However."
 	},
 	{
 		"type": "MSGSET",
@@ -1386,7 +1386,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0890.",
 		"TextJPN": "「くっひっひっひ……。@k@|@y@vS25/50/NUNE_0891.ひ……？」",
 		"NamesENG": "Une",
-		"TextENG": "``Hee hee hee hee......@k@|@y@vS25/50/NUNE_0891. hee......?``"
+		"TextENG": "``Khihihi......@k@|@y@vS25/50/NUNE_0891. Hi......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1395,7 +1395,7 @@
 		"PreTextTags": "@vS25/02/NREN_1320.",
 		"TextJPN": "「こんにちは。あなたが采ちゃん、かなかな……？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Hello. Are you Une-chan, I wonder I wonder......?``"
+		"TextENG": "``Good afternoon. Are you Une-chan? Are you......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1404,7 +1404,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0900.",
 		"TextJPN": "「……汝、……誰なのです……？」",
 		"NamesENG": "Une",
-		"TextENG": "``......You...... who are you......?``"
+		"TextENG": "``......Who, are you......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1413,7 +1413,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1450.",
 		"TextJPN": "「レナ、見付けたのか？！　おお、確かにこの子だ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Rena, did you find her?! Oh, it's certainly this child!``"
+		"TextENG": "``Rena, did you find her?! Ohh, this must be her!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1422,7 +1422,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1480.",
 		"TextJPN": "「おー、確かに確かに！　似顔絵にそっくりだねぇ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Oh, certainly, certainly! She looks just like her portrait!``"
+		"TextENG": "``Ohh, it is, it is! She looks exactly like she did in the portrait!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1431,19 +1431,19 @@
 		"PreTextTags": "@vS25/04/NSAT_0680.",
 		"TextJPN": "「梨花って、結構、絵がお上手なんですのねぇ。驚きましてよ！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Rika did great, she's really skillful at sketching. I'm surprised!``"
+		"TextENG": "``Rika's pretty good at drawing, isn't she? I'm quite surprised!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155465,
 		"TextJPN": "ポニーテールのお姉さんが、我の顔にそっくりな似顔絵の描かれたスケッチブックを見せる。",
-		"TextENG": "The young lady with a ponytail shows me a sketchbook drawing with a portrait that looks exactly like my face."
+		"TextENG": "The older girl with a ponytail held up a sketchbook with a portrait that looked exactly like me."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155466,
 		"TextJPN": "唐突にこんなにも大勢に囲まれて、意味がわからない。",
-		"TextENG": "All of a sudden, I have been abruptly surrounded by this large number of people, I don't understand the meaning of it."
+		"TextENG": "I was suddenly surrounded and didn't understand why."
 	},
 	{
 		"type": "MSGSET",
@@ -1452,7 +1452,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1410.",
 		"TextJPN": "「……やっと見つけたわよ、采」",
 		"NamesENG": "Rika",
-		"TextENG": "``......I've finally found you, Une.``"
+		"TextENG": "``......I finally found you, Une.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1461,7 +1461,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0910.",
 		"TextJPN": "「ど、……どちら様、でしょう……？」",
 		"NamesENG": "Une",
-		"TextENG": "``Wh-Who...... are you......?``"
+		"TextENG": "``Wh-Who might you be......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1470,7 +1470,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1420.",
 		"TextJPN": "「初対面は数週間後になるけどね。でも私はつい先日会ったばかりよ。まぁ、私の言うつい先日ってのは、数ヶ月くらいのことだけれどね。今日が一日しかないもんだから、ずいぶんとあんた探しに手こずらせてもらったわ、采っ」",
 		"NamesENG": "Rika",
-		"TextENG": "``I should be first meeting you several weeks from now. But I just met you the other day. Well, when I just said the other day, I meant around several months. But because this is your first day, I had to search for you considerably, Une.``"
+		"TextENG": "``Our first time meeting would normally be some weeks from now. But I only met you just the other day. Well, while I say just the other day, I mean several months ago. I only had today to find you, so I had a hard time searching for you, Une!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1479,7 +1479,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0970.",
 		"TextJPN": "「ふっふっふ！　僕と梨花を侮らないことなのですよ、ウネ！！　そなたの地球征服の野望はすでにお見通しなのですッ」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Hee hee hee! You should have never made light of myself and Rika, Une!! As now we know about your ambition of earth conquest.``"
+		"TextENG": "``Fufufu! You shouldn't underestimate me and Rika, Une!! We've already seen your ambition for world conquest!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1488,7 +1488,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0920.",
 		"TextJPN": "「……わ、我の野望、……どうして見破られているのです？！」",
 		"NamesENG": "Une",
-		"TextENG": "``......M-My ambition...... how have I been found out?!``"
+		"TextENG": "``......H-How, did you see through my ambition?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1497,7 +1497,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1430.",
 		"TextJPN": "「ねぇ？　角の民の長とその巫女の能力、無能じゃないでしょ？　ちょーっと気が長くなるくらい面倒臭いだけで、私から見れば、無能はあんたの方なんだからね。くすくすくすくす！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Didn't you know? The leader of the nation of horns and her shrine maidens abilities, are you that incompetent? It seems you only cared about being super and troublesome. Now, look at me, and you'll see how such an incompetent person you were. Hee hee hee hee hee hee hee hee!``"
+		"TextENG": "``See? The leader of the horned people and her priestess aren't so powerless or incompetent after all, huh? It's just so tiresome it wears on the patience a bit, but from my point of view, you're the incompetent one. Heeheeheehee!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1506,7 +1506,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0980.",
 		"TextJPN": "「ピカーッ！　これこそは古手神社祭具殿に伝わる、神縛りの秘宝！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Beaaaam! This is what has been passed down by the Furude shrine's Ritual Equipment Temple, a God restraint treasure!``"
+		"TextENG": "``Flash! This is the ancient god-binding treasure normally kept in the Furude Shrine's ritual storehouse!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1515,7 +1515,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1440.",
 		"TextJPN": "「さぁみんな！　この注連縄でふん縛ってしまうのですよ！　にぱ～♪」",
 		"NamesENG": "Rika",
-		"TextENG": "``Now, everyone! Tie her up with the Shinto straw festoon! Nipah~♪.``"
+		"TextENG": "``Now, everyone! Bind her up in this sacred rope! Nipah♪``"
 	},
 	{
 		"type": "MSGSET",
@@ -1524,7 +1524,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0930.",
 		"TextJPN": "「……わ、我、グルグル巻き！　あ～れ～！！」",
 		"NamesENG": "Une",
-		"TextENG": "``......I, I, spinning in circles! Ahhhh!!``"
+		"TextENG": "``......Y-You're binding me in circles! Ahhhh!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1533,7 +1533,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0350.",
 		"TextJPN": "「おお、吾輩にも見つけられなかったウネをこれほどあっさりと！　礼を言う也や、人の子よ！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Oh, it seems your people found Une rather easily! I should say thanks, child of man!``"
+		"TextENG": "``Ohh! To think you'd find Une so easily when I couldn't uncover her! You have my thanks, children of man!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1542,7 +1542,7 @@
 		"PreTextTags": "@vS25/12/NHAN_0990.",
 		"TextJPN": "「出ましたのですね、田村媛命！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``There you are Tamurahime no Mikoto!``"
+		"TextENG": "``You've shown yourself, Tamurahime-no-Mikoto!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1551,7 +1551,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1450.",
 		"TextJPN": "「ちなみにあんたも有罪だからね。あんたが下らないプライドを捨てて私たちに助力を仰いでいたら、あの大災害の必要はなかったんだからね」",
 		"NamesENG": "Rika",
-		"TextENG": "``By the way, you're guilty too. Because if you had abandoned that worthless pride of yours and asked us for help, a great disaster like this would never have happened.``"
+		"TextENG": "``By the way, you're equally guilty. If you'd just let go of your pride and asked us for help, you wouldn't have needed to cause such a huge disaster in the first place.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1560,7 +1560,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0360.",
 		"TextJPN": "「吾輩はこれでも誇り高き田村媛命！　野蛮で不浄なる角の民に借りなど作らぬと知り奉れ！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``I am the proud Tamurahime no Mikoto! You should know that I cannot owe a debt to such uncivilized impurities such as the nation of horns!``"
+		"TextENG": "``I am the proud Tamurahime-no-Mikoto! Know that I would never indebt myself to the savage and tainted horned people!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1569,7 +1569,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1460.",
 		"TextJPN": "「というわけで有罪ね。@k@|@y@vS25/05/NRIK_1461.ピカー！！」",
 		"NamesENG": "Rika",
-		"TextENG": "``Therefore, you're guilty.@k@|@y@vS25/05/NRIK_1461. Beaaaam!!``"
+		"TextENG": "``That's why you're just as guilty.@k@|@y@vS25/05/NRIK_1461. Flash!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1578,7 +1578,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0370.",
 		"TextJPN": "「なッ、なんと！！　神縛りの秘宝とは！！　あ～れ～！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Wh-What!! A God restraint treasure!! Ahhh!!``"
+		"TextENG": "``W-What?!! The god-binding treasure?!! Ahhh!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1587,7 +1587,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1000.",
 		"TextJPN": "「さぁ、これで今回の騒ぎの首謀者を全てタイホできたのですよ！　あう！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Now, we have arrested all the ringleaders of this uproar! Au!``"
+		"TextENG": "``Now we've captured all the ringleaders of this commotion! Au!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1596,7 +1596,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1470.",
 		"TextJPN": "「そもそも、あんたと田村が仲違いをしてなければ防げた惨劇よ。あんたたち、ご飯の一杯で喧嘩したみたいなことを言ってたわね？」",
 		"NamesENG": "Rika",
-		"TextENG": "``In the first place, this tragedy could have been prevented if Tamura didn't quarrel with you. Also, what did the both of you mean when you were quarreling about a cup of rice?``"
+		"TextENG": "``This was a tragedy that could've been prevented if you and Tamura weren't on bad terms in the first place. You said the two of you fought over a single meal, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1605,7 +1605,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1010.",
 		"TextJPN": "「僕は悪くないのですよ！　田村がケチケチしてるからいけないのです！　あれだけたくさんお供えされてるのですから、少しくらい僕がもらってもバチは当たらないのです！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``It's not my fault! Tamura was being stingy, she's in the wrong! Even after I gave many offerings, she never gave me any in return, not even a little bit!``"
+		"TextENG": "``It's not my fault! Tamura shouldn't have been so stingy! She had so much being offered to her! It wouldn't have hurt her to share a bit with me!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1614,7 +1614,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1480.",
 		"TextJPN": "「つまり、あんたがドロボーしたってことでしょうが。というわけで、あんたも有罪！@k@|@y@vS25/05/NRIK_1481.　ピカー！！！」",
 		"NamesENG": "Rika",
-		"TextENG": "``In other words, you stole from her. Therefore, you are guilty too!@k@|@y@vS25/05/NRIK_1481. Beaaaam!!!``"
+		"TextENG": "``In other words, you stole it from her. So you're just as guilty!@k@|@y@vS25/05/NRIK_1481. Flash!!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1623,6 +1623,6 @@
 		"PreTextTags": "@vS25/12/NHAN_1020.",
 		"TextJPN": "「だから注連縄を３本持ってきたのですか～！　あ～れ～！！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``So, you must have brought three Shinto straw festoons! Ahhh!!!``"
+		"TextENG": "``Is this why you brought three sacred ropes with you?! Ahhh!!!``"
 	}
 ]

--- a/kamikashimashi_7.json
+++ b/kamikashimashi_7.json
@@ -129,7 +129,7 @@
 		"type": "MSGSET",
 		"MessageID": 155296,
 		"TextJPN": "でも、希望の光は灯った。采は、その鍵だ。",
-		"TextENG": "But we had our light of hope.Une was the key."
+		"TextENG": "But we had our light of hope. Une was the key."
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1150.",
 		"TextJPN": "「……あんたは、ウネを拡散させない為に、……鷹野にη１７３をばら撒かせた……？」",
 		"NamesENG": "Rika",
-		"TextENG": "``......You had Takano spread η173 ......so Une couldn't spread herself......?``"
+		"TextENG": "``......You had Takano spread η173...... so Une couldn't spread herself......?``"
 	},
 	{
 		"type": "MSGSET",

--- a/kamikashimashi_end.json
+++ b/kamikashimashi_end.json
@@ -573,7 +573,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0750.",
 		"TextJPN": "「スクール水着姿で偉そうにされても、滑稽にしか見えませんでしてよ？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Still, this is an incredible outfit. What's it even from?``"
+		"TextENG": "``You know, it's funny to see you in a school swimsuit looking all high and mighty.``"
 	},
 	{
 		"type": "MSGSET",
@@ -582,7 +582,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1520.",
 		"TextJPN": "「にぱ～☆　その姿でご主人さまにご奉仕ご奉仕なのですよ☆」",
 		"NamesENG": "Rika",
-		"TextENG": "``Nipah! It's a dream collaboration with Blahblahblah so she can pretend to be an adult pro-wrestler!``"
+		"TextENG": "``Nipah! You'll be serving your master in that form☆.``"
 	},
 	{
 		"type": "MSGSET",
@@ -681,7 +681,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0770.",
 		"TextJPN": "「似合いすぎて逆に危ないですわね。圭一さん、鼻血出すんじゃありませんの？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``This is another cruel outfit. What is this one from?``"
+		"TextENG": "``It looks so good on you that it's dangerous. Keiichi-san, aren't you going to get a nosebleed?``"
 	},
 	{
 		"type": "MSGSET",
@@ -690,7 +690,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1550.",
 		"TextJPN": "「きっと、富竹たちにも大人気間違いなしなのですよ。にぱ～☆」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's an indecent outfit that came up when I googled 'embarrassing outfits'. Nipah!``"
+		"TextENG": "``I'm sure it will be very popular with Tomitake and others. Nipah~☆``"
 	},
 	{
 		"type": "MSGSET",
@@ -790,7 +790,7 @@
 		"TextJPN": "「……………うりゅ～」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``............Au.``@e"
+		"TextENG": "``............Au.``"
 	},
 	{
 		"type": "MSGSET",
@@ -800,7 +800,7 @@
 		"TextJPN": "「これからは神様同士仲良くする也や、もう許して奉れ～っ」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Tamura",
-		"TextENG": "``I promise the three of us gods will get along now! So spare us already!``@e"
+		"TextENG": "``I promise the three of us gods will get along now! So spare us already!``"
 	},
 	{
 		"type": "MSGSET",
@@ -810,7 +810,7 @@
 		"TextJPN": "「我も、チョー改心するのですー！」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Une",
-		"TextENG": "``I'm super repenting too!``@e"
+		"TextENG": "``I'm super repenting too!``"
 	},
 	{
 		"type": "LOGSET",
@@ -828,7 +828,7 @@
 		"TextJPN": "「………………………」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Hau~!!! So kyute!! I'm taking you home~!!!``@e"
+		"TextENG": "``...........................``"
 	},
 	{
 		"type": "MSGSET",
@@ -838,6 +838,6 @@
 		"TextJPN": "「な、………納得できないのですーッ！！」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``...........................I......... I won't accept this!!``@e"
+		"TextENG": "``I......... I won't accept this!!``"
 	}
 ]

--- a/kamikashimashi_end.json
+++ b/kamikashimashi_end.json
@@ -12,7 +12,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1490.",
 		"TextJPN": "「話は全て梨花ちゃんから聞かせてもらったよ。……あんたたち、神様なんでしょ？　あんたたちの騒ぎに巻き込まれて迷惑する人間のことも、ちょーっと考えて欲しいねぇ？」",
 		"NamesENG": "Mion",
-		"TextENG": "``We heard all the stories from Rika-chan. ......So you guys are Gods? Well, it's kind of annoying to think that humans got caught up in your uproar, don't you think so?``"
+		"TextENG": "``We heard the whole story from Rika-chan. ......You're all gods, right? I wish you'd give a little consideration to the humans you're endangering.``"
 	},
 	{
 		"type": "MSGSET",
@@ -21,7 +21,7 @@
 		"PreTextTags": "@vS25/02/NREN_1330.",
 		"TextJPN": "「未然に防げたからいいけど。……大変な騒ぎになってたかもしれないんでしょ？」",
 		"NamesENG": "Rena",
-		"TextENG": "``But, I think it's good we were able to prevent it. ......Otherwise a great uproar would have occurred, right?``"
+		"TextENG": "``It's good that we prevented it ahead of time. ......But this might have turned into a terrible disaster, you know?``"
 	},
 	{
 		"type": "MSGSET",
@@ -30,7 +30,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1490.",
 		"TextJPN": "「大変も何も。ボクが身をもって体験してきたのですよ」",
 		"NamesENG": "Rika",
-		"TextENG": "``It didn't end very well. I experienced that firsthand.``"
+		"TextENG": "``It wasn't just terrible. I experienced it firsthand.``"
 	},
 	{
 		"type": "MSGSET",
@@ -39,7 +39,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1460.",
 		"TextJPN": "「とにかくだ！　神様同士、仲良くしてくれなきゃ困るぜ？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Anyway! If Gods are bothered by one another, then we have to help them get along, right?``"
+		"TextENG": "``Anyway! It's not good for us if you gods don't get along with each other.``"
 	},
 	{
 		"type": "MSGSET",
@@ -48,7 +48,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0690.",
 		"TextJPN": "「しかし、ずいぶんと可愛い神様たちですわねぇ。……私、もっとおっかない風貌を想像していましてよ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``However, those Gods are very cute. ......It's hard for me to image them appearing fearful.``"
+		"TextENG": "``Still, they're awfully cute gods, aren't they? ......I imagined they'd have much scarier faces.``"
 	},
 	{
 		"type": "MSGSET",
@@ -57,7 +57,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1030.",
 		"TextJPN": "「あぅあぅあぅ！　我こそはオヤシロさまなのですよ！　この扱いはあんまりなのです！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Au au au! I am Oyashiro-sama! This treatment is unreasonable!``"
+		"TextENG": "``Auauau! I am Oyashiro-sama! This treatment isn't fair!``"
 	},
 	{
 		"type": "MSGSET",
@@ -66,7 +66,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0380.",
 		"TextJPN": "「おのれ、人の子らめ！　我輩を敬わずに可愛いとは言語道断と知り奉れ！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``You, children of man! You show us no respect, you should know it is outrageous to call one cute without first offering worship!``"
+		"TextENG": "``Why you, children of man! It is outrageous to show me such disrespect and call me cute!``"
 	},
 	{
 		"type": "MSGSET",
@@ -75,7 +75,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0940.",
 		"TextJPN": "「我の世界征服の野望がどうして知られたのですか！　チョー納得できないのです！」",
 		"NamesENG": "Une",
-		"TextENG": "``How was my ambition of world domination known! I superly cannot understand!``"
+		"TextENG": "``How did you know about my ambition to conquer the world?! I totally can't accept this!``"
 	},
 	{
 		"type": "MSGSET",
@@ -84,7 +84,7 @@
 		"PreTextTags": "@vS25/02/NREN_1340.",
 		"TextJPN": "「采ちゃんはどうして、世界を滅ぼそうなんて物騒なことを考えたの？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Une-chan, don't you think it's dangerous to destroy the world?``"
+		"TextENG": "``Une-chan, why were you plotting to destroy our world in the first place?``"
 	},
 	{
 		"type": "MSGSET",
@@ -93,7 +93,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0950.",
 		"TextJPN": "「我、全部食い尽くすのがチョー大好きなのです！」",
 		"NamesENG": "Une",
-		"TextENG": "``I love it, I will devour you all superly!``"
+		"TextENG": "``Because we super love consuming everything!``"
 	},
 	{
 		"type": "MSGSET",
@@ -102,7 +102,7 @@
 		"PreTextTags": "@vS25/02/NREN_1350.",
 		"TextJPN": "「それで、全てを食べ尽くして滅ぼして。次の星に出会うまでどれくらいかかるの？」",
 		"NamesENG": "Rena",
-		"TextENG": "``So, you want to eat everything up and destroy it. How long would it take until you would encounter the next star?``"
+		"TextENG": "``So then what about after you've consumed and ruined everything? How long does it take you to find a new planet?``"
 	},
 	{
 		"type": "MSGSET",
@@ -111,7 +111,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0960.",
 		"TextJPN": "「ん～…………」",
 		"NamesENG": "Une",
-		"TextENG": "``Eh............``"
+		"TextENG": "``Hmm.........``"
 	},
 	{
 		"type": "MSGSET",
@@ -120,7 +120,7 @@
 		"PreTextTags": "@vS25/02/NREN_1360.",
 		"TextJPN": "「気の遠くなるような時間が掛かるんじゃない？　その間、ひとりぼっちで寂しいんじゃないかな、かな」",
 		"NamesENG": "Rena",
-		"TextENG": "``Wouldn't moving to such a distant star take a long time? Meanwhile, I wonder if you would be lonely all by yourself, I wonder.``"
+		"TextENG": "``It takes long enough to drive you crazy, doesn't it? And I'm betting you're feeling lonely that whole time, aren't you? Aren't you?``"
 	},
 	{
 		"type": "MSGSET",
@@ -129,7 +129,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0970.",
 		"TextJPN": "「…………んんんん……。でも、……田村が出て行けというから、……我、チョー頭に来て……。最初は、静かに暮らそうかと思ったのです……」",
 		"NamesENG": "Une",
-		"TextENG": "``............Ehhhh...... But...... Tamura told me to leave...... so, I got mad...... At first, I intended to live quietly......``"
+		"TextENG": "``.........Nnnnnh...... But...... Tamura told me to get out...... That super ticked me off...... At first I thought about living here peacefully......``"
 	},
 	{
 		"type": "MSGSET",
@@ -138,7 +138,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1040.",
 		"TextJPN": "「田村の意地悪が全ての元凶なのですよ！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``See, malicious Tamura was the cause after all!``"
+		"TextENG": "``Tamura's bullying is the root of all evil!``"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0390.",
 		"TextJPN": "「そなたらがウネを市外に脱出させたことこそが致命的也や！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Allowing Une to escape into the suburbs would have been fatal for me!``"
+		"TextENG": "``You all would have made the fatal mistake of letting Une escape the city!``"
 	},
 	{
 		"type": "MSGSET",
@@ -156,7 +156,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1470.",
 		"TextJPN": "「つまりだ。ウネが世界を滅ぼそうとしたのは、この星から出て行けと田村媛命に言われたからと」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``In other words. Une was only trying to destroy this world, because Tamurahime no Mikoto told her to leave this star.``"
+		"TextENG": "``So in short, Une decided to destroy the world because Tamurahime-no-Mikoto told her to get off this planet.``"
 	},
 	{
 		"type": "MSGSET",
@@ -165,7 +165,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0980.",
 		"TextJPN": "「……はいなのです……」",
 		"NamesENG": "Une",
-		"TextENG": "``......Yes......``"
+		"TextENG": "``......Yes, that's right......``"
 	},
 	{
 		"type": "MSGSET",
@@ -174,7 +174,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1500.",
 		"TextJPN": "「んで、田村ちゃんは喧嘩したオヤシロさまこと羽入ちゃんに相談せずに、性質の悪い方法で解決しようとしたと」",
 		"NamesENG": "Mion",
-		"TextENG": "``Hmm, so Tamura-chan quarreled with Hanyuu-chan, also known as Oyashiro-sama, without consulting her beforehand, and then tried to solve this situation by herself in a bad way out of disposition.``"
+		"TextENG": "``So then Tamura-chan refused to talk to Hanyuu-chan or Oyashiro-sama about it because they fought, and decided to resolve it herself using terrible methods.``"
 	},
 	{
 		"type": "MSGSET",
@@ -183,7 +183,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0400.",
 		"TextJPN": "「不浄の民の手など借りたくなかった也や！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``I could never owe a debt to such an impurity!``"
+		"TextENG": "``I didn't want to borrow any help from the tainted people!``"
 	},
 	{
 		"type": "MSGSET",
@@ -192,7 +192,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0700.",
 		"TextJPN": "「そもそもの不仲の原因は、羽入さんのお供え泥棒に端を発するわけですわね？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``And the discord between you two originally stems from when Hanyuu-san stole one of your offerings, right?``"
+		"TextENG": "``Yet the whole reason they're on bad terms in the first place, is because Hanyuu-san stole some of her offerings, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -201,7 +201,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1050.",
 		"TextJPN": "「僕のせいですか？！　僕が一番の元凶扱いは納得できませんのですよー！　あうあうあう！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Why are you blaming me?! I don't understand why you're treating me as one of the causes! Au au au!!``"
+		"TextENG": "``It's my fault?! I can't believe you're treating me like I'm the main cause of all this! Auauau!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -210,7 +210,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1510.",
 		"TextJPN": "「はいはい、静粛に！！　被告の言い分はわかったよ！　つまりは、あんたたち３人が仲良くしなかったからいけないわけだね！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Yes yes, now be silent!! I understand the case of the defendant! In other words, this is all because the three of you didn't get along, right?``"
+		"TextENG": "``Yes, yes, quiet!! We've heard the defendants' excuses! To sum up, you're all at fault because you three couldn't get along!``"
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS25/02/NREN_1370.",
 		"TextJPN": "「ウネちゃんだって、長い孤独な旅の末に地球に辿り着いたわけだし。田村ちゃんも、少しは受け入れてあげてもよかったんじゃないかな、かな」",
 		"NamesENG": "Rena",
-		"TextENG": "``Even after Une-chan arrived at the earth after a long lonely journey. Tamura-chan, I wonder if you could have accepted her even just a little, I wonder.``"
+		"TextENG": "``Une-chan finally made it here to Earth after her long, isolated journey too. I think Tamura-chan could have tried to accept her a bit more. Just a bit.``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,7 +228,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1480.",
 		"TextJPN": "「田村媛命もさ。お供え物を勝手に食われた恨みはわかるけどよ。それで千年仲違いで、この肝心な時に相談も協力もせず、独断的な方法に訴えるってのは、あまり褒められたもんじゃねぇなぁ？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``You too, Tamurahime no Mikoto. I can understand your resentment at having your offerings eaten without your permission. I'm sure you can understand the resentment of having your offerings eaten without permission, but to have a thousand years of differences, and then to resort to arbitrary methods without consulting or cooperating at this crucial time, is not very admirable, is it?``"
+		"TextENG": "``And Tamurahime-no-Mikoto, I can understand you might resent her for eating your offering. But to stay on bad terms for a thousand years and then refuse to consult her or ask for her help in a time of need, only to ultimately take drastic actions on your own, isn't very praiseworthy either, you know?``"
 	},
 	{
 		"type": "MSGSET",
@@ -237,7 +237,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0710.",
 		"TextJPN": "「そもそも、羽入さんが素直に謝っていれば拗れなかった問題ですわ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``In the first place, Hanyuu-san shouldn't have complicated the issue and apologized obediently.``"
+		"TextENG": "``For starters, this whole problem became more complicated because Hanyuu-san just refused to apologize.``"
 	},
 	{
 		"type": "MSGSET",
@@ -246,7 +246,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1060.",
 		"TextJPN": "「ご飯一杯くらいで、あんなに怒ることはなかったのですよ！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``It was only one cup of rice, she shouldn't have gotten so angry!!``"
+		"TextENG": "``No one should get that mad over just one meal!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -255,7 +255,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0410.",
 		"TextJPN": "「こんな腹ペコ空っぽシュークリームと仲直りなんて、吾輩は絶対に御免也や！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``I will never be able to make peace with this hungry, empty cream puff!!``"
+		"TextENG": "``I will never reconcile with that starving, empty-headed, cream puff!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -264,7 +264,7 @@
 		"PreTextTags": "@vS25/50/NUNE_0990.",
 		"TextJPN": "「我だって、少しだけ花壇を分けて欲しかっただけなのです。なのに、田村が意地悪を！」",
 		"NamesENG": "Une",
-		"TextENG": "``Even I only wanted you to distribute the flower bed just a little. But despite this, Tamura was malicious!``"
+		"TextENG": "``I just wanted you to share a little bit of this flower bed with me. Yet you bullied me, Tamura!``"
 	},
 	{
 		"type": "MSGSET",
@@ -273,7 +273,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1070.",
 		"TextJPN": "「ほらほら見ましたですか？！　やはり全ての元凶は田村なのです！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Look, look, can't you see?! Tamura was the cause after all!``"
+		"TextENG": "``See, see, did you see?! This really is all Tamura's fault!``"
 	},
 	{
 		"type": "MSGSET",
@@ -282,7 +282,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0420.",
 		"TextJPN": "「ウネこそが全てを滅ぼす悪魔也や！　ウネこそが全ての元凶！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Une is a devil which would have ruined us all! Une is the ringleader!!``"
+		"TextENG": "``Une is a devil that would destroy everything! Une is the one to blame for all this!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@vS25/50/NUNE_1000.",
 		"TextJPN": "「……そもそも、田村が異民族嫌いになった発端は、羽入が勝手に盗み食いをしたせいのように思いますのです。羽入が盗み食いをしなかったら、田村も異民族を嫌いにならず、我を受け入れてくれたかもしれないのです」",
 		"NamesENG": "Une",
-		"TextENG": "``......In the first place, it was Tamura's fault for having such a different ethnophobia from the beginning, but I think that was the result of Hanyuu stealing her food without permission, so she is to blame also. Because if Hanyuu did not steal her food, then Tamura wouldn't have started to hate different ethnic groups, and would have accepted me.``"
+		"TextENG": "``......I think Tamura's hatred for the other races all started when Hanyuu went and stole food from her. If Hanyuu hadn't done that, then Tamura wouldn't hate outsiders, and she might have accepted me.``"
 	},
 	{
 		"type": "MSGSET",
@@ -300,7 +300,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0430.",
 		"TextJPN": "「ふむふむ、まったくにもってその通り也やと知り奉れ！！　このシュークリーム頭こそが元凶也や！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Hmph hmph, That's exactly what I want you to know. This cream puff head is the culprit!``"
+		"TextENG": "``Mhmm, you know that is exactly right!! This cream puff for brains is the cause of all this!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -309,7 +309,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1080.",
 		"TextJPN": "「僕が元凶扱いなんて納得いかないのですよぉおお！！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I can't accept that I'm being treated as the source of the problem!``"
+		"TextENG": "``I refuse to be treated like I'm the one to blame!!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -318,7 +318,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1520.",
 		"TextJPN": "「えぇい、静粛にぃいいぃ！！　というわけで判決！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ahhh, be silent!! So I can rule judgment!!"
+		"TextENG": "``Argh! Silennnnce!! Now, we'll hand out the verdict!!"
 	},
 	{
 		"type": "MSGSET",
@@ -327,7 +327,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1530.",
 		"TextJPN": "「３人は等しく仲良く出来なかった罪で、部活ゲーム刑に処す！！」",
 		"NamesENG": "Mion",
-		"TextENG": "By the crime that you three people were not able to get along well equally, I sentence you to a club game punishment!!``"
+		"TextENG": "All three of you are equally guilty of the crime for failing to get along, so your punishment is having to play games in our club!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -336,7 +336,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1500.",
 		"TextJPN": "「くす。あんたたち３人で楽しくゲームをして、交流を深めて、いざこざを全て水に流してしまいましょうっていう、古手神社の巫女の寛大なお沙汰よ」",
 		"NamesENG": "Rika",
-		"TextENG": "``Heh heh. The shrine maiden of Furude Shrine has graciously offered to let the three of you play a fun game, deepen your relationship, and put all your troubles behind you.``"
+		"TextENG": "``Heehee. The three of you can happily play games together and deepen your camaraderie, so you can all forgive and forget when it matters most. Consider this a generous sentence from the priestess of the Furude shrine.``"
 	},
 	{
 		"type": "MSGSET",
@@ -345,7 +345,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0720.",
 		"TextJPN": "「ほっほっほっほ！　ゲームで楽しく親睦を深めてもらうだけでしてよ！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Ho ho ho ho! Have fun deepening your friendship in this game!``"
+		"TextENG": "``Hohohoho! You'll just be deepening your friendship over some fun games!``"
 	},
 	{
 		"type": "MSGSET",
@@ -354,7 +354,7 @@
 		"PreTextTags": "@vS25/02/NREN_1380.",
 		"TextJPN": "「みんなで楽しく同じ経験をすれば、仲もきっと良くなれると思うかな、かな！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Everyone should have the same fun experience, I wonder if your relations will surely improve that way, I wonder!``"
+		"TextENG": "``Once you've all had fun enjoying the same experiences, I'm sure you'll get along better! I'm sure!``"
 	},
 	{
 		"type": "MSGSET",
@@ -363,7 +363,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1490.",
 		"TextJPN": "「神様だけじゃないぜ！　俺たち人間も混じって、わいわいと賑やかに行こうじゃねぇか！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``But it won't only be you Gods! We humans will join in too, it wouldn't be lively and noisy enough if we didn't!``"
+		"TextENG": "``It won't just be you gods either! We humans will join in too, to really make this a lively affair!``"
 	},
 	{
 		"type": "MSGSET",
@@ -372,7 +372,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1540.",
 		"TextJPN": "「ただーし！　……部活メンバーに接待プレイは存在しないけどねぇ？　くっくっくっくっく！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``However! ......This won't be fun for club members, you see. Hee hee hee hee hee!!``"
+		"TextENG": "``However! ......We club members never take it easy on opponents, do we? Kukukukuku!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -381,7 +381,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0730.",
 		"TextJPN": "「神様の喧嘩に人間を巻き込んでくださったお礼を、たーっぷりお返しして差し上げましてよー！！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``So as thanks for involving us humans in a quarrel of Gods, this will be our return gift!!``"
+		"TextENG": "``We'll have to show you plenty of our gratitude for getting us humans caught up in your fight between gods!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -390,7 +390,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1550.",
 		"TextJPN": "「神様の争いだけで、私たちが参戦できないのは面白くないからね～！　人間を舐めちゃいけないってことを、この機会にターップリ勉強してってもらおうと思ってね～？　にっひっひ～！」",
 		"NamesENG": "Mion",
-		"TextENG": "``It wouldn't be fun if we couldn't participate in the war because it's just Gods War~! I thought I'd take this opportunity to let you learn that you shouldn't underestimate humans, you know~? Hee hee hee~!``"
+		"TextENG": "``It's no fun when you gods fight by yourselves and we can't participate! So we'll take this opportunity to teach all three of you that you shouldn't take humans lightly, okay? Nihihi!``"
 	},
 	{
 		"type": "MSGSET",
@@ -399,7 +399,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0440.",
 		"TextJPN": "「何と愚か也や！　我ら神々が、人の子の遊戯如きで後れを取ると思った也や」",
 		"NamesENG": "Tamura",
-		"TextENG": "``What fools! To expect us Gods to play with such backwards children of man.``"
+		"TextENG": "``What fools! We are gods! We will not be defeated in the mere games of man!``"
 	},
 	{
 		"type": "MSGSET",
@@ -408,7 +408,7 @@
 		"PreTextTags": "@vS25/50/NUNE_1010.",
 		"TextJPN": "「我、人の子如きに後れなどチョー取らないのです。くっふっふっふ！」",
 		"NamesENG": "Une",
-		"TextENG": "``I superly don't have a problem playing with the backwards children of man. Hee hee hee hee!``"
+		"TextENG": "``I'll totally never be defeated by mere humans. Kfufufu!``"
 	},
 	{
 		"type": "MSGSET",
@@ -417,7 +417,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1090.",
 		"TextJPN": "「ほほう、それは神々への人の子の挑戦と受け取っていいのですね？」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Hoo hoo, so children of man want to challenge Gods?"
+		"TextENG": "``Oh-ho? So you humans are challenging the gods?"
 	},
 	{
 		"type": "MSGSET",
@@ -426,37 +426,37 @@
 		"PreTextTags": "@vS25/12/NHAN_1100.",
 		"TextJPN": "「僕たちも手加減はしませんのですよ？！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "We're not going to go easy on you!``"
+		"TextENG": "Then we won't hold back either!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155534,
 		"TextJPN": "田村媛命は堅実。攻撃よりも守備を重んじるスタイルは手強いはず。",
-		"TextENG": "Tamurahime no Mikoto is solid. Her firm style favors defense than attack."
+		"TextENG": "Tamurahime-no-Mikoto was a steady player. Her style focused on defense more than offense, so she should've been a tough opponent."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155535,
 		"TextJPN": "ウネは狡猾さでの自在の立ち回りで、きっと華麗に翻弄してくるだろう。",
-		"TextENG": "Une fights freely and is cunning, she will surely monkey around splendidly."
+		"TextENG": "Une was likely to toy with us magnificently using her sly tricks and fluid adaptability."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155536,
 		"TextJPN": "そして羽入には、意味不明の馬鹿ヅキ、幸運がある。運の絡むゲームではある意味最強だ！",
-		"TextENG": "And Hanyuu, she is a fool of unknown meaning, with good luck. So in that sense, she will be the strongest in this game affected by luck!"
+		"TextENG": "Then Hanyuu had her indecipherable dumb luck. She was the greatest opponent in a game involving chance!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155537,
 		"TextJPN": "仮にも神々。人間如きとゲームをして、負けるはずなどない。",
-		"TextENG": "Meaning, they are all no longer Gods. But humans playing a game, so they have nothing to lose."
+		"TextENG": "They were still gods. There was no reason for them to lose a game to humans."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 155538,
 		"TextJPN": "しかし、……部活メンバーは、ことゲームにおいては人にあらず！",
-		"TextENG": "However...... as club members, there will always be a punishment for playing such a game!"
+		"TextENG": "However... when it came to games, the club members weren't human either!"
 	},
 	{
 		"type": "MSGSET",
@@ -465,7 +465,7 @@
 		"PreTextTags": "@vS25/02/NREN_1390.",
 		"TextJPN": "「じゃあ、親は田村ちゃんだから、田村ちゃんから捨ててね」",
 		"NamesENG": "Rena",
-		"TextENG": "``Well, you're quite the dealer, Tamura-chan. Now cast them aside, Tamura-chan.``"
+		"TextENG": "``Well, since Tamura-chan's the dealer, she discards first.``"
 	},
 	{
 		"type": "MSGSET",
@@ -474,7 +474,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0450.",
 		"TextJPN": "「ふっふっふ！　神の強運を思い知り給え！！　@bハツ.@<發@>を切ってダブル@bリーチ.@<立直@>と知り奉れッ！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Hee hee hee! Realize the good luck of God!! And know that I start with a double riichi!``"
+		"TextENG": "``Fufufu! Know the powerful luck of the gods!! I am discarding a green dragon and declaring double riichi!``"
 	},
 	{
 		"type": "MSGSET",
@@ -483,7 +483,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1560.",
 		"TextJPN": "「御無礼！　@bレンホー.@<人和@>、@bリューイーソー.@<緑一色@>、@bスーアンコー.@<四暗刻@>単騎！　４倍役満、１２万８千！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``How rude! Renhou, ryuuiisou, suu ankou tanki! Four bai yakuman, 128,000!!``"
+		"TextENG": "``Pardon me! Hand of man, all green, four concealed triplets, single wait! That's four yakuman, or 128,000 points!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -492,7 +492,7 @@
 		"PreTextTags": "@vS25/02/NREN_1400.",
 		"TextJPN": "「私もロ～ン！　@bレンホー.@<人和@>、@bチートイツ.@<七対子@>、赤々ドラドラ、ただの役満、３万２千点～！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``I will ron~! Renhou, chitoitsu, aka dora dora, yakuman, 32,000 points~!!``"
+		"TextENG": "``Ron for me too! Hand of man, seven pairs, red, red, dora, dora, so just a simple yakuman for 32,000 points!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -501,7 +501,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0460.",
 		"TextJPN": "「んなッ、なななななななななッ？！？！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``Whwh... ...whawhawhawhawhawhawhawhawhat?!?!``"
+		"TextENG": "``Wha?! W-W-W-W-W-W-W-W-Wha?!?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -510,7 +510,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1500.",
 		"TextJPN": "「おっと、田村。まだ嘆くのは早いぜ～？　トリロンありだったよなぁ？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Uh-oh, Tamura. Isn't it a little too early to grieve? This a tori ron, right?``"
+		"TextENG": "``Hey, Tamura. It's still too early to cry. Triple rons are allowed, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -519,7 +519,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1510.",
 		"TextJPN": "「こっちもロンだぜ！　@bレンホー.@<人和@>、@bダイスーシー.@<大四喜@>、@bツーイーソー.@<字一色@>、@bスーアンコー.@<四暗刻@>単騎、６倍役満直撃、１９万２千だぁあああぁッ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``So I think I'll ron also! Renhou, daisuushi, tsuiso, suu ankou tanki, 6-bai yakuman, direct hit 192,000!!!!!!``"
+		"TextENG": "``Then a ron for me too! Hand of man, big four winds, all honors, four concealed triplets, single wait. That's six yakuman straight from you for 192,000 poiiiiints!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -528,7 +528,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0470.",
 		"TextJPN": "「ちょ、直撃３５万２千？！？！　そ、そんなこと有り得ない也や！　ぎゃわわ～んッ！！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``D-Direct hit, 352,000?!?! Such a thing is impossible! Gyawawa~n!!!``"
+		"TextENG": "``3-352,000 straight from me?!?! T-That's impossible! Gyawawahn!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -537,7 +537,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0740.",
 		"TextJPN": "「をーっほっほっほ！！　卓の点棒を全て集めても足りませんでしてよ～！！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Oh ho ho ho!! You lost even though you gathered all the point sticks on the table!!``"
+		"TextENG": "``Ohhohoho!! There's not enough to pay that, even if we collected all the point sticks from the table!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -546,7 +546,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1520.",
 		"TextJPN": "「さぁ！！　罰ゲームの衣装はこれだーーーッ！！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Now!! The costume of todays punishment game is this!!!``"
+		"TextENG": "``Now!! Here's your punishment game outfit---!!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -555,7 +555,7 @@
 		"PreTextTags": "@vS25/51/NTAM_0480.",
 		"TextJPN": "「わ、吾輩がこのような辱めを受けるとは納得出来ぬ也や～ッ！！」",
 		"NamesENG": "Tamura",
-		"TextENG": "``I-I cannot believe you convinced me to undergo such humiliation!!``"
+		"TextENG": "``I-I don't understand why I must bear such disgrace!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -564,7 +564,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1510.",
 		"TextJPN": "「にぱ～☆　かわいそかわいそなのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``Nipah~☆, you look so cute and pretty.``"
+		"TextENG": "``Nipah! Poor thing, poor thing.``"
 	},
 	{
 		"type": "MSGSET",
@@ -573,7 +573,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0750.",
 		"TextJPN": "「スクール水着姿で偉そうにされても、滑稽にしか見えませんでしてよ？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``You know, it's funny to see you in a school swimsuit looking all high and mighty..``"
+		"TextENG": "``Still, this is an incredible outfit. What's it even from?``"
 	},
 	{
 		"type": "MSGSET",
@@ -582,7 +582,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1520.",
 		"TextJPN": "「にぱ～☆　その姿でご主人さまにご奉仕ご奉仕なのですよ☆」",
 		"NamesENG": "Rika",
-		"TextENG": "``Nipah~☆ You'll be serving your master in that form.☆.``"
+		"TextENG": "``Nipah! It's a dream collaboration with Blahblahblah so she can pretend to be an adult pro-wrestler!``"
 	},
 	{
 		"type": "MSGSET",
@@ -591,7 +591,7 @@
 		"PreTextTags": "@vS25/02/NREN_1410.",
 		"TextJPN": "「じゃ～ん！　これでアガリ～！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Ta-da! Agari for me!``"
+		"TextENG": "``Tada! Now I'm out!``"
 	},
 	{
 		"type": "MSGSET",
@@ -600,7 +600,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0760.",
 		"TextJPN": "「をっほっほっほ！　私もこれでアガリでしてよー！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Oh ho ho ho! It's agari for me, too!``"
+		"TextENG": "``Ohhohoho! I'm out now too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -609,7 +609,7 @@
 		"PreTextTags": "@vS25/50/NUNE_1020.",
 		"TextJPN": "「わ、我も、あと１枚でチョーアガリなのです……！」",
 		"NamesENG": "Une",
-		"TextENG": "``I-I should have gotten super agari last turn, too......!``"
+		"TextENG": "``I-I'm just one card away from totally being out......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -618,7 +618,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1570.",
 		"TextJPN": "「おぉっとぉ、残念！　ラス１の宣言してなぁい！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Uh-oh! You didn't say 'The Last One'!!``"
+		"TextENG": "``Hold it! You didn't say uno!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -627,7 +627,7 @@
 		"PreTextTags": "@vS25/50/NUNE_1030.",
 		"TextJPN": "「ぎゃわッ？！　チョーぎゃわわ～んッ！！」",
 		"NamesENG": "Une",
-		"TextENG": "``Gyawa?! Super gyawawa~n!!``"
+		"TextENG": "``Gyawa?! Super gyawawahn!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -636,7 +636,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1530.",
 		"TextJPN": "「あらよっと、俺もアーガリぃ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Off we go, agari for me, too!``"
+		"TextENG": "``And there, I'm out too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -645,7 +645,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1530.",
 		"TextJPN": "「ボクもこれでアガリなのですよ、にぱ～☆」",
 		"NamesENG": "Rika",
-		"TextENG": "``It seems like I have agari too, nipah~☆.``"
+		"TextENG": "``Now I'm out too, nipah!``"
 	},
 	{
 		"type": "MSGSET",
@@ -654,7 +654,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1580.",
 		"TextJPN": "「んで、これで私がアガってぇ！　ビリっけつはウネちゃんに決定～！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Hmm, I also have agari! It's been decided, you're in last place, Une-chan!!``"
+		"TextENG": "``So, now I'm out! Looks like last place goes to Une-chan!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -663,7 +663,7 @@
 		"PreTextTags": "@vS25/50/NUNE_1040.",
 		"TextJPN": "「わッ、我！　こんな格好、チョー恥ずかしいのですー！！」",
 		"NamesENG": "Une",
-		"TextENG": "``I, I! In such an appearance, super embarrassed!!``"
+		"TextENG": "``T-This! This outfit is super embarrassing on me!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -672,7 +672,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1540.",
 		"TextJPN": "「にぱ～☆　かわいそかわいそなのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``Nipah~☆, you look so cute and pretty.``"
+		"TextENG": "``Nipah! Poor thing, poor thing.``"
 	},
 	{
 		"type": "MSGSET",
@@ -681,7 +681,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0770.",
 		"TextJPN": "「似合いすぎて逆に危ないですわね。圭一さん、鼻血出すんじゃありませんの？」",
 		"NamesENG": "Satoko",
-		"TextENG": "``It looks so good on you that it's dangerous. Keiichi-san, aren't you going to get a nosebleed?``"
+		"TextENG": "``This is another cruel outfit. What is this one from?``"
 	},
 	{
 		"type": "MSGSET",
@@ -690,7 +690,7 @@
 		"PreTextTags": "@vS25/05/NRIK_1550.",
 		"TextJPN": "「きっと、富竹たちにも大人気間違いなしなのですよ。にぱ～☆」",
 		"NamesENG": "Rika",
-		"TextENG": "``I'm sure it will be very popular with Tomitake and others. Nipah~☆``"
+		"TextENG": "``It's an indecent outfit that came up when I googled 'embarrassing outfits'. Nipah!``"
 	},
 	{
 		"type": "MSGSET",
@@ -699,7 +699,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1110.",
 		"TextJPN": "「僕は二人のようにはやられないのですよ、あぅあぅ！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``As for me, I hope I don't get a popular one like those two, au au!!``"
+		"TextENG": "``You won't take me down like you did those two. Auau!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -708,7 +708,7 @@
 		"PreTextTags": "@vS25/02/NREN_1420.",
 		"TextJPN": "「ではゲームを開始するね～！　それでは狼さん、顔を上げて下さい。続いて占い師、顔を上げて下さ～い」",
 		"NamesENG": "Rena",
-		"TextENG": "``Let the game begin!　Then, wolf, please raise your face. Then, fortune teller, please raise your head.``"
+		"TextENG": "``Now, let the game begin! Will the wolf please raise your head. Now, the fortune teller, please raise your head.``"
 	},
 	{
 		"type": "MSGSET",
@@ -717,7 +717,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1590.",
 		"TextJPN": "「ハーイ！　カミングアウトします、おじさんは占い師です！　羽入ちゃんは狼でーす！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Yes! It's coming out, Old Man has fortune-teller! And Hanyuu-chan has wolf!!``"
+		"TextENG": "``Okay! I'm revealing myself! I'm the fortune teller! Hanyuu-chan is the wolf!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -726,7 +726,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1120.",
 		"TextJPN": "「あぅあぅあぅ？！？！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Au au au?!?!``"
+		"TextENG": "``Auauau?!?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -735,7 +735,7 @@
 		"PreTextTags": "@vS25/04/NSAT_0780.",
 		"TextJPN": "「では、全会一致で初日の生贄は、」",
 		"NamesENG": "Satoko",
-		"TextENG": "``Well, it seems you're the unanimous sacrifice for the first day.``"
+		"TextENG": "``So then with a unanimous vote, our sacrifice for the first day is...``"
 	},
 	{
 		"type": "MSGSET",
@@ -744,7 +744,7 @@
 		"PreTextTags": "@vS25/01/NKEI_1540.",
 		"TextJPN": "「決定だぜ！　吊るされるのは羽入だぁああぁぁ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``It's decided! Hanyuu will hang!!!!``"
+		"TextENG": "``Decided! We're hanging Hanyuuuuu!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -753,7 +753,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1130.",
 		"TextJPN": "「ゲ、ゲームにさえ参加できないいいぃいいぃ！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I can't participate even in a g-game!!``"
+		"TextENG": "``I-I didn't even get to participate in the gaaaaaaame!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -762,7 +762,7 @@
 		"PreTextTags": "@vS25/03/NMIO_1600.",
 		"TextJPN": "「くっくっく！　さぁ、羽入ちゃんも罰ゲームの衣装に着替えてもらおうかねぇ～？」",
 		"NamesENG": "Mion",
-		"TextENG": "``Hee hee hee! Now, won't you change into your punishment game costume, Hanyuu-chan?``"
+		"TextENG": "``Kukuku! Now to have Hanyuu-chan change into her punishment outfit too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -771,7 +771,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1140.",
 		"TextJPN": "「やめるのです！　僕にも恥ずかしい服を着せる気なのですね？！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Stop! Are you going to dress me in some indecent clothes as well?!``"
+		"TextENG": "``Stop it! You're planning to make me wear something indecent, aren't you?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -780,7 +780,7 @@
 		"PreTextTags": "@vS25/12/NHAN_1150.",
 		"TextJPN": "「薄い本みたいに、薄い本みたいにっ！！」",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``Like an ero doujin, like an ero doujin!!``"
+		"TextENG": "``Like something from an erotic doujinshi!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -790,7 +790,7 @@
 		"TextJPN": "「……………うりゅ～」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``...............Au.``"
+		"TextENG": "``............Au.``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -800,7 +800,7 @@
 		"TextJPN": "「これからは神様同士仲良くする也や、もう許して奉れ～っ」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Tamura",
-		"TextENG": "``It seems we Gods will have to get along from now on, so you have my permission.``"
+		"TextENG": "``I promise the three of us gods will get along now! So spare us already!``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -810,7 +810,7 @@
 		"TextJPN": "「我も、チョー改心するのですー！」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Une",
-		"TextENG": "``I will superly reform myself, too!``"
+		"TextENG": "``I'm super repenting too!``@e"
 	},
 	{
 		"type": "LOGSET",
@@ -828,7 +828,7 @@
 		"TextJPN": "「………………………」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``...........................``"
+		"TextENG": "``Hau~!!! So kyute!! I'm taking you home~!!!``@e"
 	},
 	{
 		"type": "MSGSET",
@@ -838,6 +838,6 @@
 		"TextJPN": "「な、………納得できないのですーッ！！」",
 		"AfterTextTags": "@e",
 		"NamesENG": "Hanyuu",
-		"TextENG": "``I... ......I can't accept it!!``"
+		"TextENG": "``...........................I......... I won't accept this!!``@e"
 	}
 ]

--- a/outbreak_1.json
+++ b/outbreak_1.json
@@ -18,7 +18,7 @@
 		"PreTextTags": "@vS24/00/NJIE_0000.",
 		"TextJPN": "「こちらは陸上自衛隊です！　本日０４００より雛見沢地区以下、県知事が定めた地域は防疫隔離されました」",
 		"NamesENG": "Self-Defense Force Member",
-		"TextENG": "``This is the Ground Self-Defense Force! The Hinamizawa district as of 0400 today, has been placed under an isolated quarantine by the Regional Governor."
+		"TextENG": "``This is the Japan Ground Self-Defense Force! As of 04:00 today, we have quarantined the Hinamizawa region, and other surrounding regions as designated by the prefectural governor.``"
 	},
 	{
 		"type": "MSGSET",
@@ -27,7 +27,7 @@
 		"PreTextTags": "@vS24/00/NJIE_0010.",
 		"TextJPN": "「住民の皆さんはご自宅へ待機をお願いいたします。防災無線やテレビ、ラジオ等での情報収集に努めてください」",
 		"NamesENG": "Self-Defense Force Member",
-		"TextENG": "Everyone, please stay inside your homes, and make an effort to gather information about the disaster prevention, through your TV and radio.``"
+		"TextENG": "``We ask that all the residents of these areas please remain indoors and await further instructions. Please use your televisions, radios, and the disaster management radio system to stay informed.``"
 	},
 	{
 		"type": "MSGSET",
@@ -36,13 +36,13 @@
 		"PreTextTags": "@vS24/00/NJIE_0020.",
 		"TextJPN": "「防疫上の安全が確認されるまで、当地区からの離脱はできません！　繰り返します、当地区からの離脱はできません！　これに従わない場合、国内法によって処罰されます！　どうか皆さん、自宅に戻り冷静な対応をお願いいたします！」",
 		"NamesENG": "Self-Defense Force Member",
-		"TextENG": "``Until safety of the quarantine zone has been confirmed, you cannot leave the district! I repeat, you cannot leave the district! If you do not obey, you will be punished by national law! Everyone, thank you for your kind response and return to your homes!``"
+		"TextENG": "``You will not be permitted to leave this district until we can confirm it is medically safe to do so. We repeat, you will not be permitted to leave this district! Any who do not comply will be dealt with according to national law! So everyone, we must ask that you please return to your homes and remain calm!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153424,
 		"TextJPN": "荒いスピーカーの声は、迷彩ヘリコプターの爆音が混じり、とても聞き取りにくかった。",
-		"TextENG": "The roar of the helicopter, and the rough voice of the speaker were mixed, it was very difficult to hear."
+		"TextENG": "It was really hard to hear that rough voice over the roar of their camouflaged helicopter."
 	},
 	{
 		"type": "MSGSET",
@@ -51,7 +51,7 @@
 		"PreTextTags": "@vS24/00/NANA_0000.",
 		"TextJPN": "「……ィルスが検出されたとのことです。これはＷＨＯ、世界保健機構が指定するウィルスの中でも最も危険な分類に入るもので…、」",
 		"NamesENG": "Announcer",
-		"TextENG": "``......A virus has been detected. The WHO has declared this virus to be one of the most dangerous ever discovered...``"
+		"TextENG": "``...have discovered the outbreak of a previously-unknown virus. This virus has been classified as one of the most hazardous of viruses by the World Health Organization.``"
 	},
 	{
 		"type": "MSGSET",
@@ -60,7 +60,7 @@
 		"PreTextTags": "@vS24/00/NANA_0010.",
 		"TextJPN": "「アメリカ政府よりワクチンの緊急援助の申し出があったことをすでに複数の政府筋が認めており、政府は受け容れの対応に入ったものと思われます」",
 		"NamesENG": "Announcer",
-		"TextENG": "``Sources within the government state that they have already received a proposal of emergency assistance vaccines from the United States government, it is likely they will enter some form of agreement.``"
+		"TextENG": "``Several government sources have already confirmed an offer from the American government to provide emergency assistance in developing a vaccine. We believe our government has already begun preparations to accept their aid.``"
 	},
 	{
 		"type": "MSGSET",
@@ -69,7 +69,7 @@
 		"PreTextTags": "@vS24/00/NANA_0020.",
 		"TextJPN": "「このウィルスは潜伏期間が３０日から５０日ほどで、隔離された住民２０００人分のワクチン確保が急務となっています」",
 		"NamesENG": "Announcer",
-		"TextENG": "``The virus's incubation period ranges from 30 to 50 days, and priority has been placed on ensuring a vaccine for the 2000 residents under quarantine.``"
+		"TextENG": "``This virus has an incubation period stretching 30 to 50 days, and they are scrambling to secure enough vaccine for the 2,000 quarantined residents.``"
 	},
 	{
 		"type": "MSGSET",
@@ -78,7 +78,7 @@
 		"PreTextTags": "@vS24/00/NANB_0000.",
 		"TextJPN": "「現在、雛見沢地区へは電話が殺到しており、ほとんどが不通となっています。県防災本部では、事態把握に支障が出かねないとして…、」",
 		"NamesENG": "Announcer",
-		"TextENG": "``Currently, all telephones to and from the Hinamizawa district have been suspended, preventing the prefectural disaster prevention headquarters from fully grasping the situation...``"
+		"TextENG": "``At the present time, all phone lines to the Hinamizawa district are flooded, and reaching anyone within is nearly impossible. The current congestion is making it difficult for the prefecture's disaster prevention center to ascertain the exact situation...``"
 	},
 	{
 		"type": "MSGSET",
@@ -87,7 +87,7 @@
 		"PreTextTags": "@vS24/00/NANC_0000.",
 		"TextJPN": "「なお、水道水、井戸水の使用を厳禁します！　飲料水は自衛隊給水車によるもの以外は使用しないでください！　また、路上への違法な駐車は災害救援を妨げます。直ちに移動をさせてください！」",
 		"NamesENG": "Announcer",
-		"TextENG": "``In addition, the use of tap and well water is strictly forbidden! Please do not drink anything else other than the water provided to you by the Self-Defense Forces water truck! Also, parking on the street is illegal and will interfere with the disaster relief. Please move your vehicles immediately!``"
+		"TextENG": "``Furthermore, a ban on tap water and well water has been put in place! Please do not consume any water except that provided by the SDF's water trucks! In addition, illegally parking on any roads will hinder the disaster relief efforts! Please relocate your vehicles at once!``"
 	},
 	{
 		"type": "MSGSET",
@@ -96,7 +96,7 @@
 		"PreTextTags": "@vS24/00/NAND_0000.",
 		"TextJPN": "「社明党の海原代表は、自衛隊の災害派遣命令に対し適切な手順が省かれた問題を指摘し、これを軍国主義へ回帰するものとして激しく非難、アジアでの一層の孤立化を招くものとして…、」",
 		"NamesENG": "Announcer",
-		"TextENG": "``Various political parties have also stated that the appropriate procedure was omitted by the disaster relief command for the Self-Defense Forces, and criticized this as a heavy return to militarism, that will only lead to further isolation within Asia...``"
+		"TextENG": "``Representative Unabara of the Democratic Socialist Party has criticized the avoidance of proper procedures in ordering the dispatch of SDF disaster relief, strongly voicing his opinion that this is a step backward toward militarism, which could lead to further isolation of our nation within the Asian political community...``"
 	},
 	{
 		"type": "MSGSET",
@@ -105,7 +105,7 @@
 		"PreTextTags": "@vS24/00/NSAI_0000.",
 		"TextJPN": "「こちらは災害対策本部です！　本日１２時より、以下に定める場所にて一斉診察が行なわれます。町会、自治会の指示に従って参集してください。特別な事情がない限り、必ず受診してください！　体調に異常が認められる方は必ずその旨、」",
 		"NamesENG": "Disaster Countermeasures",
-		"TextENG": "``This is the Prefectural Disaster Countermeasures Headquarters! From noon today, a mass medical examination will be carried out at the location set forth below. Everyone, please gather accordingly following instructions from your local neighborhood association. Unless you are under special circumstances, please undergo the medical examination by all means! The only excepted to this examination are those under extreme physical health conditions.``"
+		"TextENG": "``This is the Prefecture Disaster Prevention Center! At 12:00 today, we shall conduct simultaneous medical examinations in the following locations. Please follow the instructions of your town or neighborhood council as you assemble there. Please make certain you get examined unless you have extenuating circumstances! If you notice any symptoms of illness, you must...``"
 	},
 	{
 		"type": "MSGSET",
@@ -114,7 +114,7 @@
 		"PreTextTags": "@vS24/00/NJIE_0030.",
 		"TextJPN": "「こちらは陸上自衛隊です！　当地区は防疫上の理由から県知事の判断により緊急に隔離されました」",
 		"NamesENG": "Self-Defense Force Member",
-		"TextENG": "``This is the Ground Self-Defense Force! The district has been placed under quarantine at the discretion of the prefectural governor to prevent further spread of the epidemic."
+		"TextENG": "``This is the JGSDF! By order of your prefectural governor, this region has been quarantined to prevent the further spread of disease.``"
 	},
 	{
 		"type": "MSGSET",
@@ -123,49 +123,49 @@
 		"PreTextTags": "@vS24/00/NJIE_0040.",
 		"TextJPN": "「隔離地区からの離脱はできません！　皆さんへの食料、飲料水、生活必需品、電力、通信の自由は保障されます！　どうか冷静な対応をお願いいたします！！」",
 		"NamesENG": "Self-Defense Force Member",
-		"TextENG": "It is impossible to leave the quarantine area! Food, drinking water, daily necessities, and electricity will be provided to everyone, the freedom of communications are also guaranteed! Please respond in a calm and ordinary manner!!``"
+		"TextENG": "``You are not permitted to leave the quarantine zone! We promise to secure food, water, other daily necessities, electricity, and communication systems for everyone! Please continue to remain calm!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153434,
 		"TextJPN": "退屈で平凡な日常は、ある日突然に打ち破られた。",
-		"TextENG": "My ordinary boring life became suddenly broken overnight."
+		"TextENG": "All of a sudden one day, the peaceful boredom of everyday life was shattered."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153435,
 		"TextJPN": "誰もがいつもと変わりない初夏の朝を疑わずに起床しただろう。空の青さだっていつも通りだったし、昇ってきた太陽だってそれを疑わなかったに違いない。",
-		"TextENG": "I would get up every morning in early summer. See the blue sky as always, and watch the sun rise."
+		"TextENG": "I doubt anyone woke up today expecting it to be any different from an ordinary early summer morning. The sky was just as blue as ever, and the sun rose just as it always did."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153436,
 		"TextJPN": "だが、低空を飛びまわりスピーカーで怒鳴り続けるヘリコプターと、町への幹線道路が封鎖され渋滞している光景を見て、人々は今朝がこれまでの朝とはあまりに異質であることを知るのだった。",
-		"TextENG": "But, as I watched helicopters fly low with blaring loudspeakers, and saw the blocked congested main road to the town, I knew that this was not an ordinary morning."
+		"TextENG": "Yet, the helicopters flying at low altitudes with their speakers blaring, and the sight of traffic backed up at a blockade on the main road into the city, were enough to let everyone know that this morning was anything but normal."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153437,
 		"TextJPN": "早朝の混乱は、朝のニュースが放送される頃には一定の収まりを見せていた。",
-		"TextENG": "The confusion in early morning set the tone alongside the morning news broadcast."
+		"TextENG": "By the time it was broadcast on the morning news, the confusion had already settled down to a degree."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153438,
 		"TextJPN": "雛見沢の住民たちはその非常放送を、どこか遠くの町での出来事のように感じずにはいられなかったが、…それは紛れもなく、自分たちの住まう郷里に起こった異常事態だったのである…。",
-		"TextENG": "The inhabitants of Hinamizawa heard the broadcast, although they could not help but feel this was an event in some far-off town... but undeniably, this abnormal situation was happening in their very own home town..."
+		"TextENG": "The residents of Hinamizawa couldn't act like this was all happening in some distant city as they listened to the emergency broadcasts... because there was no doubt that this emergency was happening in the very town we lived in..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153439,
 		"TextJPN": "俺はそのニュースを、いつものようにもそもそと寝床を抜け出して、食堂に下りてきた時、テレビに釘付けになる両親の肩越しに見て知った。",
-		"TextENG": "This was all news to me, as I restlessly got out of bed like always, walked down into the dining room, and leaned over my parents shoulders as they were glued to the TV."
+		"TextENG": "I stirred restlessly in my bed like I usually did before eventually crawling out, and when I came down to our dining room, I found my parents glued to the television, which is where I learned the news, peeking over their shoulders."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153440,
 		"TextJPN": "俺と同じ第一声を口にした村人は、果たして何人いたのだろう。",
-		"TextENG": "I would expect the rest of the village to be doing the same."
+		"TextENG": "I wonder just how many villagers muttered the same thing I did at first?"
 	},
 	{
 		"type": "MSGSET",
@@ -174,7 +174,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0000.",
 		"TextJPN": "「………な、…なんだって…？　何このニュース……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``.........What...? What's happening in the news......``"
+		"TextENG": "``......Wh... What...? What's going on...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -183,7 +183,7 @@
 		"PreTextTags": "@vS24/00/NKMO_0000.",
 		"TextJPN": "「圭一！　大変よ！　あのね、雛見沢がね、悪いウィルスが見付かったとかで隔離されちゃったんですって！」",
 		"NamesENG": "Keiichi's mom",
-		"TextENG": "``Keiichi! This is serious! Hinamizawa has been quarantined after they detected a killer virus!``"
+		"TextENG": "``Keiichi! It's awful! Listen, they've discovered a horrible disease here in Hinamizawa, and they've quarantined the whole village!``"
 	},
 	{
 		"type": "MSGSET",
@@ -192,7 +192,7 @@
 		"PreTextTags": "@vS24/00/NKFA_0000.",
 		"TextJPN": "「困ったなぁ…、これ、いつ解除になるんだ？　明日、大阪のイベントの打ち合わせに出なきゃならないってのになぁ…」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``What terrible timing... Does that mean we have to cancel our trip? We were meant to leave for a business trip in Osaka tomorrow...``"
+		"TextENG": "``This is terrible... when do you think they're going to let us go? I need to head out for a meeting tomorrow for the event in Osaka...``"
 	},
 	{
 		"type": "MSGSET",
@@ -201,7 +201,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0010.",
 		"TextJPN": "「隔離って、……んじゃあ、町へも出られないってこと？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Quarantined...... Does that mean we can't leave the town?``"
+		"TextENG": "``Quarantined? ...Then we can't go into town either?``"
 	},
 	{
 		"type": "MSGSET",
@@ -210,7 +210,7 @@
 		"PreTextTags": "@vS24/00/NKMO_0010.",
 		"TextJPN": "「そうみたいね…。食料の援助とかはあるそうだけど…、困ったわぁ！　今日、興宮で特売があるからって、冷蔵庫の中ほとんど食材がないのよ」",
 		"NamesENG": "Keiichi's mom",
-		"TextENG": "``It seems that way... We also really need some food... this is awkward! There was supposed to be a sale at Okinomiya today, so we've got nothing in the fridge.``"
+		"TextENG": "``Looks like it... They said they'd provide food... but this is a real pain! We barely have anything in our refrigerator since today's when they have that special sale down in Okinomiya.``"
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS24/00/NKFA_0010.",
 		"TextJPN": "「それより、この何とかウィルスはどういうもんなんだ…！　隔離ってくらいだから相当恐ろしいモンなんだろ？！　そのウィルスはどうなってんだ！　ウチにも感染してるってのか？！」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``What exactly will the virus do...! This is scary, do we have to quarantine ourselves?! How the hell does this virus work! Has it already infected the inside of our house?!``"
+		"TextENG": "``More importantly, what is this virus, anyway?! It has to be pretty dangerous if they're quarantining the whole region, right?! What's going on here?! Are we infected too?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,79 +228,79 @@
 		"PreTextTags": "@vS24/01/NKEI_0020.",
 		"TextJPN": "「………シ！　今テレビでその説明してるよ！！　……発症すると、１週間ほどで以下の症状がって、…………ぅ、」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``.........We will be giving an explanation on TV soon!! ......When they develop! Approximately one week following the first symptoms! ............!``"
+		"TextENG": "``......Shh! They're explaining it on the TV right now!! ......Once the initial signs appear, the following symptoms develop over the following week... ...Hhh!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153448,
 		"TextJPN": "家族全員が、……いや、その映像が流れた瞬間、村中が絶句した。",
-		"TextENG": "My whole family...... no, the entire village is at a loss for words, as I can only play back this moment inside my head like a tape on rewind."
+		"TextENG": "Our entire family... no, I'm sure everyone in the village went speechless as that footage played."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153449,
 		"TextJPN": "…外国の小さな村を全滅させたというその惨状は惨たらしく、……亡骸の変わり果てた姿があまりに恐ろしかった。",
-		"TextENG": "A devastation that wipes out entire small villages in Africa, this is too cruel...... the horrible sight of dead and dying corpses is too terrifying to imagine."
+		"TextENG": "...A small African village was completely annihilated, and the terrible spectacle was almost too gory to look at... given the unrecognizable state of the resulting corpses."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153450,
 		"TextJPN": "我が身に危険が及ばない無責任な視聴者にとって、謎の危険なウィルスがどんな害をもたらすのか映像を見たいというのは、率直な野次馬感情だろう。",
-		"TextENG": "A danger beyond the viewers themselves, simply waiting for video footage of a mysterious and dangerous virus... They're just curious."
+		"TextENG": "The people out of this danger's reach were being irresponsible in satisfying their urge to spectate, watching this footage of the harm dealt by this mysterious, heretofore unknown virus."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153451,
 		"TextJPN": "……だが、実際にその危機に直面している俺たちには、……あまりに笑えない、恐ろしいものだった…。",
-		"TextENG": "......But, to be confronted with a crisis like this...... I can't even laugh, this is terrifying..."
+		"TextENG": "......But for those of us directly faced with this crisis... it was far too real, and far too terrifying."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153452,
 		"TextJPN": "ふと、時計を見上げると、レナとの待ち合わせの時間をとっくに過ぎ去り、すでに遅刻している時間だった。",
-		"TextENG": "Suddenly, when I look up at the clock, I realize the time has long passed my meet up with Rena, she is late."
+		"TextENG": "I suddenly glanced up at the clock and saw that it was long past time for me to meet up with Rena. I was already late."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153453,
 		"TextJPN": "普段のレナだったら、約束した時間を５分過ぎれば直接迎えに来る。…でも今朝はそれはなかった。",
-		"TextENG": "Rena would appear everyday to pick me up, but it's now 5 minutes past our promised time... However, she hasn't arrived."
+		"TextENG": "Normally Rena would have come to pick me up directly if it was over five minutes past our meeting time. ...But that didn't happen this morning."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153454,
 		"TextJPN": "……当然だ。きっとレナだって今頃、家族と一緒にテレビに釘付けになっているに違いない…。",
-		"TextENG": "......Naturally, Rena by now is probably glued to the TV with her family..."
+		"TextENG": "......Of course not. I'm sure Rena's also glued to the TV along with her family right about now."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153455,
 		"TextJPN": "それともまさか、……この怪しげなウィルスにやられて苦しんでいるというのではないだろうか…。",
-		"TextENG": "Or possibly...... she may be suffering from this mysterious virus..."
+		"TextENG": "Either that, or maybe... she's currently infected with this mysterious virus, and is suffering under its symptoms..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153456,
 		"TextJPN": "そう思った瞬間、レナだけじゃなく、魅音や沙都子、梨花ちゃんの安否が心の底から気になった。",
-		"TextENG": "I thought about it for just a moment, it's not only Rena, but Mion, Satoko and Rika-chan too, I worry about them from the bottom of my heart."
+		"TextENG": "The moment that thought reached my mind, I started worrying about not just her, but Mion, Satoko, and Rika-chan as well."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153457,
 		"TextJPN": "直情的に俺は廊下へ駆け受話器を取りダイヤルするが、普段のようなコール音すら聞かせてもらうことはできなかった。",
-		"TextENG": "I run for the corridor and dial the phone, there isn't an answering sound."
+		"TextENG": "I ran for our telephone in the hallway on impulse and tried dialing a number, but I didn't even hear the usual dial tone."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153458,
 		"TextJPN": "…無理もない。村中が、そして村に親類を持つさらに大勢が、今の俺と同じように一斉に受話器を握っただろう。電話回線がパンクしているだろうことなど容易に想像がつく。",
-		"TextENG": "...No wonder. The entire village must be dialing their relatives or friends at a time like this, just like me. It's easy to imagine the line would go dead."
+		"TextENG": "...It made sense. The whole village and the population of those outside with relatives in the area probably went for their receivers all at once, just as I had. It was reasonable to assume that the phone lines couldn't keep up."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153459,
 		"TextJPN": "なら、直接訪問してその無事を確かめたい。……だが、危険なウィルスが村の中に満ちているかもしれないというのだ。そんな戸外へわざわざ飛び出すのは自殺行為ではないのか…？",
-		"TextENG": "So, I should go visit and check their safety directly...... But, that dangerous virus could be lurking in the village. Would it be suicidal to run outside at a time like this...?"
+		"TextENG": "That left me wanting to visit them, to make sure of their safety in person... But the whole village could be full of pockets of that dangerous virus. Wouldn't it be suicide to barge outdoors, in that case...?"
 	},
 	{
 		"type": "MSGSET",
@@ -309,19 +309,19 @@
 		"PreTextTags": "@vS24/00/NKFA_0020.",
 		"TextJPN": "「圭一！　ちょっと来い！！　大至急だ！」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``Keiichi! Come back here!! Immediately!``"
+		"TextENG": "``Keiichi! Come here!! Quickly!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153461,
 		"TextJPN": "親父がアトリエから出てくるところだった。ダンボール箱を抱えている。見ると、中身は未開封のビニールに包まれたガムテープがぎっしり入っていた。親父が画材か何かに使うためにストックしていたものらしい。",
-		"TextENG": "My dad soon came out of his studio. He is carrying a large cardboard box. I look inside, and see various unopened wrapping and vinyl tapes. They appear to be part of my dad's stock he uses for his painting tools."
+		"TextENG": "My dad was just coming out of his atelier. His arms were full of cardboard boxes. From what I could see, they were packed full of duct tape wrapped in unopened vinyl bags. Apparently my dad had them in stock to use with his paintings or something."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153462,
 		"TextJPN": "この緊急時になぜガムテープ、とは思わなかった。…すぐに何のために親父が俺を呼び出したのかを理解する。",
-		"TextENG": "Why packing tape in an emergency like this, I never even considered it. ...Although I now understand why my father called for me."
+		"TextENG": "I didn't even question why he had grabbed duct tape in this emergency. ...I understood immediately why my dad was calling for me to help."
 	},
 	{
 		"type": "MSGSET",
@@ -330,7 +330,7 @@
 		"PreTextTags": "@vS24/00/NKFA_0030.",
 		"TextJPN": "「圭一は２階を頼むぞ！　窓をぴったり閉めてガムテープで目張りをするんだ！」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``Take the second floor, Keiichi! Close up all the windows and seal them with packing tape!"
+		"TextENG": "``Keiichi, you cover the second floor! Shut the windows tight and seal them up with duct tape!``"
 	},
 	{
 		"type": "MSGSET",
@@ -339,7 +339,7 @@
 		"PreTextTags": "@vS24/00/NKFA_0040.",
 		"TextJPN": "「クーラーも外気とつながってるかもしれんな！　クーラーは噴出孔を新聞紙で覆ってそれからガムテープでしっかりと止めるんだ！　父さんは１階をやるからな！　母さんは台所を頼む！！」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "Even the air conditioner, it's connected to the outside! Stuff its inside with newspaper and then seal it with packing tape! I'll take the first floor! Your mother will take the kitchen!!``"
+		"TextENG": "``Our air conditioner might be connected to the air outside, too! Cover the AC vents with newspaper, then seal them up with duct tape! I'll cover the first floor! Your mom can cover the kitchen!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -348,7 +348,7 @@
 		"PreTextTags": "@vS24/00/NKMO_0020.",
 		"TextJPN": "「お父さん、今さらそんなことしても仕方ないでしょ。ガムテープなんかじゃ極小のウィルスを防ぐ効果なんて全然ないわよ…！」",
 		"NamesENG": "Keiichi's mom",
-		"TextENG": "``Dad, that won't help at all. The packing tape can't stop such a small virus from getting in...!``"
+		"TextENG": "``Dear, it's too late for any of that. Duct tape won't do anything to keep microorganisms out...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -357,126 +357,126 @@
 		"PreTextTags": "@vS24/00/NKFA_0050.",
 		"TextJPN": "「それでも少しは違うだろうが！！　いいから母さんもやりなさいッ！！」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``Even though that may be true!! Just do it like your mother!!``"
+		"TextENG": "``It'll still make a small difference!! Just help already!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153467,
 		"TextJPN": "親父が問答を許さない強い口調で怒鳴りつける。…でも、こういう事態においても比較的冷静なお袋の言い分ももっともだと思った。",
-		"TextENG": "My dad shouted in a strong tone, as if to prevent any questions or answers. ...However, my mom was relatively calm in such a situation."
+		"TextENG": "My dad's tone made it clear that he wasn't going to suffer any objections. ...But my mom was right. She was being relatively calm, given the situation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153468,
 		"TextJPN": "埃なんかよりも遥かに微小な存在であるウィルスの侵入を、こんな市販の布ガムテープで目張りして回るだけで防げるなんて、迷信もいいところだ…。",
-		"TextENG": "They say that a virus can be as small as dust, and that it can't be prevented by commercially available packing tape, something you would quickly realize after being superstitious..."
+		"TextENG": "Viruses are tiny organisms smaller than even dust, so it was pretty delusional to think that sealing up openings with store-bought duct tape could keep them out..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153469,
 		"TextJPN": "だが同時に、親父の言い分も理解できた。……今は、あまりに突然の事態に誰もがショックを隠せないのだ。",
-		"TextENG": "Although at the same time, I can understand what my dad was trying to say...... At present, nobody can hide their shock from such a sudden situation."
+		"TextENG": "At the same time, I understood how my dad was feeling too. ......It was just so sudden."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153470,
 		"TextJPN": "科学的根拠があるなしじゃなく、例え迷信や気休めでもいいから、何かの備えをせずにはいられない。……何もせずテレビの前に居続けるより、よっぽど心が安らかでいられるに違いないのだ。",
-		"TextENG": "We don't even have any scientific proof that it exists or not, we're just using superstition to soothe ourselves into thinking that things will be alright, but I can't help but feel I need to prepare myself for something. ......Rather than staying in front of the TV doing nothing, I need some space to put my mind at ease."
+		"TextENG": "Even if there was no scientific backing to his beliefs, and even though it wouldn't make any difference, he still had to try and do something to stop it. ...That would comfort his mind far more than just sitting in front of the television."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153471,
 		"TextJPN": "こういう時には妙に頑固なお袋と親父の感情的な罵り合いを避けるように、俺は２階へ上がった。",
-		"TextENG": "So to avoid an emotional brawling match between my mom and dad, I went up to the second floor."
+		"TextENG": "Whenever my mom, oddly stubborn, and my father, wildly emotional, start arguing like that, I go up to the second floor to avoid them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153472,
 		"TextJPN": "お袋の言うように、防疫上の効果が期待できないのはわかってる。…でも、気休めのおまじない程度でも、何かをしたい気持ちはきっと親父と同じだったからだ。",
-		"TextENG": "As my mom always says, you can't be expected to know the effects of a quarantine. ...But, we have to try and ensure our safety, I'm sure my dad was thinking the same thing."
+		"TextENG": "My mom was right. I knew we couldn't really do anything to prevent infection. ...But I shared my dad's desire to do something about it, even if it was just for my own peace of mind."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153473,
 		"TextJPN": "窓から外を見る。…その雄大な光景は、引っ越してきたばかりの頃、深い感動をもたらしてくれた自慢の眺望だった。",
-		"TextENG": "I take a look outside. ...I remember when we first moved in, it was a magnificent scene, the pride I felt then has left a deep impression."
+		"TextENG": "I looked out the window. ...The grand sight before me was a view I took pride in, one that moved me deeply when I first arrived here."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153474,
 		"TextJPN": "その雄大な光景は、昨日までの美しい伝統的建築物を連ねる雛見沢と何も変わりない。",
-		"TextENG": "That magnificent scene, against the backdrop of Hinamizawa's beautiful and traditional buildings, nothing had changed since then, until this day."
+		"TextENG": "The magnificent scenery itself was the same view as always of Hinamizawa's beautiful, traditional buildings."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153475,
 		"TextJPN": "だが、村人の人影はなかった。",
-		"TextENG": "I can't see any villagers outside."
+		"TextENG": "Yet today, there was no sight of any villagers."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153476,
 		"TextJPN": "野良仕事をしている村人の姿を、水田の中に一人たりとも見つけることができなかった。",
-		"TextENG": "No one in the farms or the rice paddy fields, it's impossible to find even a single villager."
+		"TextENG": "I couldn't spot a single villager out working the paddy fields."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153477,
 		"TextJPN": "……こういう事態でも、頑固なお年寄りは野良仕事をさぼらないに違いない、等という浅はかな予想はあっさり裏切られた。",
-		"TextENG": "......Even in such a situation, I expected the stubborn elderly to labor in the farms, but it seems that shallow expectation was easily betrayed."
+		"TextENG": "......I was certain that the stubborn old farmers wouldn't ditch their work, even today. But that silly hope of mine was shattered."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153478,
 		"TextJPN": "……実は、そういう光景に普段通りの日常を見出して安心したかった自分がいたことを知る。",
-		"TextENG": "......In fact, I just wanted to feel relieved after seeing their daily lives continue."
+		"TextENG": "......To be honest, that made me realize I was hoping to find solace in the sight of them carrying on like normal."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153479,
 		"TextJPN": "今やどんなに頑固なお年寄りであっても、野良仕事には出なかった。",
-		"TextENG": "No matter how stubborn the elderly are, their spite wasn't reflected in the farms."
+		"TextENG": "Even the most stubborn of the village elders weren't out working their fields."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153480,
 		"TextJPN": "それはウィルスに感染するかもしれないことを恐れたのではない。ウィルスに感染したと思われ、村から放逐されることを恐れたのである。",
-		"TextENG": "They could be afraid it is infected with the virus. If that appears to be so, then I can understand the villagers reaction."
+		"TextENG": "Maybe they were afraid of getting infected with the virus. Or maybe they were afraid of another villager thinking they were infected instead."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153481,
 		"TextJPN": "その意味においては、防疫上の効果があるかどうかを問う母親より、素人思考の父親の感情的なウィルス対応策の方がずっと正しいと言えただろう。",
-		"TextENG": "Meanwhile, my mom is questioning my dad if his quarantine will even work, it seems he should have thought his amateurish virus countermeasures through."
+		"TextENG": "In that sense, my dad's amateur idea of trying to keep the virus out with duct tape might be the more normal response, instead of questioning its effectiveness like my mom was doing."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153482,
 		"TextJPN": "村は今、静寂の恐怖に包まれている…。",
-		"TextENG": "The village is now wrapped in fear and silence..."
+		"TextENG": "The village was shrouded in a silent fear..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153483,
 		"TextJPN": "それを打ち破るのは防災無線の声と、それを掻き乱す自衛隊のヘリコプターの爆音だけ。",
-		"TextENG": "Only to broken by the the Self-Defense Forces disaster prevention radio, and the roar of their helicopter."
+		"TextENG": "The only sounds to be heard were the voices over the disaster management radios, and the roar of the SDF's helicopters."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153484,
 		"TextJPN": "それらはむしろ、静寂によって一層、不気味に引き立てられるのだった。",
-		"TextENG": "An eerie silence begins to settle itself in."
+		"TextENG": "Those sounds only served to make the silence more chilling."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153485,
 		"TextJPN": "…普段通りにセミたちは合唱を始めているのに…。",
-		"TextENG": "...And as usual, the cicadas begin to cry..."
+		"TextENG": "...Normally the chorus of the cicadas would be starting around this time..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153486,
 		"TextJPN": "その合唱が村人の耳に届くことはなかった…。",
-		"TextENG": "But their cries cannot reach the ears of the villagers..."
+		"TextENG": "But their chorus didn't reach the villagers' ears..."
 	}
 ]

--- a/outbreak_2.json
+++ b/outbreak_2.json
@@ -9,103 +9,103 @@
 		"type": "MSGSET",
 		"MessageID": 153487,
 		"TextJPN": "水道が遮断されたため、水洗トイレが使用できなくなった。",
-		"TextENG": "Since the water was shut off, I can't even flush the toilet."
+		"TextENG": "With the water supply shut off, we couldn't use our flush toilet."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153488,
 		"TextJPN": "自衛隊の救援部隊が、仮設トイレを設置してくれたらしいが、親父は使用に強く反対していたため、前原家は水の出ない水洗トイレを使用し続けていた。",
-		"TextENG": "The relief troops of the Self-Defense Forces seemed to have set up temporary toilets, although my dad had strongly opposed for us to the use them, he wants us to continue using the toilets of the Maebara house even though they can't flush."
+		"TextENG": "The SDF relief squad had set up portable bathrooms, but since my dad was strongly opposed to using them, the Maebara family continued to use our flush toilets without any running water."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153489,
 		"TextJPN": "洗濯に使うために風呂水を残していたため、それを洗面器にすくって流せばしばらくは何とかなるわけだ。",
-		"TextENG": "I can't even use the bath water since we need that for washing our laundry, we save what we can and use it like a washbasin, it's enough to get by."
+		"TextENG": "We had kept our bath water to use for laundry, so we were managing by scooping that into the basin and flushing it away."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153490,
 		"TextJPN": "親父が言うには、保菌者の排泄はウィルスの塊みたいなものなのだという。仮設トイレへ出掛けるのは感染に行くようなものだと、家族に絶対に使わないよう言っていた。",
-		"TextENG": "My dad said, that the virus would lurk within everyone's bowel movements. So anyone who uses the public toilet are walking right into the infection, that's why he asked my family to never use them."
+		"TextENG": "According to my dad, the excrement of disease carriers would just be full of viruses. So he refused to let our family go out and use the public bathrooms, saying that was the same as going out to get ourselves infected."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153491,
 		"TextJPN": "だが風呂桶の水だってそう多くはない。いつまでも水の出ない水洗トイレなど使えない。それに問題のウィルスの潜伏期間が一ヶ月以上もあることを考えれば、雛見沢の隔離がそれ以上に続くだろうことは容易に想像がつく。",
-		"TextENG": "There isn't even that much water in our bath tub. And we won't be able to use our toilets forever. Given that it may take a month for symptoms of the virus to appear, I can only imagine that the isolation of Hinamizawa will continue."
+		"TextENG": "We didn't have that much water left in our bath tub, though. So we couldn't keep using a flush toilet without water forever. To make matters worse, since the virus involved here has a one-month incubation period, it wasn't hard to imagine the quarantine around Hinamizawa would last even longer than that."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153492,
 		"TextJPN": "お袋はその隔離期間を、軽く見積もって３ヶ月は続くだろうと見込んだ。",
-		"TextENG": "My mom gave an estimated on the quarantine period, she expects it to last for three months."
+		"TextENG": "By my mom's quick estimate, the quarantine was likely to last three months."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153493,
 		"TextJPN": "……３ヶ月間。",
-		"TextENG": "......Three months."
+		"TextENG": "......Three whole months."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153494,
 		"TextJPN": "今は６月末だから、…隔離が解かれるのは、９月末、下手をすれば１０月を越えるだろう。",
-		"TextENG": "Since it's the end of June now... the quarantine will probably last until September, or even October if it's that bad."
+		"TextENG": "It was the end of June... so the quarantine wouldn't be lifted until the end of September or maybe even October."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153495,
 		"TextJPN": "つまり、…雛見沢からは昭和５８年の夏が、ごっそり切り取られてしまったことになる。",
-		"TextENG": "In other words... the 1983 summer of Hinamizawa has been completely destroyed."
+		"TextENG": "That meant... that the whole summer of 1983 was going to be cut away from Hinamizawa."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153496,
 		"TextJPN": "それはあまりに悲しいことだった…。",
-		"TextENG": "This is just too sad..."
+		"TextENG": "It was... very tragic for us."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153497,
 		"TextJPN": "初日こそ、家の外にはウィルスが蔓延しているという恐怖にも苛まれたが、給水車の応援や、自衛隊による救援物資の到着、医師団による集団診察が始まると、戸外にまったく出ないわけにも行かなくなった。",
-		"TextENG": "On the first day we were tormented in fear that a virus laid outside our house, and even with the arrival of relief supplies by the Self-Defense Forces, or teams of doctors performing medical examinations, we never went outside."
+		"TextENG": "On the first day, we were caught up in the fear that the virus was everywhere outside of our house, but then the water trucks and relief supplies arrived, thanks to the SDF, and once their doctors started their group examinations, we couldn't afford to stay completely shut inside any longer."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153498,
 		"TextJPN": "父親を初めとする一部の人間は、それでもなお戸外に出ることを拒んだが、生活のためや、医師に診察を受けて自分が感染しているという恐怖を払拭したい人間は、次第に戸外へ出るようになっていた。",
-		"TextENG": "Men appear outside our house, but my dad refuses to leave and breath the infected air, even though they only wanted to wipe away our fear of being infected with a medical examination by a doctor, but then someone took a step outside."
+		"TextENG": "Some people, like my dad, still refused to go outside even then, but they steadily started coming outside over time, both to secure necessities and assuage their fear of infection by having the doctors examine them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153499,
 		"TextJPN": "それは俺もだった。家族だけでガムテープで目張りをしてシャッターを下ろした不気味な家の中で、テレビの前で無言で過ごし続けるなんて神経が持つわけもない。それより、表に出て知り合いの安否を確かめたい気持ちの方が強かった。",
-		"TextENG": "It was me. I appear from an eerie house sealed with packing tape, my parents soon follow, there was no reason not to, we couldn't spend the rest of our days silent in front of the TV, and I need to check the safety of my friends."
+		"TextENG": "The same went for me. I couldn't stand staying cooped up in our creepy house with its duct-taped shutters, silently watching the television with no one but my family around. I was much more anxious to go outside and check on my friends' well-being."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153500,
 		"TextJPN": "親父は引き篭もりを決め込み、呆れたお袋は、俺と一緒に集団診察に出掛けた。",
-		"TextENG": "My dad pulls me through the crowd with my mom for the medical examination."
+		"TextENG": "My dad continued to be stubborn about holing in the house, so my exasperated mom and I went to the group examinations together."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153501,
 		"TextJPN": "前原家の属する町会は学校校庭に集まることになっていた。",
-		"TextENG": "The men belonging to the neighborhood association told us we were meant to gather at the school grounds."
+		"TextENG": "The town council our family fell under had decided to conduct the examinations in the schoolyard."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153502,
 		"TextJPN": "校庭には大勢の村人が集まり、町会の回覧板区分に従い列を作らされている。",
-		"TextENG": "Most of the villagers had already gathered here, where they had to form a line in accordance with the neighborhood association."
+		"TextENG": "Lots of the villagers had gathered there, and we were all lined up according to the divisions used for the council's newsletters."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153503,
 		"TextJPN": "普段着姿の村人と、真っ白な雨合羽のようなものをすっぽりと被った医師団との対比が、なぜだかとても不愉快だった。…それは、俺たちを怪しげなウィルスの感染者だと疑っているというこれ以上ない明白な証拠だからだ。",
-		"TextENG": "The villagers appear in their everyday clothes, before the comfortable doctors in their white raincoats, it seems they are suffering, what an unpleasant sight. ...It's clear evidence that even they doubt we're infected with this suspicious virus."
+		"TextENG": "The disparity between the villagers in their normal clothes and the doctors covered head-to-toe in a white raincoat-like suit was very unsettling. ...It was clear evidence that they suspected us all of being carriers of the virus."
 	},
 	{
 		"type": "MSGSET",
@@ -114,7 +114,7 @@
 		"PreTextTags": "@vS24/02/NREN_0000.",
 		"TextJPN": "「あ、圭一くーん！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Oh, Keiichi-kun!!``"
+		"TextENG": "``Ah, Keiichi-kuuun!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -123,7 +123,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0030.",
 		"TextJPN": "「おぅレナ！！　よかったぜ、無事だったか！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Rena!! I'm glad you're safe!!``"
+		"TextENG": "``Oh, Rena!! Thank goodness you're safe!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -132,7 +132,7 @@
 		"PreTextTags": "@vS24/02/NREN_0010.",
 		"TextJPN": "「う、うん！　さっき魅ぃちゃんに会ったよ。魅ぃちゃんも元気そうだった！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Y-Yup! I met Mii-chan a little while ago. Mii-chan seemed to be fine!``"
+		"TextENG": "``Y-Yeah! I just ran into Mii-chan. She was looking healthy too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -141,7 +141,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0040.",
 		"TextJPN": "「そうか！　沙都子や梨花ちゃんは？！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I see! What about Rika-chan and Satoko?!``"
+		"TextENG": "``Really?! What about Satoko and Rika-chan?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -150,7 +150,7 @@
 		"PreTextTags": "@vS24/02/NREN_0020.",
 		"TextJPN": "「梨花ちゃんたちは町会区分が違うと思うから他の場所に集合してると思うよ…。何度か電話してるんだけど繋がらないの…」",
 		"NamesENG": "Rena",
-		"TextENG": "``Rika-chan and the others live in a different district, so I think they were told to gather at a different location designated by the neighborhood association... I tried calling several times, but there was no answer...``"
+		"TextENG": "``They're in a different division, so I think they had to go somewhere else... I've tried calling them a few times, but I can't get through...``"
 	},
 	{
 		"type": "MSGSET",
@@ -159,7 +159,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0050.",
 		"TextJPN": "「俺も何度か電話してるが全然ダメだ…。やっぱり電話が殺到してパンクしてるんだろうな…」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I tried calling several times, too, but it was useless... The telephones have all gone dead after all...``"
+		"TextENG": "``I tried calling several times too, but I had no luck at all... I guess the phone lines are just too congested to handle it...``"
 	},
 	{
 		"type": "MSGSET",
@@ -168,7 +168,7 @@
 		"PreTextTags": "@vS24/02/NREN_0030.",
 		"TextJPN": "「自衛隊の人の言うことを聞かないで暴走した車が、事故で電柱を倒しちゃって、それで電話線を引き千切っちゃったって噂を聞いたの。…でも別の人は、行政が関係者専用に設定を変えたので、一般市民は使用不能になってるとか言ってた」",
 		"NamesENG": "Rena",
-		"TextENG": "``I heard someone say that one of the Self-Defense Forces vehicles drove recklessly, and accidentally knocked down the telephone pole, or so that's the rumor why the telephone lines are down. ...But then another person said, that the government changed the configuration for private use only, so it's unavailable to the general public.``"
+		"TextENG": "``I heard a rumor that there was someone in a car who wouldn't listen to the SDF's directions, so they had an accident and crashed into a telephone pole, cutting the lines out completely. ...But another person said the government had switched them over to authorized use only, so the average citizen can't use them right now.``"
 	},
 	{
 		"type": "MSGSET",
@@ -177,13 +177,13 @@
 		"PreTextTags": "@vS24/01/NKEI_0060.",
 		"TextJPN": "「…早い話が、情報が錯綜してて誰もが混乱してるってことか…」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``...It seems everyone's conflicting stories are just adding to the confusion...``"
+		"TextENG": "``...Long story short, everyone's confused and the information's all mixed up, huh...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153512,
 		"TextJPN": "その時、背中を強く叩かれる。魅音だった。",
-		"TextENG": "Suddenly, someone strongly tapped my back. It was Mion."
+		"TextENG": "Right after I said that, someone smacked me hard on the back. It was Mion."
 	},
 	{
 		"type": "MSGSET",
@@ -192,7 +192,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0000.",
 		"TextJPN": "「圭ちゃん！！　よかった、無事だったんだね！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Kei-chan!! I'm glad you're safe!!``"
+		"TextENG": "``Kei-chan!! Great to see you're safe!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -201,25 +201,25 @@
 		"PreTextTags": "@vS24/01/NKEI_0070.",
 		"TextJPN": "「俺のセリフだぜ！！　お前も無事でよかった！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``That's my line!! I'm glad you're safe, too!``"
+		"TextENG": "``That's my line!! I'm glad to see you're safe too!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153515,
 		"TextJPN": "魅音は涙を拭くような大袈裟なフリをしながら、ほんの数日振りの再会を喜んでくれた。",
-		"TextENG": "Mion wipes away her exaggerating tears, happy we could meet once again after days of separation."
+		"TextENG": "Mion made a big show of wiping her tears away, enjoying our reunion after only a scant few days."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153516,
 		"TextJPN": "今さら説明するまでもなく、雛見沢は古い慣習により、御三家と呼ばれる旧家によって統率されている。今やその筆頭家は魅音の園崎家だ。",
-		"TextENG": "She doesn't need to explain why she's late. Hinamizawa by old customs is governed by the old family's referred to as the big three. With the largest the Sonozaki family now lead by Mion."
+		"TextENG": "There's no need to explain it at this point, I think, but the old customs here meant Hinamizawa was governed by three ancient clans known as the Three Families. Right now Mion's family, the Sonozaki family, was the head of that organization."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153517,
 		"TextJPN": "魅音によると、園崎家は連合町会を指揮して事態の沈静化を図ろうと率先して動いているらしかった。また、行政や自衛隊とも協力していて、一般の村人が知り及んでいない情報についても知っているようだった。",
-		"TextENG": "According to Mion, the Sonozaki family took the initiative and directed the neighborhood association in order to calm the situation. Furthermore, they instructed the villagers to cooperate with the government and Self-Defense Forces, to share what information we have."
+		"TextENG": "According to Mion, the Sonozaki family was already taking the initiative and leading the unified town council to try and settle the whole situation. They were also working together with the government and the SDF, so they had information that regular villagers didn't know about."
 	},
 	{
 		"type": "MSGSET",
@@ -228,7 +228,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0080.",
 		"TextJPN": "「魅音、ぶっちゃけた話、どうなってんだ！　そのウィルスってヤツは本当に村人全員に感染してんのか？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Mion, that story can't be true! Has this virus really infected all of the villagers in town?``"
+		"TextENG": "``Mion, be blunt with us, what's going on?! Has this virus really infected all of the villagers?``"
 	},
 	{
 		"type": "MSGSET",
@@ -237,7 +237,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0010.",
 		"TextJPN": "「早朝にあった説明では、その可能性は極めて薄いってさ。話では、感染者が出たのは高津戸の方らしいんだよ。あっちはほとんど人が住んでないからね。素早く隔離封鎖がされたから、雛見沢地区には及んでないんじゃないかって言われてる」",
 		"NamesENG": "Mion",
-		"TextENG": "``Since this happened in the early morning, the possibility seems very unlikely. And according to this story, the first person to be infected was from Takatsudo. Not much people live in that area anyway. So they managed to quarantine it pretty quick, they also said it's unlikely the virus will spread to the Hinamizawa district.``"
+		"TextENG": "``According to this morning's explanation, the likelihood of that is pretty slim. From what they've said, the infected showed up over in Takatsudo. And hardly anyone lives over there! Since the quarantine was set up so quick, they're saying they don't think it's reached the Hinamizawa area yet.``"
 	},
 	{
 		"type": "MSGSET",
@@ -246,7 +246,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0020.",
 		"TextJPN": "「雛見沢地区の全員がシロであることが確認できたら、段階的に隔離は解除になるんじゃないかって楽観論も出てるよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``So if we can confirm nobody in the Hinamizawa area is infected, there's some optimism they'll gradually lift the quarantine.``"
+		"TextENG": "``Once they can confirm everyone in Hinamizawa is clean, they're hopeful that they can start lifting the quarantine in stages.``"
 	},
 	{
 		"type": "MSGSET",
@@ -255,13 +255,13 @@
 		"PreTextTags": "@vS24/02/NREN_0040.",
 		"TextJPN": "「そ、そうならいいよね…。高津戸に住んでる人には悪いけど、雛見沢地区だけでも、早く隔離が終わるといいね…」",
 		"NamesENG": "Rena",
-		"TextENG": "``I hope so... I feel bad for the people living in Takatsudo, let alone the Hinamizawa area, I hope this quarantine will be over soon...``"
+		"TextENG": "``I-I hope that's true... I feel bad for those living in Takatsudo, but it'll be nice if Hinamizawa's quarantine ends sooner...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153522,
 		"TextJPN": "そこで魅音は目つきを一度鋭くし、俺とレナの頭を引っ掴んで、魅音と俺たちの頭をぶつけて近寄せた。そして俺たちにしか聞こえない小声で言う。",
-		"TextENG": "Mion sharpens her eyes, seizes both mine and Rena's heads, and bumps our heads as she pulls us closer to her. She begins to speak in a low voice."
+		"TextENG": "That was when Mion gave us a sharp look. Then she grabbed my head and Rena's, pulling us in close to her own. Then she whispered so quietly that only we could hear."
 	},
 	{
 		"type": "MSGSET",
@@ -270,7 +270,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0030.",
 		"TextJPN": "「………でも、私はそう楽観的だとは思えないね。おじさん、無線使えるんだけどさ。警察や自衛隊の回線にも入れるように改造してあるんだよ。…そこで傍受してる限りは、そんな簡単な話じゃないみたい」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........But, I don't think I can be so optimistic. Uncle knows how radio works. I modified one to make it possible to listen in on the police and Self-Defense Forces communication lines. ...From what I've intercepted so far, it doesn't sound like their usual chatter.``"
+		"TextENG": "``.........But I don't think we can be that optimistic, actually. I'm able to use a radio myself, you know. I modified mine to pick up transmissions from the police and the SDF. ...From what I'm hearing there, this isn't that simple.``"
 	},
 	{
 		"type": "MSGSET",
@@ -279,7 +279,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0040.",
 		"TextJPN": "「何しろ、雛見沢は山間部の寒村で陸の孤島。どういう経路で海外からこの村へウィルスが伝播したのか経路がさっぱりなんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Anyway, Hinamizawa is a poor lonely village in the mountain. So they probably have no idea if the virus came from overseas or not.``"
+		"TextENG": "``After all, Hinamizawa is a pretty isolated village, all by itself here in a mountain range. They don't have a clue how this virus managed to transmit itself here from overseas.``"
 	},
 	{
 		"type": "MSGSET",
@@ -288,7 +288,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0050.",
 		"TextJPN": "「…現在、行政が把握している発症者は海外渡航歴がないらしくてね。他に潜在保菌者がいるんじゃないかって疑われてて、村人全員の海外渡航歴を調査中らしいよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Currently, the government have detected this person has no records of overseas travel. So it is suspected a potential carrier came from somewhere else, and it seems they are investigating all the villagers history for overseas travel.``"
+		"TextENG": "``...So far, none of the infected people the government has discovered have any history of traveling out of the country. So now they're investigating the travel history of everyone in the village, wondering if there might be another carrier.``"
 	},
 	{
 		"type": "MSGSET",
@@ -297,7 +297,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0090.",
 		"TextJPN": "「つまり、誰かが海外で感染してこの村へ持ち込んだ、ってわけか…」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``In other words, someone got infected abroad and brought it back to this village...``"
+		"TextENG": "``So you're saying that someone got infected while in a different country and brought this back to our village...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -306,7 +306,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0060.",
 		"TextJPN": "「うん。何しろ潜伏期間に幅があるらしいからね。持ち込んだ本人が未だ潜伏期の可能性が否定できないらしいんだよ。それに、その人物に海外渡航歴がある保証もない。村の外で保菌者に接触して持ち込んだ可能性もあるからね」",
 		"NamesENG": "Mion",
-		"TextENG": "``Yeah. I've also heard that the incubation period seems to vary. And that the one who brought it hasn't yet denied the possibility of a variable incubation period. Also, there isn't a guarantee that this person even has a record of overseas travel. It's entirely possible that someone came into contact with a carrier outside the village and brought it in.``"
+		"TextENG": "``Yeah. Apparently there's some leeway in its incubation period. They can't rule out the chance that whoever brought it here is still incubating the disease. Also, there's no guarantee that the person ever traveled abroad at all. There's still a chance they got infected when they came into contact with a carrier from outside the village...``"
 	},
 	{
 		"type": "MSGSET",
@@ -315,7 +315,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0070.",
 		"TextJPN": "「……おじさんの睨んだところじゃ、隔離地区は雛見沢だけに収まらない。下手をすれば県内、あるいは地方レベルにまでも及びかねないね…」",
 		"NamesENG": "Mion",
-		"TextENG": "``......From what Uncle has seen, the quarantine area doesn't cover just Hinamizawa. If it's as bad as it seems, it could extend to the entire region or even the whole prefecture...``"
+		"TextENG": "``......By my guess, the quarantined zones won't be limited to just Hinamizawa. Worst case is, the quarantine could extend to the prefecture, or even to this whole part of the country...``"
 	},
 	{
 		"type": "MSGSET",
@@ -324,7 +324,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0100.",
 		"TextJPN": "「………………………何てこった……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``...........................What the hell......``"
+		"TextENG": "``........................... How can this be......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -333,7 +333,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0080.",
 		"TextJPN": "「あとは、……ここだけの話なんだけど。………このウィルス、テレビで言ってる外国の殺人ウィルスってのとは別物らしいって噂もあるんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Also...... don't tell anyone else what I'm about to say. .........This virus, it seems there's a rumor it's not the same as that African killer virus we saw on TV.``"
+		"TextENG": "``Also...... this is just between us, but......... there's talk that this one might be different from the African killer virus they mentioned on TV.``"
 	},
 	{
 		"type": "MSGSET",
@@ -342,7 +342,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0110.",
 		"TextJPN": "「…どういうことだよ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``...What does that mean?``"
+		"TextENG": "``...What do you mean?``"
 	},
 	{
 		"type": "MSGSET",
@@ -351,7 +351,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0090.",
 		"TextJPN": "「……私もよくはわからないんだけど、傍受できた無線の一部から、今回のウィルス騒ぎを雛見沢土着の風土病を疑うような内容が聞けたんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``......I didn't really understand it well, but from what I was able to intercept on the radio in all the uproar, it seems they've started to suspect the virus to be a local disease indigenous to Hinamizawa.``"
+		"TextENG": "``......I'm not sure either, but some of the chatter I'm picking up on the radio suggests that they suspect this whole virus crisis might be caused by an endemic disease native to Hinamizawa.``"
 	},
 	{
 		"type": "MSGSET",
@@ -360,7 +360,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0120.",
 		"TextJPN": "「この殺人ウィルスが昔から雛見沢に眠ってたってのか？！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``You mean that killer virus from Hinamizawa asleep since ancient times?!``"
+		"TextENG": "``You mean some killer virus has been hiding in Hinamizawa for years?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -369,7 +369,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0100.",
 		"TextJPN": "「私もよくはわかんないけど…。ただ、雛見沢の古い伝承には、沼から不浄な何かが湧き出して村を襲ったという話が残ってる。それが再び湧き出したのではないかって疑えないこともないね」",
 		"NamesENG": "Mion",
-		"TextENG": "``I don't know much about it either... However, it's an old Hinamizawa legend, the story of an unholy something rising out from the nearby swamp and attacking the village. People are suspecting the same thing could rise again.``"
+		"TextENG": "``I'm not sure either... The only thing I do know is that there's an old legend still passed on around here that talks about something 'impure' rising from the swamp and attacking the village. Makes you wonder whether something's risen up out of there again.``"
 	},
 	{
 		"type": "MSGSET",
@@ -378,7 +378,7 @@
 		"PreTextTags": "@vS24/02/NREN_0050.",
 		"TextJPN": "「でも魅ぃちゃん。だとしたらまだ安心できるね。だって、その大昔の時には、村が滅んだわけじゃないんでしょ？　ということは、テレビで言ってる村を全滅させるようなウィルスよりはずっと毒性が弱いってことだよ」",
 		"NamesENG": "Rena",
-		"TextENG": "``But, Mii-chan. I think we can rest assured. Because, back then, the village wasn't destroyed, right? Which means, this virus isn't as dangerous as the one that annihilated those villages we heard about on TV.``"
+		"TextENG": "``But Mii-chan, if that's true, then we can rest easy. I mean, the village wasn't wiped out all those years ago, right? Which means it's far less lethal than the virus they're talking about on TV that wipes out whole villages.``"
 	},
 	{
 		"type": "MSGSET",
@@ -387,7 +387,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0110.",
 		"TextJPN": "「…鬼ヶ淵村の伝承では、沼より湧き出した不浄に取り憑かれると鬼と化したらしい。結局、人の手では何もできず、オヤシロさまの降臨まで人々に打つ手はなかった」",
 		"NamesENG": "Mion",
-		"TextENG": "``...According to the legend of Onigafuchi village, if you got touched by the impurities who rose from the swamp, you were turned into a demon. After all, nothing could be done by the hand of man, you couldn't be saved until Oyashiro-sama descended.``"
+		"TextENG": "``...According to the myths of old Onigafuchi, anyone possessed by the impurity from the swamp became a demon. In the end, the villagers couldn't do anything, and they were at their wits' end... until Oyashiro-sama descended before them.``"
 	},
 	{
 		"type": "MSGSET",
@@ -396,7 +396,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0130.",
 		"TextJPN": "「………つまり、伝説に残るような奇跡が起こるまで、村はその災禍から逃れられなかったってことだな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``.........In other words, all we have to do is wait for a miracle like the one described in the legend, then our village can escape such a disaster.``"
+		"TextENG": "``.........Which means the village couldn't escape that disaster until a miracle occurred.``"
 	},
 	{
 		"type": "MSGSET",
@@ -405,13 +405,13 @@
 		"PreTextTags": "@vS24/03/NMIO_0120.",
 		"TextJPN": "「そうだね。…奇跡が起こらなければ、村は全滅してたってことだね…」",
 		"NamesENG": "Mion",
-		"TextENG": "``You're right. ...But unless a miracle happens, our entire village will be wiped out...``"
+		"TextENG": "``Exactly. ...If not for that miracle, the village would've been wiped out...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153539,
 		"TextJPN": "今回のウィルス騒ぎを、オヤシロさまの祟りだと捉えるお年寄りは多いようだった。あちこちで数珠を揉みながら祈りを上げ、許しを請い続ける姿が見つけられた。",
-		"TextENG": "This virus has caused alot of commotion, even the elderly are beginning to think this is the curse of Oyashiro-sama. They have already started praying and rubbing beads in many places, continuing to ask for forgiveness from his statues."
+		"TextENG": "It seemed there were a lot of older villagers who believed this whole virus commotion was Oyashiro-sama's curse. I could see them here and there going through rosaries and offering prayers up as they begged for forgiveness."
 	},
 	{
 		"type": "MSGSET",
@@ -420,7 +420,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0130.",
 		"TextJPN": "「オヤシロさまの生まれ変わりである梨花ちゃんが、それを否定してくれれば騒ぎは落ち着くんだろうけどね。婆っちゃが今、自衛隊の人にそれを説明してるところだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``If Rika-chan, the reincarnation of Oyashiro-sama, showed herself and denied everything going on, I'm pretty sure everyone would calm down. My grandma is trying to explain this to the Self-Defense Forces right now.``"
+		"TextENG": "``That commotion would settle down if Rika-chan, the reincarnation of Oyashiro-sama, would just deny that it's the curse. My granny's trying to explain that to the people from the SDF right now.``"
 	},
 	{
 		"type": "MSGSET",
@@ -429,7 +429,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0140.",
 		"TextJPN": "「…まぁ、他所から来た連中には、梨花ちゃまのこの村における意味は理解できないだろうからねぇ」",
 		"NamesENG": "Mion",
-		"TextENG": "``...But, it seems those outsiders just don't understand how important Rika-chama is to the people of this village.``"
+		"TextENG": "``...Well, I doubt outsiders can understand what Rika-chama means to this village.``"
 	},
 	{
 		"type": "MSGSET",
@@ -438,54 +438,54 @@
 		"PreTextTags": "@vS24/01/NKEI_0140.",
 		"TextJPN": "「…だな。………迷信の話は抜きにしても、俺も早く無事な梨花ちゃんと沙都子の姿を見て安心したいぜ…」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``...I see. .........Well, let's put aside all this talk of superstition, I want to put my mind at ease and see for myself that Rika-chan and Satoko are safe...``"
+		"TextENG": "``...Yeah. .........The superstitions aside, it would be a relief to see Rika-chan and Satoko myself...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153543,
 		"TextJPN": "そう。雛見沢はオヤシロさまという守り神を崇拝する、独特の信仰がある。",
-		"TextENG": "I see. So the people of Hinamizawa worship their guardian deity named Oyashiro, what a unique faith."
+		"TextENG": "That's right. Hinamizawa has a unique religion that worships a guardian deity known as Oyashiro-sama."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153544,
 		"TextJPN": "その信仰が描く終末、「オヤシロさまの祟り」。それを今回の騒ぎに重ねる村人はとても多かった。",
-		"TextENG": "Even so, this faith's end draws near, ``The curse of Oyashiro-sama``. It seems many of the villagers believe this is the cause of the turmoil."
+		"TextENG": "Central to that faith was the legend of ``Oyashiro-sama's curse``. So there were a lot of villagers conflating that curse with the current commotion."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153545,
 		"TextJPN": "だからこそ誰もが、そのオヤシロさまの生まれ変わりとして崇められる古手梨花の元気な姿を見て、今回の騒ぎがオヤシロさまと関係ないことを宣言してもらいたいと思っていた。",
-		"TextENG": "And that's why everyone is cheerfully worshiping Furude Rika, the reincarnation of Oyashiro-sama. I just want them to declare there is no relation between Oyashiro-sama and the virus."
+		"TextENG": "That was why everyone wanted to see Rika Furude, who was considered to be Oyashiro-sama's reincarnation, alive and healthy, and hear her proclaim that this commotion had nothing to do with Oyashiro-sama."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153546,
 		"TextJPN": "村が初めて経験する異常事態。誰もが心のショックから未だ立ち直れず、何かにすがりたいと思っている。",
-		"TextENG": "This village is experiencing such an abnormal situation for the first time. Nobody has recovered from the shock, I feel a need to cling to something."
+		"TextENG": "It was the first emergency situation of this manner that the village had faced. No one had yet to recover from the shock to their heart, and they wanted something to cling to."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153547,
 		"TextJPN": "でも、迷信が支配する村とはいえ、２０世紀を迎えた現代日本の村でもある。",
-		"TextENG": "But, despite the superstition which dominates this village, it's also a modern village, which greeted the 20th century of Japan."
+		"TextENG": "But even if the village was ruled by superstition, it was still a part of modern 20th century Japan."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153548,
 		"TextJPN": "右往左往せず冷静に事態に対応したいという気持ちももちろん持っている。",
-		"TextENG": "Of course, we have to support this situation calmly and not run into utter confusion."
+		"TextENG": "So of course they wanted to respond calmly without mulling about in confusion."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153549,
 		"TextJPN": "だからみんな、古手梨花の元気な姿さえ見れたなら、すぐにでも冷静を取り戻そうと心に決めていたのである。",
-		"TextENG": "Therefore, if we are able to see a healthy Furude Rika, it should immediately calm our minds."
+		"TextENG": "So many had decided for themselves that as long as they saw Rika Furude safe and sound, then they would regain their composure."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153550,
 		"TextJPN": "それはつまり、古手梨花の姿を見られなかったなら、いつまでも迷信に取り憑かれて混迷したままでいようということの裏返しでもあった……。",
-		"TextENG": "But, that also means, if we don't see Furude Rika, this confusion and obsessed superstition will continue forever......"
+		"TextENG": "That also meant that if they couldn't see Rika Furude, then they would remain lost in their superstitions..."
 	}
 ]

--- a/outbreak_3.json
+++ b/outbreak_3.json
@@ -9,73 +9,73 @@
 		"type": "MSGSET",
 		"MessageID": 153551,
 		"TextJPN": "学校がなく、曜日感覚を完全に失った最近は、テレビの番組編成によってのみ辛うじてその感覚を保たせる脆弱な日常の上に成り立っていた。",
-		"TextENG": "There isn't any school, and my daily life has completely fallen apart. The only thing left is sitting in front of the TV watching television all day, but even then I can barely keep my senses awake."
+		"TextENG": "Without school, I had completely lost my sense for what day it was, so the television programming was all that barely maintained my sense of daily life."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153552,
 		"TextJPN": "テレビが、いわゆる「雛見沢ウィルス騒動」を取り上げたのは、隔離封鎖の初期だけで、１０日目を迎えると、特別な動きがない限りニュースで取り上げられることはなくなっていた。",
-		"TextENG": "On TV, they addressed the so called ``Hinamizawa virus disturbance``, but only the initial blockade and quarantine. It's been 10 days now, and the news has stopped covering the event."
+		"TextENG": "For the first few days, the television only covered what they dubbed the ``Hinamizawa Virus Outbreak`` and the resulting quarantine. Once the tenth day had passed, the news only mentioned it when something special was happening."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153553,
 		"TextJPN": "世間では、どこぞの大臣が雛見沢の騒ぎの時にゴルフを切り上げなかったとか何とかで、そこからケチがついて秘書の給与疑惑に発展してどうのこうの。…実にどうでもいい方向へ話題が転がっていっていた。",
-		"TextENG": "Elsewhere in the news, various ministers didn't stop a scheduled round of golf during the commotion in Hinamizawa, which in turn evolved into a salary scandal for their secretaries. ...From that point on, the topics rolled into a really trifling direction."
+		"TextENG": "As far as the public was concerned, some minister or another hadn't cut his golf game short when the Hinamizawa crisis happened or something, so they quibbled over that, which lead to queries into his secretary's salary or something. ...All completely pointless stuff."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153554,
 		"TextJPN": "世間はニュースが取り上げなければ、もうウィルス騒ぎが解決してしまったに違いないと錯覚するのだろうか。",
-		"TextENG": "And so news of the outbreak was never picked up again, I guess they want to uphold an illusion the virus was cured."
+		"TextENG": "So long as it wasn't brought up in the news, society probably deluded themselves into believing the virus crisis was resolved."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153555,
 		"TextJPN": "人の不幸に飽食する世間の冷たさを思い知らずにはいられなかった。",
-		"TextENG": "I couldn't help but realize the coldness of this world as it pampered itself against the misfortune of others."
+		"TextENG": "I couldn't help but realize how coldly society gorged itself on the misfortune of others."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153556,
 		"TextJPN": "この頃には、配給などの用事があれば戸外へ出歩くことに対する抵抗は、ほとんどの村人から払拭されたようだった。",
-		"TextENG": "By now, the resistance against restriction of movements outdoors for errands such as rations has mostly been wiped from the villagers minds."
+		"TextENG": "By this point most villagers had gotten over their hesitation to go outside, at least to collect supplies and such."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153557,
 		"TextJPN": "最近の魅音などは、隔離されたのは村じゃなくて、むしろ興宮の方ではないのか。町まで買い物に行かなくていいし、水も食料もみんなタダで配給してもらえるので気楽ではないかと軽口を叩いてみせるようになっていた。",
-		"TextENG": "Although Mion would rather prefer to visit Okinomiya, than stay isolated within the village. But we don't need to go there for shopping, and although some took this as a joke, all water and food is being distributed free of charge, so there isn't anything to worry about."
+		"TextENG": "Lately Mion's been wondering if it's not just our village being quarantined, but Okinomiya as well. We didn't have to go into town to shop, and some had started joking that it was much easier with water and food all being delivered for free."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153558,
 		"TextJPN": "それに苦笑いで応えるが、すでに十日にも及んでいる隔離の閉塞感は拭えるものではなかった。",
-		"TextENG": "However, it was eventually met with a bitter smile, as this feeling of confinement and isolation which has lasted for ten days cannot be wiped away."
+		"TextENG": "I'd force a smile at that, but I couldn't shake the sense of entrapment brought on by the quarantine lasting ten days already."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153559,
 		"TextJPN": "それは魅音も同じだ。言葉だけなら余裕の軽口にも聞こえるが、魅音自身、その表情から不安感は拭えていなかった。",
-		"TextENG": "Mion feels the same way. She took their words as a joke, but Mion could not wipe away a feeling of anxiety from her face."
+		"TextENG": "The same went for Mion. She sounded lighthearted and carefree on the surface, but Mion couldn't shake the anxiety from her expression either."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153560,
 		"TextJPN": "こんな昨今だからこそ家でうじうじとしていても仕方がない。せめて誰かと話している方が気が紛れる。俺も飲料水のポリタンク運びを積極的に手伝い、給水場所で仲間たちと再会できるのを楽しみにしていた。",
-		"TextENG": "I can't help it either, I've been cooked up inside my house these past days. At least if I can talk to someone it can distract my mind from our current situation. However, my plastic tank of drinking water is almost at an end, so I'm looking forward to meeting up with my friends at the water supply point."
+		"TextENG": "With the way things were, staying at home wasn't helping. If I was at least talking to someone, I could distract myself. I even started volunteering to help carry the plastic tanks of drinking water, excited at the chance to see my friends by the water supply."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153561,
 		"TextJPN": "だが、楽しいというのとはもちろん違う。",
-		"TextENG": "But, I think this time will be different."
+		"TextENG": "Of course, it wasn't like it was fun, though."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153562,
 		"TextJPN": "会えば互いの不安を吐き合うだけだ。…でも、それでも。ひとりで布団を被っているのに比べたらずっとマシだった……。",
-		"TextENG": "I have an uneasy feeling going to meet them. ...But, still, it's much better than sitting alone on the futon......"
+		"TextENG": "When we saw each other we only shared our anxieties. ...But even so. It was still far better than huddling under a blanket all by myself......"
 	},
 	{
 		"type": "MSGSET",
@@ -84,7 +84,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0150.",
 		"TextJPN": "「……圭ちゃん！　具合は良さそうだね。変な斑点とか出てない？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Kei-chan! You look great. Do have strange spots all over your body yet?``"
+		"TextENG": "``...Kei-chan! You look well. Got any strange spots?``"
 	},
 	{
 		"type": "MSGSET",
@@ -102,7 +102,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0150.",
 		"TextJPN": "「魅音！　レナもか！　よかった、相変わらず電話が通じないからな。こうして会えるとほっとするぜ…」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Mion! Rena! I'm glad, the phones were down as usual. I'm relieved we can meet like this...``"
+		"TextENG": "``Mion! And Rena too! Thank goodness. The phones are still out, as usual. So seeing you here is a relief...``"
 	},
 	{
 		"type": "MSGSET",
@@ -111,19 +111,19 @@
 		"PreTextTags": "@vS24/02/NREN_0070.",
 		"TextJPN": "「だね。レナも最近は、学校が再開してくれないかなって思うくらいだもん。…はぅ」",
 		"NamesENG": "Rena",
-		"TextENG": "``I see. Rena's been thinking recently whether we should reopen the school or not. ...Hauu.``"
+		"TextENG": "``Yeah. Lately I've been wishing they'd reopen the school. ...Hau.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153567,
 		"TextJPN": "…学校が再開してくれたなら、皆、平穏だった頃の日常を思い出しながら、精一杯いつものように元気に振舞うだろうか。",
-		"TextENG": "...If school reopens, then everyone can remember those peaceful days, although I do wonder if everyone would return to their usual happy selves."
+		"TextENG": "...If the school were to reopen, then we could all think back on our peaceful everyday lives, and do our best to pretend everything was fine."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153568,
 		"TextJPN": "……でも、…ダメか。知恵先生は確か興宮に家があるはず。隔離されているから学校に来られないのだから、俺たちのクラスは再開できない…。",
-		"TextENG": "......However ...it's no use. Chie-sensei lives in Okinomiya. And she can't come to school because it's quarantined, so class can't be resumed..."
+		"TextENG": "......But... I guess not. If I recall, Chie-sensei lives in Okinomiya. So they can't reopen the school if she can't get there because of the quarantine..."
 	},
 	{
 		"type": "MSGSET",
@@ -132,19 +132,19 @@
 		"PreTextTags": "@vS24/03/NMIO_0160.",
 		"TextJPN": "「はは、せっかく未曾有の大災害で休校なんだからさ。たまにはこういうライフを満喫するのも悪くないけどねぇ～！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Ha ha, who would've known closure of school would have brought forth such an unprecedented disaster. This kinda life can't be that bad, we should enjoy ourselves!``"
+		"TextENG": "``Haha, well, it's not so bad. Since school's closed over this unprecedented disaster, we should take the chance to enjoy living free like this!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153570,
 		"TextJPN": "こういう時、魅音の軽口は本当に貴重だった。そこから、まるでいつもの日常のような気楽な話が次々とつながっていく。",
-		"TextENG": "At times like this, Mion's jokes are really valuable. So from here on out, we should enjoy our days without a care in the world."
+		"TextENG": "Mion's personality was truly valuable in times like this. She could get the conversation going easily, and make it as light as our usual everyday chatter."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153571,
 		"TextJPN": "……でも、最後には必ず、現状に対する不安の話で締めくくられるのだ。",
-		"TextENG": "......But, in the end, I still can't shake this feeling of uneasiness from our current situation."
+		"TextENG": "...But in the end, she brought the conversation back to our worries about our current situation."
 	},
 	{
 		"type": "MSGSET",
@@ -153,13 +153,13 @@
 		"PreTextTags": "@vS24/03/NMIO_0170.",
 		"TextJPN": "「そうだ、…………レナ、圭ちゃん。…気を悪くしないで聞いて。ここだけの話だから」",
 		"NamesENG": "Mion",
-		"TextENG": "``Anyway............ Rena, Kei-chan. Don't feel bad about what you're about to hear. Just listen to what I have to say.``"
+		"TextENG": "``Oh, right...... Rena, Kei-chan. ...Don't get upset, but listen. This is just between us, okay?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153573,
 		"TextJPN": "魅音が俺たち二人を物陰に引き込むと声を潜めた。",
-		"TextENG": "Mion draws us both into the shade, and drops her voice."
+		"TextENG": "Mion drew us both behind cover and lowered her voice to a whisper."
 	},
 	{
 		"type": "MSGSET",
@@ -168,7 +168,7 @@
 		"PreTextTags": "@vS24/02/NREN_0080.",
 		"TextJPN": "「…何？　どうしたの魅ぃちゃん」",
 		"NamesENG": "Rena",
-		"TextENG": "``...What is it? What's the matter, Mii-chan?``"
+		"TextENG": "``...What? What is it, Mii-chan?``"
 	},
 	{
 		"type": "MSGSET",
@@ -177,31 +177,31 @@
 		"PreTextTags": "@vS24/01/NKEI_0160.",
 		"TextJPN": "「また何か情報でもわかったのか」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``You've found out some more information?``"
+		"TextENG": "``Have you learned something new?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153576,
 		"TextJPN": "隔離の初期にこそ自衛隊から充分な説明があったが、最近はどういう状況になっているのか対外的な発表は一切なくなっていた。",
-		"TextENG": "There was enough of an explanation from the Self-Defense Forces during the early periods of the quarantine, but recently, they've stopped announcing what kind of situation we are in."
+		"TextENG": "The SDF gave us a good enough explanation when the quarantine first started, but lately they haven't made any more announcements about the ongoing situation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153577,
 		"TextJPN": "そうなると口コミの噂話しかなくなるが、各町会ごとに細かく隔離されていたため、村人の交流は限られており、その噂話すらも満足に疎通できない状態だった。",
-		"TextENG": "The rumors have also started to disappear, and due to the isolation of every neighborhood, the interactions between the villagers are very limited, we are at a state where even rumors aren't an acceptable form of communication."
+		"TextENG": "That meant we were left with nothing but rumors and word of mouth, but since we were further isolated based on how we were divided under the council, the villagers had limited interaction with each other, and even those rumors weren't able to get around well enough."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153578,
 		"TextJPN": "だが幸いなことに、この村にはアマチュア無線の愛好家が少なくなかった。彼らはそれを使い、連絡を取り合っていたのである。",
-		"TextENG": "But luckily, there are a few amateur radio enthusiasts in the village. They've been keeping in touch with one another that way."
+		"TextENG": "Fortunately enough, our village had a decent amount of amateur radio fans. So they were using their radios to contact each other."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153579,
 		"TextJPN": "魅音は無線を使って、別の隔離町会の状況などを確認し合い、雛見沢全体の状況把握に努めているらしかった。",
-		"TextENG": "So by using the Radio, Mion has been able to confirm the situation of the other neighborhoods, that way, she was able to grasp the entire situation Hinamizawa is now part of."
+		"TextENG": "Mion was one of the people using her radio to check how the other quarantined areas were doing, trying to get a grasp of the full state of Hinamizawa."
 	},
 	{
 		"type": "MSGSET",
@@ -210,7 +210,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0170.",
 		"TextJPN": "「何しろ、未だ電話が回復しないからな。こういう時、本当に無線は貴重だぜ。…それで、何がわかったんだ？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``After all, the phones aren't working yet. So at a time like this, a radio can be pretty valuable. ...Have you found out anything else?``"
+		"TextENG": "``Well, our phone lines still haven't recovered. So the radios are really crucial in times like these. ...So, did you learn anything?``"
 	},
 	{
 		"type": "MSGSET",
@@ -219,43 +219,43 @@
 		"PreTextTags": "@vS24/03/NMIO_0180.",
 		"TextJPN": "「………………うん。というか、……………梨花ちゃんが収容されて容態不明ってのは本当らしい」",
 		"NamesENG": "Mion",
-		"TextENG": "``..................Yeah. It seems............... Rika-chan has been taken and labeled as an unknown condition.``"
+		"TextENG": "``..................Yes. Well............... It sounds like it's true that Rika-chan's been taken into custody, and no one knows what's going on with her.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153582,
 		"TextJPN": "ここで話は少しだけ遡る。",
-		"TextENG": "I need a moment to think."
+		"TextENG": "She took a brief pause after that."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153583,
 		"TextJPN": "オヤシロさまの祟りを疑い不安感を拭えない人々のために、古手梨花の村内巡回を園崎家は強く要望していたのだが、なぜかその要望は無視され続けた。",
-		"TextENG": "For people filled with insecurity and doubt the curse of Oyashiro-sama, the Sonozaki family strongly requested a patrol of the village in search of Rika Furude, ignoring the demands of the Self-Defense Forces."
+		"TextENG": "The Sonozaki family had been strongly requesting that Rika Furude go around the village, so they could wipe away any fears of Oyashiro-sama's curse, but those demands kept getting ignored."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153584,
 		"TextJPN": "保菌者が村内を闊歩することで感染を拡大することがないよう、町会区分ごとに厳しく自衛隊が隔離していたため、古手梨花の近況を知ることができず、そのことはさらに村人の不安感を掻き立てていたのである。",
-		"TextENG": "They didn't want the villagers and carriers striding around the village spreading the virus, one of the reasons why the Self-Defense Forces had to strictly isolate each neighborhood from one another. But without knowing the present condition of Rika Furude, the villagers sense of anxiety will only increase further."
+		"TextENG": "The SDF didn't want a carrier traversing the village and spreading infection, so they kept each council area strictly isolated, and so none of the villagers could find out how Rika Furude was doing, which only stirred their anxieties up even more."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153585,
 		"TextJPN": "もし、オヤシロさまの生まれ変わりである彼女の身に何かあったなら、…それが意味するところはただひとつ。伝承が伝える、村の終末に他ならないのだから。",
-		"TextENG": "If she really is the reincarnation Oyashiro-sama... then this can only mean one thing. The legend says, it will equal none other than the end of this village."
+		"TextENG": "If anything were to happen to her, the reincarnation of Oyashiro-sama... then that could only mean one thing. The end of the village, as passed down in legend."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153586,
 		"TextJPN": "その不安はとうとう行き着くところまで行き着き、古手梨花の情報が入らないのは、彼女の身に何かがあったからで、自衛隊はそれを隠すためにわざとはぐらかしているのではないかというデマが生まれるまでに至った。",
-		"TextENG": "We have finally reached the point where our anxiety is at its limit, there isn't even any information on Rika Furude, was there something hidden inside her body, or will the Self-Defense Forces call this rumor false to cover up what's inside her."
+		"TextENG": "That fear had finally reached its logical conclusion-- if they couldn't get information on Rika Furude, then something had happened to her, and the SDF was trying to cover it up--that fear had made its way into rumor."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153587,
 		"TextJPN": "誰もがそのデマを否定したが、そのデマを払拭する方法は古手梨花の無事な姿を村人が見ることしかない。だがそれは叶えられず、さらに村人の不安感を掻き立てることになっていた…。",
-		"TextENG": "Even if they deny it, the villagers will have to see Rika Furude safe so the rumor can be dispelled. But we all know that won't happen, as they want to further arouse a sense of insecurity among the villagers..."
+		"TextENG": "Everyone denied those rumors, of course, but the only way to get rid of them was for the villagers to see Rika Furude safe and sound. That wasn't happening, though, so the villagers' collective anxiety was only growing stronger..."
 	},
 	{
 		"type": "MSGSET",
@@ -264,7 +264,7 @@
 		"PreTextTags": "@vS24/02/NREN_0090.",
 		"TextJPN": "「梨花ちゃんが容態不明ってどういうことなの？！　梨花ちゃんがウィルスにやられちゃったってことなの？！」",
 		"NamesENG": "Rena",
-		"TextENG": "``What is this unknown condition they labeled Rika-chan with?! Does it mean Rika-chan got infected with the virus?!``"
+		"TextENG": "``What do you mean no one knows how Rika-chan's doing?! Are you saying Rika-chan got hit by the virus?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -273,7 +273,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0190.",
 		"TextJPN": "「シー！！　声が大きいよ！　……ウィルスかどうかは知らないけど、とにかく防疫部隊に収容されて、その後、戻ってこないらしいの。安否は不明。連れてかれたのは何人かが目撃していて間違いないって」",
 		"NamesENG": "Mion",
-		"TextENG": "``Shush!! You're being too loud! ......I don't know if it's the virus or not, but she's been taken by the quarantine troops. Since then, she hasn't come back. Her safety is unknown. But, it seems there are some witnesses that saw her being taken away.``"
+		"TextENG": "``Shh!! You're being too loud! ......I don't know if it was the virus, but either way, she was taken into custody by the disease control squad, and she hasn't been seen since. No one knows if she's safe. Several different people witnessed her being taken away, so that's certain, at least.``"
 	},
 	{
 		"type": "MSGSET",
@@ -282,7 +282,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0180.",
 		"TextJPN": "「それはいつの話だ？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``How long has it been since she was taken?``"
+		"TextENG": "``When did that happen?``"
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0200.",
 		"TextJPN": "「隔離の当日だって」",
 		"NamesENG": "Mion",
-		"TextENG": "``Since the day the quarantine began.``"
+		"TextENG": "``The day of the quarantine.``"
 	},
 	{
 		"type": "MSGSET",
@@ -300,13 +300,13 @@
 		"PreTextTags": "@vS24/02/NREN_0100.",
 		"TextJPN": "「…沙都子ちゃんは？！　梨花ちゃんと一緒に住んでるんだから、……その、…、」",
 		"NamesENG": "Rena",
-		"TextENG": "``...And Satoko-chan?! She's living with Rika-chan...... is she with her...``"
+		"TextENG": "``...And Satoko-chan?! She lives with Rika-chan, so... well...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153593,
 		"TextJPN": "梨花ちゃんがウィルスの犠牲者なら、同居している沙都子も……。",
-		"TextENG": "If Rika-chan is a victim of the virus, and since Satoko lives with her, then does that mean......"
+		"TextENG": "If Rika-chan fell victim to the virus, then as her housemate, Satoko would've..."
 	},
 	{
 		"type": "MSGSET",
@@ -315,7 +315,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0210.",
 		"TextJPN": "「そこまで詳しくは…」",
 		"NamesENG": "Mion",
-		"TextENG": "``There wasn't any details about that...``"
+		"TextENG": "``I don't have any info on that...``"
 	},
 	{
 		"type": "MSGSET",
@@ -324,7 +324,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0190.",
 		"TextJPN": "「……だろうな。村の年寄り連中は、梨花ちゃんのことに関心はあっても、沙都子のことはまったく無関心だからな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......I know why. It's because all those old people in the village only care about Rika-chan, they don't feel any sympathy towards Satoko at all.``"
+		"TextENG": "``...Figures. The elders of the village may care about Rika-chan, but they've never wanted anything to do with Satoko.``"
 	},
 	{
 		"type": "MSGSET",
@@ -333,7 +333,7 @@
 		"PreTextTags": "@vS24/02/NREN_0110.",
 		"TextJPN": "「沙都子ちゃんも、収容されたのかな……」",
 		"NamesENG": "Rena",
-		"TextENG": "``I wonder if Satoko-chan was taken, too......``"
+		"TextENG": "``Do you think Satoko-chan was taken into custody too......?``"
 	},
 	{
 		"type": "MSGSET",
@@ -342,7 +342,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0220.",
 		"TextJPN": "「………沙都子は収容されたわけじゃないみたい。…感染者が出たら、同居人だって疑うのが防疫の基本だと思うんだけどね」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........It doesn't seem Satoko was taken. ...But if someone comes down with the infection, normally the basic next step in a quarantine would be to confine their housemates.``"
+		"TextENG": "``......Doesn't sound like it. ...Though I think it's just basic disease control to suspect infection in anyone living with an infected person.``"
 	},
 	{
 		"type": "MSGSET",
@@ -351,7 +351,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0230.",
 		"TextJPN": "「…無線で聞く限りは、収容されたのは梨花ちゃんだけで、沙都子はそういうわけじゃないみたい。………それでね、…何だか妙な話になってるんだよ…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...From what I heard on the radio, the only one being held is Rika-chan, but there shouldn't be a reason why they didn't take Satoko. .........So, this story is getting pretty strange...``"
+		"TextENG": "``...From what I'm hearing on the radio, only Rika-chan was taken in. Satoko wasn't, apparently. ......Also... this part sounds kind of strange, but...``"
 	},
 	{
 		"type": "MSGSET",
@@ -360,7 +360,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0200.",
 		"TextJPN": "「妙な話…？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``A strange story...?``"
+		"TextENG": "``Strange...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -369,7 +369,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0240.",
 		"TextJPN": "「…うん。…………ほら、沙都子の両親がダムの誘致派だったのは知ってるでしょ？」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Yeah. ............Hey, you do know Satoko's parents were part of and promoted the pro dam faction, right?"
+		"TextENG": "``...Yeah. .........So, you know how Satoko's parents were in favor of the dam being built, right?``"
 	},
 	{
 		"type": "MSGSET",
@@ -378,7 +378,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0250.",
 		"TextJPN": "「それで、オヤシロさまのバチが当たって事故死しちゃって…、」",
 		"NamesENG": "Mion",
-		"TextENG": "And so, they received divine punishment from Oyashiro-sama and died in an accident...``"
+		"TextENG": "``And how afterward, they died in an accident due to Oyashiro-sama's curse...``"
 	},
 	{
 		"type": "MSGSET",
@@ -387,7 +387,7 @@
 		"PreTextTags": "@vS24/02/NREN_0120.",
 		"TextJPN": "「……沙都子ちゃんの北条家が、オヤシロさまに祟られている、呪われている、というような話？」",
 		"NamesENG": "Rena",
-		"TextENG": "``......So you're saying that the Houjou family and Satoko-chan, were targeted and cursed by Oyashiro-sama, something like that?``"
+		"TextENG": "``...You're talking about the rumor that Satoko-chan and the Houjou family are cursed and hated by Oyashiro-sama?``"
 	},
 	{
 		"type": "MSGSET",
@@ -396,7 +396,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0260.",
 		"TextJPN": "「うん。……罰当たり者の沙都子が、オヤシロさまの生まれ変わりである神聖な梨花ちゃまと同居すると穢れが移るかもしれない、みたいな酷いことを言ってる連中が前からいたんだけど……」",
 		"NamesENG": "Mion",
-		"TextENG": "``Yeah. That Satoko was bad karma because she was an impurity who lived alongside sacred Rika-chama, the reincarnation of Oyashiro-sama... People have been saying this for some time......"
+		"TextENG": "``Yeah. ......There has always been a horrible group of people that said living with a cursed person like Satoko would cause her taint to pass onto the holy reincarnation, Rika-chan...``"
 	},
 	{
 		"type": "MSGSET",
@@ -405,7 +405,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0270.",
 		"TextJPN": "「そういう連中が、今回の『オヤシロさまの祟り』を沙都子のせいだと言い出してるみたいなんだ」",
 		"NamesENG": "Mion",
-		"TextENG": "But now, they're saying that ``The curse of Oyashiro-sama`` has been brought on by Satoko.``"
+		"TextENG": "``And now those people are starting to say this is Oyashiro-sama's curse, that Satoko's to blame.``"
 	},
 	{
 		"type": "MSGSET",
@@ -414,7 +414,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0210.",
 		"TextJPN": "「何だって？！　馬鹿な話しやがって！！　連中は箸が転んでも沙都子のせいだな！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``What?! That's stupid talk!! How can those people blame everything on Satoko!!``"
+		"TextENG": "``What?! That's stupid as hell!! Those jerks will blame Satoko at the drop of a hat!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -423,7 +423,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0280.",
 		"TextJPN": "「もちろん、冗談だと信じたいけど。……沙都子を簀巻きにして鬼ヶ淵に沈めれば、オヤシロさまのお怒りが治まるんじゃないかって話が、向こうの町会でまことしやかに流れてるらしいよ…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Of course, I would like this to be just a joke. ......But, some people are actually thinking we should punish Satoko by wrapping her in a bamboo mat and throw her into Onigafuchi Swamp, in an attempt to quell Oyashiro-sama's anger. It's very plausible the neighborhood association might try this sooner or later...``"
+		"TextENG": "``Of course it's nonsense. ...but people in the other areas are starting to say they might be able to quell Oyashiro-sama's anger by binding up Satoko and sinking her into the swamp. And they're talking like they believe it too...``"
 	},
 	{
 		"type": "MSGSET",
@@ -432,19 +432,19 @@
 		"PreTextTags": "@vS24/02/NREN_0130.",
 		"TextJPN": "「そんな…！！　ねぇ私たちって、そんなにも未開人なの？！　文明人じゃないの？！　私たちが日常を失ってから、やっと１週間が経った程度なのに、もうそんな迷信が蔓延ってるの？！」",
 		"NamesENG": "Rena",
-		"TextENG": "``This can't be...!! Are these people savages?! Aren't they civilized?! Our daily lives have fallen apart, and it's only been one week, how has this superstition gotten so rampant?!``"
+		"TextENG": "``No way...!! Are we savages now?! I thought we were civilized! It's only been a week since our daily routines were broken, and we're already talking about drowning people in swamps?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153608,
 		"TextJPN": "レナの憤慨はもっともだった。…だが、思い返せば、雛見沢が迷信に取り憑かれていたのは、ウィルス騒ぎのずっと前からだ。",
-		"TextENG": "It seems Rena is outraged the most. But in retrospect, Hinamizawa has always had an obsession with superstition, even long before outbreak of this virus."
+		"TextENG": "Rena's indignation was justified. ...But thinking back on it, Hinamizawa was possessed by such strange beliefs long before this whole virus commotion."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153609,
 		"TextJPN": "雛見沢は文明の地であった試しなどないのだ。文明人のふりをしているだけで、ちょっと化けの皮が剥がれれば、すぐにでも無知蒙昧な迷信が顔を出す…。",
-		"TextENG": "It even feels like Hinamizawa never passed through the trials of civilization. That it just pretended to be civilized, but now its mask has come off, and all its ignorant superstition has appeared immediately..."
+		"TextENG": "Hinamizawa had never shown any proof it was a ``civilized`` land. The people there simply acted that way, but once you tore away the facade, they quickly revealed themselves as adherents to some truly bizarre delusions..."
 	},
 	{
 		"type": "MSGSET",
@@ -453,7 +453,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0220.",
 		"TextJPN": "「………魅音の表情を見る限り、…どうも冗談で済まそうって話にはなってないらしいな…」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``.........From what I can tell about your expression, Mion... it doesn't seem this story is some kind of joke...``"
+		"TextENG": "``......Judging from your expression, Mion... you're not going to tell us this was some joke all along, right...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -468,7 +468,7 @@
 		"type": "MSGSET",
 		"MessageID": 153612,
 		"TextJPN": "魅音の俯きは返事なくしてそれを肯定した。",
-		"TextENG": "Mion looks down, and doesn't answer."
+		"TextENG": "Mion's silence and downcast stare affirmed it as true."
 	},
 	{
 		"type": "MSGSET",
@@ -477,7 +477,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0300.",
 		"TextJPN": "「も、もちろん私も無線で冷静になるように言ってるよ？！　でも、なかなか治まってくれない…」",
 		"NamesENG": "Mion",
-		"TextENG": "``Of course, do you think I should try and calm them down through the radio?! However, I doubt it would work...``"
+		"TextENG": "``O-Of course I've told them they need to calm down over the radio! But they're not listening to me at all...``"
 	},
 	{
 		"type": "MSGSET",
@@ -486,7 +486,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0230.",
 		"TextJPN": "「く、くそ…！　梨花ちゃんが収容されたということは、沙都子は今、ひとりであの倉庫小屋に暮らしてるわけか。………万が一を考えると危なくないか？！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Damn it...! Rika-chan was taken from us and now they're thinking about taking Satoko, she's even living all alone in that warehouse right now. .........When I think about it, isn't she in danger?!``"
+		"TextENG": "``Kh! Shit...! If Rika-chan's been taken into custody, that means Satoko is currently living in that storage hut all by herself? ......She's in danger if they try to pull anything, isn't she?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -495,49 +495,49 @@
 		"PreTextTags": "@vS24/02/NREN_0140.",
 		"TextJPN": "「そうだね。沙都子ちゃん１人じゃできることに限界もあると思う。…私たちのところに匿う方がいいんじゃないかな、かな」",
 		"NamesENG": "Rena",
-		"TextENG": "``You're right. There's a limit to what Satoko-chan can do by herself. ...I wonder if we should hide her with us, I wonder.``"
+		"TextENG": "``True. There's only so much Satoko-chan can do by herself. ...Wouldn't it be better to shelter her in our area? Wouldn't it?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153616,
 		"TextJPN": "レナの提案はもっともだった。このまま沙都子を一人きりにしたら、迷信に取り憑かれた何者かにいつ襲われるかもわからない！",
-		"TextENG": "Rena's suggestion sounds very reasonable. After all, if we leave Satoko alone like this, there's no telling when she could be attacked by someone obsessed with superstition!"
+		"TextENG": "Rena's suggestion was a good one. If we left Satoko alone like this, then those caught up in those wild fantasies might go after her!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153617,
 		"TextJPN": "だが、沙都子を誰の家に匿うんだ？",
-		"TextENG": "But, whose house should we hide Satoko in?"
+		"TextENG": "But whose home would we shelter her in?"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153618,
 		"TextJPN": "魅音が言うには、沙都子はすでにウィルスに感染しているという噂がまことしやかに囁かれているという。",
-		"TextENG": "So it is as Mion says, everyone is whispering rumors that Satoko is already infected with the virus as if it were true."
+		"TextENG": "According to Mion, the rumors that Satoko was already infected with the virus are being spread as though they're true."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153619,
 		"TextJPN": "今の雛見沢は、口コミという原始的通信手段で支配されている。この通信法はあまりにデマが紛れ込みやすい。集団心理がそうだと決め込んだある種の思い込みを、尾ひれを付けて拡大し既成事実にしてしまう。",
-		"TextENG": "Hinamizawa at present is dominated by a primitive means of communication called word of mouth. A false rumor can easily become mixed using this form of communication. This certain assumption is what convinced their group psychology it was real, they simply attached a tail fin and made it an established fact."
+		"TextENG": "Word of mouth, that primitive means of communication, was all Hinamizawa had. It was easy for rumors to work their way into such communication. And because of mass psychology, people convince themselves those statements are true, embellishing them even farther until they become established fact."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153620,
 		"TextJPN": "そうなれば、真実と無関係に沙都子は感染者ということになってしまう。そうなれば、沙都子を引き取った家も同じ扱いだ…。",
-		"TextENG": "If that can happen, then Satoko will soon be considered infected regardless of the truth. They just want to give her the same treatment as they did her family..."
+		"TextENG": "At that point, the truth won't matter. Satoko will effectively become one of the infected. Once that happens, whichever home takes her in will face the same treatment..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153621,
 		"TextJPN": "言うまでもなく、魅音の園崎家は当初から沙都子の北条家と仲が悪い。……その魅音の家が沙都子を匿うというのは非常に難しいことだろう。",
-		"TextENG": "Needless to say, the Sonozaki family and Mion have been on bad terms with the Houjou's and Satoko from the beginning. ......So it will be very difficult to shelter Satoko in Mion's house."
+		"TextENG": "It went without saying, but Mion's home, the Sonozaki family, were already on bad terms with Satoko and the Houjou family. ......It would be extremely difficult for Mion's family to shelter Satoko."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153622,
 		"TextJPN": "俺の家ならどうか。……お袋は理解してくれそうだが、偏執的なまでに未だ外部との接触を嫌う親父の理解を得られるとは到底思えなかった。",
-		"TextENG": "What about my house. ......I'm sure my mom would understand, but I haven't yet considered the possibility that my dad could be paranoid enough to be against contact with anyone from the outside."
+		"TextENG": "What about my family? ......My mother would probably understand, but considering the fact my father is still obstinately refusing to expose himself to the outdoors, I couldn't imagine him taking Satoko in."
 	},
 	{
 		"type": "MSGSET",
@@ -546,19 +546,19 @@
 		"PreTextTags": "@vS24/02/NREN_0150.",
 		"TextJPN": "「……うん。みんなの家じゃどうせ無理だろうってのはわかってるよ。だから、もし沙都子ちゃんを匿おうってことになったら、レナの家で匿うよ。……大丈夫。お父さんには文句なんか言わせないから」",
 		"NamesENG": "Rena",
-		"TextENG": "``......Yup. I knew it would be impossible to hide her at your houses. Therefore, it should be expected of Rena to hide Satoko-chan in her house. ......Okay. I'll just tell my dad something so he won't complain.``"
+		"TextENG": "``......Yeah. I know it's impossible for your families. So if we do end up sheltering Satoko-chan, I'll shelter her in my home. ......Don't worry. I won't let my father voice any objections.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153624,
 		"TextJPN": "よくは知らないが、レナは家の家計を握っていて、本気になれば父親にもぎゃふんと言わせることができるらしい。",
-		"TextENG": "I don't know about that, Rena's house is under a tight budget, so I doubt she can say anything to convince her dad to allow her."
+		"TextENG": "I had no idea why, but Rena held control of her family's finances, so if she got serious, she could make her father give in."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153625,
 		"TextJPN": "胸を張ってウチも大丈夫だと言えない自分が悲しかったし、どうせそうだろうと見下されていたことも悔しかったが、どうにもならない。…それに、今は下らないプライドは必要なかった。",
-		"TextENG": "I just want to be proud and tell her she can stay at my house, but I feel deep sadness that I can't even do that, it's so frustrating that I can only bow my head in shame, we're so helpless. ...I don't need this worthless pride right now."
+		"TextENG": "It made me sad that I couldn't stick my chest out and say my family could too, and I hated that she just assumed it wasn't possible, but I couldn't do anything about that. ...It's not like that pride would matter in this situation."
 	},
 	{
 		"type": "MSGSET",
@@ -567,7 +567,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0240.",
 		"TextJPN": "「わかった。沙都子と接触できたら、レナの家へ行くよう伝えよう。いや、むしろ何とか沙都子と接触をして、こちらへ呼びたいくらいだな。……魅音の話を聞く限り、沙都子のいる町会周りはどうもヤバそうだからな…」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I know. If we can contact Satoko, we should tell her to go to Rena's house. No, we should contact Satoko in person, I don't think we'll be able to call her. ......And from what we've heard from Mion, the neighborhood association will be looking for Satoko so it will be dangerous...``"
+		"TextENG": "``All right. If we can make contact with Satoko, we'll tell her to head to Rena's home. I wish I could reach out to her myself, but... ...From what you've told us, Mion, it sounds like the area around Satoko's house is dangerous...``"
 	},
 	{
 		"type": "MSGSET",
@@ -576,19 +576,19 @@
 		"PreTextTags": "@vS24/03/NMIO_0310.",
 		"TextJPN": "「あっちは信心深くて過激な神社部の幹部が多いからね……。でね、……実は、沙都子だけの問題じゃないんだよ。………場合によっては、…圭ちゃんやレナも危ないかもしれないんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``There are also many radical executives who have a deep devotion to the Shrine...... So in fact...... this isn't just a problem for Satoko. .........Depending on the situation, Kei-chan, Rena, you could be in danger, too.``"
+		"TextENG": "``That's because there's a lot of strong believers who live around there... But... to be honest, Satoko's not the only problem. .........Depending how it goes... both of you two could be in trouble too.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153628,
 		"TextJPN": "魅音の目がさらに鋭くなり、俺とレナを見比べる。",
-		"TextENG": "Mion's eyes become sharper, she visually compares both Rena and I."
+		"TextENG": "Mion's eyes grew even sharper, looking back and forth between me and Rena."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153629,
 		"TextJPN": "その目線の冷たさは、沙都子の心配をしながらも、自分だけは蚊帳の外だと思い込んできた浅ましさを、引き裂くものだった。",
-		"TextENG": "I can see the coldness of her glance, as she worries about Satoko, convinced that her own mosquito net of power and influence, has been torn apart."
+		"TextENG": "Even though she was worried about Satoko, the chill in her gaze was enough to shred the naive thought that at least we would be safe."
 	},
 	{
 		"type": "MSGSET",
@@ -597,7 +597,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0320.",
 		"TextJPN": "「先日も話したよね。例のウィルスが雛見沢土着のものかもしれないって噂。その話がね、だいぶ信憑性を帯びてきててね。古来から村人全員が感染してたんじゃないかって言うんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``I told you the other day. About the rumor that this virus is actually indigenous to Hinamizawa. It's just that story has a considerable amount of credibility to it. They say that all the villagers have already been infected since ancient times.``"
+		"TextENG": "``I mentioned this the other day, right? The rumors that this virus might be indigenous to Hinamizawa. Those rumors are starting to gain a lot of traction. Some are even saying every villager's probably been infected for hundreds of years.``"
 	},
 	{
 		"type": "MSGSET",
@@ -606,7 +606,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0250.",
 		"TextJPN": "「だから、それじゃおかしいだろ…！　だったら昔から連日死者が出てなきゃならないぞ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``But, there's something strange with this story...! Because if it was true, wouldn't people be dying every day?!``"
+		"TextENG": "``But that's just crazy...! If that were true, then people would've been dying every day way back when!``"
 	},
 	{
 		"type": "MSGSET",
@@ -615,7 +615,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0330.",
 		"TextJPN": "「それでその、…そうだと言ってる連中の言い分が面白いんだよ…。そのウィルスは、この村の中にいる限りは安定していて無害だって言うんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``You're right... but the people who believe this story... They say that the virus is stable and harmless as long as you remain in the village.``"
+		"TextENG": "``Well, umm... the ones insisting on that argument have an interesting idea... They're saying that the virus remains stable and harmless so long as you stay in the village."
 	},
 	{
 		"type": "MSGSET",
@@ -624,7 +624,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0340.",
 		"TextJPN": "「さらに言うと、この村にずっとずっと長く住み続けている一族には、生まれつきの免疫みたいなものがあって大丈夫だって話らしいんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``Furthermore, that the families who have continued to live in this village for a long time will be okay, since they have built up a natural immunity to it, or something like that.``"
+		"TextENG": "They go even further, arguing that the families who have lived in this village for many, many years are all born with an immunity that keeps them safe.``"
 	},
 	{
 		"type": "MSGSET",
@@ -633,7 +633,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0260.",
 		"TextJPN": "「…さっぱりわからねぇぞ。つまり何だ。……まさか、例えば他所から引っ越してきた俺やレナは、その免疫がないからとか言い出すんじゃないだろうな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``...I don't understand. In other words, wait...... No way, you mean for example that people like me and Rena who moved here from the outside don't have an immunity.``"
+		"TextENG": "``...I don't get it. So what? ......Are you telling me they're saying that people like Rena and I, who moved here from outside, are a risk because we don't have that immunity?``"
 	},
 	{
 		"type": "MSGSET",
@@ -642,7 +642,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0350.",
 		"TextJPN": "「まさにそれだよ！　近年、雛見沢に引っ越してきた人間のせいで、そのウィルスの調和が崩れて、……その、村人全員のウィルスがおかしくなって、……えぇっと、……うぅん、」",
 		"NamesENG": "Mion",
-		"TextENG": "``That's exactly it! In recent years, because of the number of people moving into Hinamizawa, the harmony of the virus has collapsed...... That, is what has been causing the virus in the villagers to act up...... Umm...... Uh.``"
+		"TextENG": "``That's exactly it! They're saying our harmony or whatever with the virus is collapsing because of the people moving into Hinamizawa... and umm, that's making the virus go crazy in everyone... Uhh... Nah.``"
 	},
 	{
 		"type": "MSGSET",
@@ -651,7 +651,7 @@
 		"PreTextTags": "@vS24/02/NREN_0160.",
 		"TextJPN": "「…まさか、魅ぃちゃんまでそのとんでもない話を信じてるわけないよね…？」",
 		"NamesENG": "Rena",
-		"TextENG": "``...No way, you don't believe this ridiculous story do you, Mii-chan...?``"
+		"TextENG": "``...You're not telling us you believe such an outrageous idea too, are you, Mii-chan?``"
 	},
 	{
 		"type": "MSGSET",
@@ -660,7 +660,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0360.",
 		"TextJPN": "「もちろんだよ！　こんな訳のわかんない話が通用するわけない！！　でも、…なぜかみんな信じてるんだよ！！　私も訳がわかんない！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Of course not! There's no way that kind of nonsense makes any sense!! But... they believe it!! And I don't know why!!``"
+		"TextENG": "``Of course not! There's no way I'd fall for anything that sounds that crazy!! But... for some reason everyone else believes it!! I don't get it at all!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -669,7 +669,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0370.",
 		"TextJPN": "「普段だったら絶対こんな馬鹿な話は誰も信じないのに！　なぜかここ数日、妙な話やデマが当り前のように通用して飛び交ってる！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Normally no one would even believe such a stupid story! But for some reason the past few days false rumors flying around like that have been spoken as if they're true!``"
+		"TextENG": "``Normally no one would ever believe such stupid nonsense! But these past few days, those weird ideas and rumors are being passed around like they're just common sense!``"
 	},
 	{
 		"type": "MSGSET",
@@ -678,7 +678,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0380.",
 		"TextJPN": "「私は初日からずっと無線を聞いてるんだけど、最近の村人はどんどんおかしくなってるんだよ…！　異常な生活で心の緊張がとかトラウマがとか、そんな甘っちょろいレベルじゃない！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Even since the day this all began, the villagers on the radio slowly started to act weird...! I guess it's the strain and trauma on the mind of living such an abnormal life!``"
+		"TextENG": "``I've been listening on the radio since the very first day, but lately, the villagers are believing weirder and weirder stuff...! I don't know if it's mental stress or trauma or whatever, but calling it that is optimistic at this point!``"
 	},
 	{
 		"type": "MSGSET",
@@ -687,7 +687,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0390.",
 		"TextJPN": "「明らかに嘘だろうデマだろうと思うことが当り前のように横行し、それを誰も覆せない！　誰かがそれを否定すると、感染者扱いをされそうになる！」",
 		"NamesENG": "Mion",
-		"TextENG": "``No one is even considering these false rumors could be a lie, they're becoming rampant and commonplace! And if you attempt to deny them, you're treated like an infected person!``"
+		"TextENG": "``These lies and rumors are running rampant, but no one is doing anything to stop them! If anyone tries, they could be treated as one of the infected too!``"
 	},
 	{
 		"type": "MSGSET",
@@ -696,49 +696,49 @@
 		"PreTextTags": "@vS24/03/NMIO_0400.",
 		"TextJPN": "「すっごく気持ち悪いことになってるんだよ！　何かが変！！　だから用心して！」",
 		"NamesENG": "Mion",
-		"TextENG": "``It's gotten really bad! Something is strange!! So be careful!``"
+		"TextENG": "``It's getting really awful around here! Something's not right with people!! So watch yourselves!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153642,
 		"TextJPN": "その魅音の必死な形相に、俺とレナは絶句する。",
-		"TextENG": "Mion looks at us desperately, Rena and I are at a loss for words."
+		"TextENG": "Rena and I were both left speechless by Mion's desperation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153643,
 		"TextJPN": "彼女が傍受したという無線を、俺たちは耳にすることができなくてさぞ幸運だったに違いない。",
-		"TextENG": "I'm glad she intercepted those radio communications. There's no way we could have heard it, we're lucky that way."
+		"TextENG": "It was clearly a good thing that we weren't able to listen to what she's picked up over the radio."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153644,
 		"TextJPN": "異常環境に置かれ、頂点にまで達したフラストレーションと信仰を基礎にする不安感と恐怖は次々にデマを生み出し、生贄に誰かを担ぎ上げることでしか払拭できない段階に至りつつあるのだ…。",
-		"TextENG": "To be placed in such an abnormal environment, where our frustration has reached its apex caused by fear and anxiety which layed the foundation for false rumors to be created one after another, it's now reached the stage where only a sacrifice can be raised to dispel our fears..."
+		"TextENG": "Thrust into these abnormal circumstances, their frustration had reached its peak, and that along with anxieties and fears founded on faith were producing new rumors one after another, and it was steadily approaching the point where someone would have to be sacrificed in order to clear those rumors away."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153645,
 		"TextJPN": "魅音の形相を見る限り、それは今や致命的なレベルに至りつつあるようだった。",
-		"TextENG": "I could tell this just by looking at Mion, she knows our situation will soon reach a critical level."
+		"TextENG": "Judging from Mion's expression, we were already approaching that critical moment."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153646,
 		"TextJPN": "…………その時、俺は初めて知る。",
-		"TextENG": "............Right there and then, I understood for the first time."
+		"TextENG": "............That was the moment I first realized it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153647,
 		"TextJPN": "俺たちが話している姿を見る村人の眼差しに、明らかに悪意が含まれていることを。",
-		"TextENG": "The villagers watching us talk, and the malice they intend to inflict."
+		"TextENG": "That there was clear hostility in the looks the villagers gave us as we talked to each other."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153648,
 		"TextJPN": "それは俺の気のせいではないらしい。レナもまたその気配を敏感に感じ取る。",
-		"TextENG": "This doesn't seem to be just my imagination. I get a sense that Rena is sensitively taking in this information as well."
+		"TextENG": "Apparently it wasn't just my imagination, either. Rena was quick to pick up on that too."
 	},
 	{
 		"type": "MSGSET",
@@ -747,7 +747,7 @@
 		"PreTextTags": "@vS24/02/NREN_0170.",
 		"TextJPN": "「…………………圭一くん。…用心しよ」",
 		"NamesENG": "Rena",
-		"TextENG": "``.....................Keiichi-kun. ...Be careful.``"
+		"TextENG": "``.....................Keiichi-kun. ...Protect yourself, okay?``"
 	},
 	{
 		"type": "MSGSET",
@@ -756,7 +756,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0270.",
 		"TextJPN": "「そ、…そうだな。下らないデマのせいで疑われるのは気に入らねぇが、@bりか.@<李下@>に@bかんむり.@<冠@>ってこともあるしな…」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I... I will. We have to be suspicious of such a stupid rumor, that's the only thing we can do now for Rika's sake...``"
+		"TextENG": "``Y-Yeah. I don't like being distrusted just because of stupid rumors, but it's best not to fuel the fire...``"
 	},
 	{
 		"type": "MSGSET",
@@ -765,7 +765,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0410.",
 		"TextJPN": "「…うん。レナも圭ちゃんも無用の外出は避けた方がいいと思う。あと、くれぐれもひとりで外出しないように。家のシャッターは締め切ってね」",
 		"NamesENG": "Mion",
-		"TextENG": "``...Yeah. Rena, Kei-chan, I think you should avoid going outside. But if you do, never go alone. Also, close all the shutters around your houses.``"
+		"TextENG": "``...Yeah. Rena, Kei-chan, you two should avoid going outside unless you have to. Also, make sure you don't go out alone. And seal your home up tight.``"
 	},
 	{
 		"type": "MSGSET",
@@ -774,24 +774,24 @@
 		"PreTextTags": "@vS24/03/NMIO_0420.",
 		"TextJPN": "「……心無いことを言ってくる人があっても、どんなに悔しくても買い言葉を返さないこと。……いいね…？」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Even if people come to your house to say cruel things, don't say anything back even if you are very annoyed. ......Understand...?``"
+		"TextENG": "``......If anyone says anything inconsiderate, don't provoke them. No matter how frustrating. ...Got it...?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153653,
 		"TextJPN": "今や、時折感じられる悪意の眼差しは、すでに気のせいでは済まされるものではない。",
-		"TextENG": "Now, I will have to occasionally feel their malicious gaze, and it's not my imagination."
+		"TextENG": "The hostile looks I felt from time to time were too much to pretend I just imagined them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153654,
 		"TextJPN": "外部との交流を断ち数百年を経た村の呪わしき習慣は、ほんの数年の文明開化ごときでは払拭できないということなのだ…。",
-		"TextENG": "They stopped exchanges with the outside and cut off contact for several hundred years using their hateful village customs, but it was all undone in just a few years of westernization..."
+		"TextENG": "The accursed customs of a village that had avoided contact with outsiders for centuries weren't about to be brushed away by a scant few years of civilization..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153655,
 		"TextJPN": "俺とレナは、表情を堅くしながら魅音の忠告に頷くしかなかった…。",
-		"TextENG": "There was nothing Rena and I could do but nod with a firm facial expression to the advice Mion gave us..."
+		"TextENG": "Rena and I could only nod in acknowledgment of Mion's warning, the tense looks clear on our faces..."
 	}
 ]

--- a/outbreak_4.json
+++ b/outbreak_4.json
@@ -11,7 +11,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "本総一エ－３４号@r昭和５８年７月７日@r雛見沢地区災害派遣本部長",
 		"AfterTextTags": "@|@y",
-		"TextENG": "58 General Affairs HQ No. 34@rJuly 7th, 1983@rHinamizawa District Disaster Relief Headquarters"
+		"TextENG": "Showa 58 HQ, General Affairs Division, Section 1, E-34@rJuly 7th, 1983@rDirector of Disaster Relief, Hinamizawa Region@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -19,7 +19,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "撤収命令（緊急）@r災害派遣本部長は、直ちに災害派遣部隊を緊急撤収せよ。@rただし撤収に当たっては、国立感染症研究所の指示に従うこと。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Withdrawal order (urgent)@rDisaster relief Headquarters, urgently withdraw disaster relief troops immediately.@rHowever upon withdrawal, follow instructions from the National Institute of Infectious Diseases."
+		"TextENG": "Evacuation Orders (Emergency)@rThe director of disaster relief is to evacuate the disaster relief units immediately.@rDuring evacuation, units are to follow the directions of the National Institute of Infectious Diseases.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -27,7 +27,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "記@r１．命令@r災害派遣部隊を国立感染症研究所の定める方法により、隔離地域外の指定された地域へ撤収させること。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Note@r1. Order@rUsing the method set by the National Institute of Infectious Diseases, the disaster relief troops must withdraw to the designated area outside the quarantine region."
+		"TextENG": "Notes:@r1. Orders@rThe disaster relief units will follow the directions of the National Institute of Infectious Diseases, and evacuate to the designated zone outside the quarantine.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -35,7 +35,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "２．理由@r隊員４名の定時採血よりη１７３型ウィルスの陽性反応が検出された。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "2. Reason@rFour members of personnel were detected positive for traces of the η-173 type virus during blood sampling."
+		"TextENG": "2. Reason@rThe routine blood tests detected a positive reaction for the Type-η173 virus in four squad members.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -43,7 +43,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "災害派遣部隊の現防疫装備では当該ウィルスに対して効果を持たないことが明らかとなった為。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "This revealed that our current disaster relief troops disease control equipment had no effect against the virus."
+		"TextENG": "This proves that the disaster relief units' current equipment is ineffective at preventing infection.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -51,7 +51,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "本総一エ－３５号@r昭和５８年７月７日@r第７３８装備実験中隊長",
 		"AfterTextTags": "@|@y",
-		"TextENG": "58 General Affairs HQ No. 35@rJuly 7th, 1983@rThe 738th Experimental Equipment Squadron Commander"
+		"TextENG": "Showa 58 HQ, General Affairs Division, Section 1, E-35@rJuly 7th, 1983@rCommander of the 738th Equipment Test Company@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -59,7 +59,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "出動命令（緊急）@r第７３８装備実験中隊は、第１３種防疫戦装備にて直ちに雛見沢地区災害派遣本部長の指示する作戦地へ出動すること。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Dispatch order (urgent)@rThe 738th experimental equipment squadron, immediately dispatch to the operational areas of the disaster relief Headquarters in the Hinamizawa district for a class thirteen quarantine."
+		"TextENG": "Dispatch Orders (Emergency)@rThe 738th Equipment Test Company is to deploy immediately with version 13 disease prevention equipment under the command of the Director of Disaster Relief, Hinamizawa Region.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -67,7 +67,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "記@r１．命令@r第７３８装備実験中隊を、本日付で雛見沢地区災害派遣本部長の指揮下に編入する。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Note@r1. Order@rThe 738th experimental equipment squadron, you are to be incorporated under the command of the Hinamizawa district disaster relief headquarters on this day."
+		"TextENG": "Notes:@r1. Orders@rAs of today, the 738th Equipment Test Company will be placed under the command of the Director of Disaster Relief, Hinamizawa Region.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -75,7 +75,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "実験中隊は本部長の指示する作戦地へ直ちに出動すること。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Your experimental Squadron will be dispatched immediately under further orders to operation areas from Headquarters."
+		"TextENG": "The Test Company shall follow the Director's orders and deploy on site immediately.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -83,7 +83,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "２．任務@r隔離地域の治安維持活動。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "2. Duty@rSecurity activities to maintain order of the quarantine area."
+		"TextENG": "2. Mission@rPeacekeeping in the quarantine zone.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -91,7 +91,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "３．備考@r別紙規定に従い実弾射撃が許可される。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "3. Remarks@rFiring with live ammunition is permitted in accordance with the provisions attachment appendix."
+		"TextENG": "3. Remarks@rDischarge of firearms will be authorized under the enclosed conditions.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -99,7 +99,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "昭和５８年７月６日@rアルファベットプロジェクト理事会@r雛見沢地区生物災害対策本部長",
 		"AfterTextTags": "@|@y",
-		"TextENG": "July 6th, 1983@rAlphabet Project board of directors@rHinamizawa district Biological Emergency Response Department"
+		"TextENG": "July 6th, 1983@rAlphabet Project Board of Directors@rDirector of Disaster Relief, Hinamizawa Region@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -107,7 +107,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "η１７３型ウィルスについて@r本件ウィルスは、丙種脳寄生型ウィルスに区分されるものです。@rここで、丙種脳寄生型（以下丙種）についてご説明いたします。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "About η-173 type virus@rThis virus, shall be classified as a Class-C brain parasite virus.@rHere, the Class-C brain parasite (Class-C or less) will be explained."
+		"TextENG": "Regarding the η173 Virus:@rThis virus has been classified as a Category C neuroparasitic virus.@rWhat follows is an explanation of its properties.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -115,7 +115,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "丙種は、人体の脳に寄生するウィルスの中でも非常に親和性が高く、また症状が特定しにくい為、近代までその存在が確認されていませんでした。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Class-C is a parasitic virus with a very high affinity to the human brain. Because of this, symptoms are hard to identify, so its existence was not confirmed until modern times."
+		"TextENG": "Of all the viruses that infect the human nervous system, this one demonstrates extremely strong compatibility with mankind. Also, due to the difficulty in identifying symptoms in the infected, its existence was not confirmed until the modern age.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -123,7 +123,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "１９４８年から行なわれた国連の非公式調査では、人類の９９％以上がこの丙種を脳内に寄生させているとしています。@rまた、その存在は人類の起源にまで遡る可能性が指摘されています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "An informal investigation was carried out by the United Nations in 1948, its findings stated that 99％ of humanity have this Class-C parasite infested within their brains.@rIn addition, the possibility that its existence dates back to the origin of the human race was also pointed out."
+		"TextENG": "According to an unofficial investigation conducted by the UN in 1948, over 99% of the human species contains this parasitic virus within their brain. Furthermore, it has been pointed out that it is likely this virus has been with humanity from the beginning.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -131,7 +131,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "上記でも申し上げましたように、丙種は人体に非常に馴染み、宿主がその寄生を意識することはありません。ですので、今日一般でもよく知られるような、大腸菌などの体内微生物と同じようなものと考えてよいでしょう。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "As mentioned above, Class-C adjusts to the human body very easily, so much that the host is never aware of the parasite. Because of this, you can consider this thing similar to internal microbes such as Escherichia coli, something well known to the general public."
+		"TextENG": "As that all suggests, this virus is extremely well integrated into the human body, and the host is unaware of the parasite. This makes the virus very similar to other microbes within the human body, such as Escherichia coli, which is commonly known of today.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -139,7 +139,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "ただ問題なのは、丙種は宿主の脳に対してある種の干渉を行う可能性が指摘されている点です。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "But the problem is, Class C-has been pointed out to exhibit a certain interference to the host's brain."
+		"TextENG": "However, the problem with this virus is that we have identified the possibility of this virus interfering with the host's brain functions.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "丙種は、同じウィルスを寄生した宿主にはより友好的になり、異なる種類の丙種ウィルスに寄生した宿主には敵対的になるよう誘導すると言われています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Class-C forces those which have been infested with the same parasite virus to become more friendly to a host, but is said to induce those infected to become hostile towards others infested with a different strain of the Class-C parasite virus."
+		"TextENG": "This virus makes its hosts amiable to other hosts of the same strain, and it directs its host to be antagonistic toward hosts of different strains.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -155,7 +155,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "国連調査の結果、丙種に区分されるウィルスは数百種にも及び、その分布図は奇しくも、今日の国境地図、宗教分布図と一致するという驚愕すべき事実を判明させました。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "As a result of the United Nations investigation, the Class-C virus was divided into several hundred strains, and coincidentally its distribution map matches the national borders of today, startling to say, we found from the facts that it also coincides with religion distribution maps."
+		"TextENG": "The UN investigation has discovered several hundred strains that would be classified under this virus, and another shocking fact was uncovered as well: The distribution map of these strains, oddly enough, matches up with present-day national borders and religious distributions.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -163,7 +163,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "また、それぞれの丙種には人格・行動の基礎にも深く関与していると言われ、各国人の人種固有と言われてきたいくつかの傾向は寄生する丙種の個性によって生み出されているとすら考えられています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "In addition, it is said that Class-C is deeply involved in the basis of our personality and behavior, and is believed to be the cause of several tendencies taken place between people of race-specific countries based on the characteristics of this unique Class-C parasite virus."
+		"TextENG": "Furthermore, it is suspected that each strain of this virus is deeply involved in shaping the foundation of its host's behavior and personality. So the theory stands that the unique traits of this parasitic virus are responsible for several tendencies generally attributed to race or nationality.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -171,7 +171,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "つまり、各国・各人種の文化や性格等、社会的生活の規範は全て、丙種の間接誘導によって作られていると考えられるのです。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "In other words, the cultural characteristics of each country and race, and standards of social life, are all thought to be produced by an indirect instruction from Class-C."
+		"TextENG": "In other words, this virus is theorized to be indirectly responsible for all patterns within societies, personalities, and the cultures of different ethnicities and nations.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -179,7 +179,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "丙種の存在を世界で最初に発見したのはドイツ人医師で、この発見を元に特定の人種への虐殺が主導されたと言われています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Class-C's existence was first discovered by a German doctor of the Nazi regime. Based on this discovery, it is said to be the main driving point for the genocide of a specific race of people."
+		"TextENG": "The first to uncover the existence of this virus was a German doctor within the Nazi administration, and it is theorized that this discovery led to the administration's massacre of particular peoples.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -187,7 +187,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "国連の丙種秘密調査委員会は、丙種が人類の最も唾棄すべき大罪のいくつかを間接的に主導している可能性を指摘し、丙種の撲滅を掲げましたが、その目標は民族浄化の引き金になりかねないという声が上がり委員会は混乱。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "The United Nations then launched a secret investigative committee into Class-C, and pointed out the possibility that it indirectly led to some of the mortal sins and abominations caused by most of humanity, not long after Class-C was soon advocated for destruction, but the committee gave voice to the confusion and stated that their goal would become the trigger for ethnic cleansing."
+		"TextENG": "The UN's secret investigation committee has identified the possibility that this virus has indirectly led humanity to commit its most heinous atrocities, and they called for the extermination of this virus, that call being held back by the fear that such an objective could trigger ethnic cleansing.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -195,7 +195,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "その末、１９５５年に丙種の研究を永遠に禁じ、その研究記録を永遠に破棄するという採択がなされました。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "In the end, research into Class-C was eternally forbidden in 1955, with all research records selected for destruction."
+		"TextENG": "As a result, all research on the virus was perpetually prohibited in 1955, and they elected to discard the records of that research.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -203,7 +203,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "つまり、人類は丙種の寄生を永遠に受け入れ、その存在を知ること自体をも永遠に禁じたのです。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "In other words, humanity had to eternally accept the Class-C parasite, and were forever forbidden to know of its existence."
+		"TextENG": "This meant humanity would perpetually embrace this parasite, and prohibit the further discovery of its existence as well.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -211,7 +211,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "ではありますが、各国は秘密裏に独自で丙種の研究を進めていると言われています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "However, each nation is said to be researching Class-C on its own in secret."
+		"TextENG": "However, several countries continued to research the virus on their own in secret.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "研究交流はないため、各国の研究水準については不明です。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "But since there are no research exchanges, it is unclear what level of research each country is at."
+		"TextENG": "Since there has been no exchange of information between these, the state of the research in other nations is unknown.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -227,7 +227,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "我が国でも１９６０年代後半から、一部の医大グループ間で秘密の研究会が発足して研究を再開。@rそれが今日の研究の母体となっています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Since the late 1960's in Japan, a group of medical schools formed a study group and resumed the research in secret.@rThat has become the basis of our research today."
+		"TextENG": "Here in Japan, a research team was founded in secret by a group of medical schools in the late 1960s. Their research is the foundation for these current studies.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -235,7 +235,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "米国は今回の事件の原因が丙種によるものであることを嗅ぎ付け、研究を横取りする気でいます。@r米国の救援の名を借りた研究搾取には断じて応じるべきではありません。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "The United States have found out we are researching Class-C, and is planning to seize the research by force.@rWe should not respond to the relief from the United States in exchange for the exploitation of our research."
+		"TextENG": "America has caught wind that this virus is the cause of the most recent incident, and they will be planning to steal our research. We must not respond to their attempts to claim that research, disguised as offers of aid.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -243,7 +243,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "また、この度のη１７３型は、丙種の中でも非常に劇的な症状を示す稀なものです。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "In addition, this η-173 type symptoms are very rarely mild when compared to other Class-C types."
+		"TextENG": "Furthermore, amongst the strains of this virus, strain η173 is a rare variety, which displays extremely dramatic symptoms.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -251,7 +251,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "すでに申し上げておりますように、本来、丙種は非常に穏やかに人体に馴染むものですが、η１７３型は感染から数十日以内に、劇的な人格変容を発症させます。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "As mentioned before, primarily, Class-C is something that adjusts to the human body very calmly. Within ten days from infection η-173, will force the infected to undergo a drastic personality transformation."
+		"TextENG": "As I have already explained, traditionally this virus is extremely compatible with the human body and is totally unnoticeable, yet the η173 strain causes dramatic alterations to personality within several days of infection.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -259,7 +259,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "その最たるものは、攻撃性・不安感の助長です。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "A prime example, the promotion of aggression and a sense of insecurity."
+		"TextENG": "The most significant change is the promotion of anxiety and aggression.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -267,7 +267,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "しかもそれを、心理的に自然に誘導していくという丙種の特徴を残したまま発症させるのです。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Furthermore, the characteristics of Class-C are to naturally deprive you psychologically."
+		"TextENG": "Yet it retains the unique aspects of this virus, guiding those changes in psychology to occur naturally.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -275,7 +275,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "雛見沢地区の感染住人には、すでにその傾向が色濃く出ており、長い期間を置かずにある種の『@bカタストロフ.@<集団暴動・集団虐殺@>』の傾向を示すでしょう。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "For the infected residents of the Hinamizawa area, this tendency has already come out strongly, without placing a long period of time it seems a catastrophe of some sorts (mass riots, genocide) will soon become a trend."
+		"TextENG": "The infected residents of the Hinamizawa region already tend to strongly exhibit those tendencies, and have demonstrated the potential to cause certain catastrophes (mass riots, mass murder), within short periods of time.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -283,7 +283,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "本件主導を直ちにアルファベットプロジェクトに移管し、我が国の財産として慎重に調査すべきです。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "At present, the main leadership will be immediately transferred to the Alphabet Project, they are to carefully investigate this on behalf of our country."
+		"TextENG": "Direction of this matter should immediately be given over to the Alphabet Project, and as such, it should be carefully investigated as one of our nation's assets.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "本件の研究は必ずや国益に貢献するものと確信しております。@rまた本件による暴動の鎮圧は、超法規的権限を持つアルファベット理事会にしかできません。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "We are convinced that their research on this matter will surely contribute to our national interest by all means.@rAnd on the suppression of riots, it will again only be possible through the Alphabet board of directors exercising extrajudicial authority."
+		"TextENG": "I am confident that research into this matter will contribute to our national interest. Furthermore, the suppression of riots caused by this matter can only be conducted by the Alphabet Board of Directors, which possesses extrajudicial authority.@|@y"
 	},
 	{
 		"type": "MSGSET",
@@ -299,6 +299,6 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "以上、ご勘案の上、明日の採択に望まれますよう深くお願い申し上げます。@r国立感染症研究所@r第１３室　担当：鰯",
 		"AfterTextTags": "@|@y",
-		"TextENG": "After taking the above into consideration, I hope you deeply consider this for tomorrow's adoption.@rThe National Institute of Infectious Diseases@rNo.13 accommodations contact: Sardine"
+		"TextENG": "I hope that you will consider these factors before making your decision tomorrow.@rNational Institute of Infectious Diseases@rHead of Room 13: Iwashi@|@y"
 	}
 ]

--- a/outbreak_4.json
+++ b/outbreak_4.json
@@ -11,7 +11,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "本総一エ－３４号@r昭和５８年７月７日@r雛見沢地区災害派遣本部長",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Showa 58 HQ, General Affairs Division, Section 1, E-34@rJuly 7th, 1983@rDirector of Disaster Relief, Hinamizawa Region@|@y"
+		"TextENG": "Showa 58 HQ, General Affairs Division, Section 1, E-34@rJuly 7th, 1983@rDirector of Disaster Relief, Hinamizawa Region"
 	},
 	{
 		"type": "MSGSET",
@@ -19,7 +19,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "撤収命令（緊急）@r災害派遣本部長は、直ちに災害派遣部隊を緊急撤収せよ。@rただし撤収に当たっては、国立感染症研究所の指示に従うこと。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Evacuation Orders (Emergency)@rThe director of disaster relief is to evacuate the disaster relief units immediately.@rDuring evacuation, units are to follow the directions of the National Institute of Infectious Diseases.@|@y"
+		"TextENG": "Evacuation Orders (Emergency)@rThe director of disaster relief is to evacuate the disaster relief units immediately.@rDuring evacuation, units are to follow the directions of the National Institute of Infectious Diseases."
 	},
 	{
 		"type": "MSGSET",
@@ -27,7 +27,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "記@r１．命令@r災害派遣部隊を国立感染症研究所の定める方法により、隔離地域外の指定された地域へ撤収させること。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Notes:@r1. Orders@rThe disaster relief units will follow the directions of the National Institute of Infectious Diseases, and evacuate to the designated zone outside the quarantine.@|@y"
+		"TextENG": "Notes:@r1. Orders@rThe disaster relief units will follow the directions of the National Institute of Infectious Diseases, and evacuate to the designated zone outside the quarantine."
 	},
 	{
 		"type": "MSGSET",
@@ -35,7 +35,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "２．理由@r隊員４名の定時採血よりη１７３型ウィルスの陽性反応が検出された。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "2. Reason@rThe routine blood tests detected a positive reaction for the Type-η173 virus in four squad members.@|@y"
+		"TextENG": "2. Reason@rThe routine blood tests detected a positive reaction for the Type-η173 virus in four squad members."
 	},
 	{
 		"type": "MSGSET",
@@ -43,7 +43,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "災害派遣部隊の現防疫装備では当該ウィルスに対して効果を持たないことが明らかとなった為。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "This proves that the disaster relief units' current equipment is ineffective at preventing infection.@|@y"
+		"TextENG": "This proves that the disaster relief units' current equipment is ineffective at preventing infection."
 	},
 	{
 		"type": "MSGSET",
@@ -51,7 +51,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "本総一エ－３５号@r昭和５８年７月７日@r第７３８装備実験中隊長",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Showa 58 HQ, General Affairs Division, Section 1, E-35@rJuly 7th, 1983@rCommander of the 738th Equipment Test Company@|@y"
+		"TextENG": "Showa 58 HQ, General Affairs Division, Section 1, E-35@rJuly 7th, 1983@rCommander of the 738th Equipment Test Company"
 	},
 	{
 		"type": "MSGSET",
@@ -59,7 +59,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "出動命令（緊急）@r第７３８装備実験中隊は、第１３種防疫戦装備にて直ちに雛見沢地区災害派遣本部長の指示する作戦地へ出動すること。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Dispatch Orders (Emergency)@rThe 738th Equipment Test Company is to deploy immediately with version 13 disease prevention equipment under the command of the Director of Disaster Relief, Hinamizawa Region.@|@y"
+		"TextENG": "Dispatch Orders (Emergency)@rThe 738th Equipment Test Company is to deploy immediately with version 13 disease prevention equipment under the command of the Director of Disaster Relief, Hinamizawa Region."
 	},
 	{
 		"type": "MSGSET",
@@ -67,7 +67,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "記@r１．命令@r第７３８装備実験中隊を、本日付で雛見沢地区災害派遣本部長の指揮下に編入する。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Notes:@r1. Orders@rAs of today, the 738th Equipment Test Company will be placed under the command of the Director of Disaster Relief, Hinamizawa Region.@|@y"
+		"TextENG": "Notes:@r1. Orders@rAs of today, the 738th Equipment Test Company will be placed under the command of the Director of Disaster Relief, Hinamizawa Region."
 	},
 	{
 		"type": "MSGSET",
@@ -75,7 +75,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "実験中隊は本部長の指示する作戦地へ直ちに出動すること。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "The Test Company shall follow the Director's orders and deploy on site immediately.@|@y"
+		"TextENG": "The Test Company shall follow the Director's orders and deploy on site immediately."
 	},
 	{
 		"type": "MSGSET",
@@ -83,7 +83,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "２．任務@r隔離地域の治安維持活動。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "2. Mission@rPeacekeeping in the quarantine zone.@|@y"
+		"TextENG": "2. Mission@rPeacekeeping in the quarantine zone."
 	},
 	{
 		"type": "MSGSET",
@@ -91,7 +91,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "３．備考@r別紙規定に従い実弾射撃が許可される。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "3. Remarks@rDischarge of firearms will be authorized under the enclosed conditions.@|@y"
+		"TextENG": "3. Remarks@rDischarge of firearms will be authorized under the enclosed conditions."
 	},
 	{
 		"type": "MSGSET",
@@ -99,7 +99,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "昭和５８年７月６日@rアルファベットプロジェクト理事会@r雛見沢地区生物災害対策本部長",
 		"AfterTextTags": "@|@y",
-		"TextENG": "July 6th, 1983@rAlphabet Project Board of Directors@rDirector of Disaster Relief, Hinamizawa Region@|@y"
+		"TextENG": "July 6th, 1983@rAlphabet Project Board of Directors@rDirector of Disaster Relief, Hinamizawa Region"
 	},
 	{
 		"type": "MSGSET",
@@ -107,7 +107,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "η１７３型ウィルスについて@r本件ウィルスは、丙種脳寄生型ウィルスに区分されるものです。@rここで、丙種脳寄生型（以下丙種）についてご説明いたします。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Regarding the η173 Virus:@rThis virus has been classified as a Category C neuroparasitic virus.@rWhat follows is an explanation of its properties.@|@y"
+		"TextENG": "Regarding the η173 Virus:@rThis virus has been classified as a Category C neuroparasitic virus.@rWhat follows is an explanation of its properties."
 	},
 	{
 		"type": "MSGSET",
@@ -115,7 +115,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "丙種は、人体の脳に寄生するウィルスの中でも非常に親和性が高く、また症状が特定しにくい為、近代までその存在が確認されていませんでした。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Of all the viruses that infect the human nervous system, this one demonstrates extremely strong compatibility with mankind. Also, due to the difficulty in identifying symptoms in the infected, its existence was not confirmed until the modern age.@|@y"
+		"TextENG": "Of all the viruses that infect the human nervous system, this one demonstrates extremely strong compatibility with mankind. Also, due to the difficulty in identifying symptoms in the infected, its existence was not confirmed until the modern age."
 	},
 	{
 		"type": "MSGSET",
@@ -123,7 +123,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "１９４８年から行なわれた国連の非公式調査では、人類の９９％以上がこの丙種を脳内に寄生させているとしています。@rまた、その存在は人類の起源にまで遡る可能性が指摘されています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "According to an unofficial investigation conducted by the UN in 1948, over 99% of the human species contains this parasitic virus within their brain. Furthermore, it has been pointed out that it is likely this virus has been with humanity from the beginning.@|@y"
+		"TextENG": "According to an unofficial investigation conducted by the UN in 1948, over 99% of the human species contains this parasitic virus within their brain. Furthermore, it has been pointed out that it is likely this virus has been with humanity from the beginning."
 	},
 	{
 		"type": "MSGSET",
@@ -131,7 +131,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "上記でも申し上げましたように、丙種は人体に非常に馴染み、宿主がその寄生を意識することはありません。ですので、今日一般でもよく知られるような、大腸菌などの体内微生物と同じようなものと考えてよいでしょう。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "As that all suggests, this virus is extremely well integrated into the human body, and the host is unaware of the parasite. This makes the virus very similar to other microbes within the human body, such as Escherichia coli, which is commonly known of today.@|@y"
+		"TextENG": "As that all suggests, this virus is extremely well integrated into the human body, and the host is unaware of the parasite. This makes the virus very similar to other microbes within the human body, such as Escherichia coli, which is commonly known of today."
 	},
 	{
 		"type": "MSGSET",
@@ -139,7 +139,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "ただ問題なのは、丙種は宿主の脳に対してある種の干渉を行う可能性が指摘されている点です。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "However, the problem with this virus is that we have identified the possibility of this virus interfering with the host's brain functions.@|@y"
+		"TextENG": "However, the problem with this virus is that we have identified the possibility of this virus interfering with the host's brain functions."
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "丙種は、同じウィルスを寄生した宿主にはより友好的になり、異なる種類の丙種ウィルスに寄生した宿主には敵対的になるよう誘導すると言われています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "This virus makes its hosts amiable to other hosts of the same strain, and it directs its host to be antagonistic toward hosts of different strains.@|@y"
+		"TextENG": "This virus makes its hosts amiable to other hosts of the same strain, and it directs its host to be antagonistic toward hosts of different strains."
 	},
 	{
 		"type": "MSGSET",
@@ -155,7 +155,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "国連調査の結果、丙種に区分されるウィルスは数百種にも及び、その分布図は奇しくも、今日の国境地図、宗教分布図と一致するという驚愕すべき事実を判明させました。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "The UN investigation has discovered several hundred strains that would be classified under this virus, and another shocking fact was uncovered as well: The distribution map of these strains, oddly enough, matches up with present-day national borders and religious distributions.@|@y"
+		"TextENG": "The UN investigation has discovered several hundred strains that would be classified under this virus, and another shocking fact was uncovered as well: The distribution map of these strains, oddly enough, matches up with present-day national borders and religious distributions."
 	},
 	{
 		"type": "MSGSET",
@@ -163,7 +163,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "また、それぞれの丙種には人格・行動の基礎にも深く関与していると言われ、各国人の人種固有と言われてきたいくつかの傾向は寄生する丙種の個性によって生み出されているとすら考えられています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Furthermore, it is suspected that each strain of this virus is deeply involved in shaping the foundation of its host's behavior and personality. So the theory stands that the unique traits of this parasitic virus are responsible for several tendencies generally attributed to race or nationality.@|@y"
+		"TextENG": "Furthermore, it is suspected that each strain of this virus is deeply involved in shaping the foundation of its host's behavior and personality. So the theory stands that the unique traits of this parasitic virus are responsible for several tendencies generally attributed to race or nationality."
 	},
 	{
 		"type": "MSGSET",
@@ -171,7 +171,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "つまり、各国・各人種の文化や性格等、社会的生活の規範は全て、丙種の間接誘導によって作られていると考えられるのです。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "In other words, this virus is theorized to be indirectly responsible for all patterns within societies, personalities, and the cultures of different ethnicities and nations.@|@y"
+		"TextENG": "In other words, this virus is theorized to be indirectly responsible for all patterns within societies, personalities, and the cultures of different ethnicities and nations."
 	},
 	{
 		"type": "MSGSET",
@@ -179,7 +179,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "丙種の存在を世界で最初に発見したのはドイツ人医師で、この発見を元に特定の人種への虐殺が主導されたと言われています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "The first to uncover the existence of this virus was a German doctor within the Nazi administration, and it is theorized that this discovery led to the administration's massacre of particular peoples.@|@y"
+		"TextENG": "The first to uncover the existence of this virus was a German doctor within the Nazi administration, and it is theorized that this discovery led to the administration's massacre of particular peoples."
 	},
 	{
 		"type": "MSGSET",
@@ -187,7 +187,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "国連の丙種秘密調査委員会は、丙種が人類の最も唾棄すべき大罪のいくつかを間接的に主導している可能性を指摘し、丙種の撲滅を掲げましたが、その目標は民族浄化の引き金になりかねないという声が上がり委員会は混乱。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "The UN's secret investigation committee has identified the possibility that this virus has indirectly led humanity to commit its most heinous atrocities, and they called for the extermination of this virus, that call being held back by the fear that such an objective could trigger ethnic cleansing.@|@y"
+		"TextENG": "The UN's secret investigation committee has identified the possibility that this virus has indirectly led humanity to commit its most heinous atrocities, and they called for the extermination of this virus, that call being held back by the fear that such an objective could trigger ethnic cleansing."
 	},
 	{
 		"type": "MSGSET",
@@ -195,7 +195,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "その末、１９５５年に丙種の研究を永遠に禁じ、その研究記録を永遠に破棄するという採択がなされました。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "As a result, all research on the virus was perpetually prohibited in 1955, and they elected to discard the records of that research.@|@y"
+		"TextENG": "As a result, all research on the virus was perpetually prohibited in 1955, and they elected to discard the records of that research."
 	},
 	{
 		"type": "MSGSET",
@@ -203,7 +203,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "つまり、人類は丙種の寄生を永遠に受け入れ、その存在を知ること自体をも永遠に禁じたのです。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "This meant humanity would perpetually embrace this parasite, and prohibit the further discovery of its existence as well.@|@y"
+		"TextENG": "This meant humanity would perpetually embrace this parasite, and prohibit the further discovery of its existence as well."
 	},
 	{
 		"type": "MSGSET",
@@ -211,7 +211,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "ではありますが、各国は秘密裏に独自で丙種の研究を進めていると言われています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "However, several countries continued to research the virus on their own in secret.@|@y"
+		"TextENG": "However, several countries continued to research the virus on their own in secret."
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "研究交流はないため、各国の研究水準については不明です。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Since there has been no exchange of information between these, the state of the research in other nations is unknown.@|@y"
+		"TextENG": "Since there has been no exchange of information between these, the state of the research in other nations is unknown."
 	},
 	{
 		"type": "MSGSET",
@@ -227,7 +227,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "我が国でも１９６０年代後半から、一部の医大グループ間で秘密の研究会が発足して研究を再開。@rそれが今日の研究の母体となっています。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Here in Japan, a research team was founded in secret by a group of medical schools in the late 1960s. Their research is the foundation for these current studies.@|@y"
+		"TextENG": "Here in Japan, a research team was founded in secret by a group of medical schools in the late 1960s. Their research is the foundation for these current studies."
 	},
 	{
 		"type": "MSGSET",
@@ -235,7 +235,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "米国は今回の事件の原因が丙種によるものであることを嗅ぎ付け、研究を横取りする気でいます。@r米国の救援の名を借りた研究搾取には断じて応じるべきではありません。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "America has caught wind that this virus is the cause of the most recent incident, and they will be planning to steal our research. We must not respond to their attempts to claim that research, disguised as offers of aid.@|@y"
+		"TextENG": "America has caught wind that this virus is the cause of the most recent incident, and they will be planning to steal our research. We must not respond to their attempts to claim that research, disguised as offers of aid."
 	},
 	{
 		"type": "MSGSET",
@@ -243,7 +243,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "また、この度のη１７３型は、丙種の中でも非常に劇的な症状を示す稀なものです。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Furthermore, amongst the strains of this virus, strain η173 is a rare variety, which displays extremely dramatic symptoms.@|@y"
+		"TextENG": "Furthermore, amongst the strains of this virus, strain η173 is a rare variety, which displays extremely dramatic symptoms."
 	},
 	{
 		"type": "MSGSET",
@@ -251,7 +251,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "すでに申し上げておりますように、本来、丙種は非常に穏やかに人体に馴染むものですが、η１７３型は感染から数十日以内に、劇的な人格変容を発症させます。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "As I have already explained, traditionally this virus is extremely compatible with the human body and is totally unnoticeable, yet the η173 strain causes dramatic alterations to personality within several days of infection.@|@y"
+		"TextENG": "As I have already explained, traditionally this virus is extremely compatible with the human body and is totally unnoticeable, yet the η173 strain causes dramatic alterations to personality within several days of infection."
 	},
 	{
 		"type": "MSGSET",
@@ -259,7 +259,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "その最たるものは、攻撃性・不安感の助長です。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "The most significant change is the promotion of anxiety and aggression.@|@y"
+		"TextENG": "The most significant change is the promotion of anxiety and aggression."
 	},
 	{
 		"type": "MSGSET",
@@ -267,7 +267,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "しかもそれを、心理的に自然に誘導していくという丙種の特徴を残したまま発症させるのです。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Yet it retains the unique aspects of this virus, guiding those changes in psychology to occur naturally.@|@y"
+		"TextENG": "Yet it retains the unique aspects of this virus, guiding those changes in psychology to occur naturally."
 	},
 	{
 		"type": "MSGSET",
@@ -275,7 +275,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "雛見沢地区の感染住人には、すでにその傾向が色濃く出ており、長い期間を置かずにある種の『@bカタストロフ.@<集団暴動・集団虐殺@>』の傾向を示すでしょう。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "The infected residents of the Hinamizawa region already tend to strongly exhibit those tendencies, and have demonstrated the potential to cause certain catastrophes (mass riots, mass murder), within short periods of time.@|@y"
+		"TextENG": "The infected residents of the Hinamizawa region already tend to strongly exhibit those tendencies, and have demonstrated the potential to cause certain catastrophes (mass riots, mass murder), within short periods of time."
 	},
 	{
 		"type": "MSGSET",
@@ -283,7 +283,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "本件主導を直ちにアルファベットプロジェクトに移管し、我が国の財産として慎重に調査すべきです。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "Direction of this matter should immediately be given over to the Alphabet Project, and as such, it should be carefully investigated as one of our nation's assets.@|@y"
+		"TextENG": "Direction of this matter should immediately be given over to the Alphabet Project, and as such, it should be carefully investigated as one of our nation's assets."
 	},
 	{
 		"type": "MSGSET",
@@ -291,7 +291,7 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "本件の研究は必ずや国益に貢献するものと確信しております。@rまた本件による暴動の鎮圧は、超法規的権限を持つアルファベット理事会にしかできません。",
 		"AfterTextTags": "@|@y",
-		"TextENG": "I am confident that research into this matter will contribute to our national interest. Furthermore, the suppression of riots caused by this matter can only be conducted by the Alphabet Board of Directors, which possesses extrajudicial authority.@|@y"
+		"TextENG": "I am confident that research into this matter will contribute to our national interest. Furthermore, the suppression of riots caused by this matter can only be conducted by the Alphabet Board of Directors, which possesses extrajudicial authority."
 	},
 	{
 		"type": "MSGSET",
@@ -299,6 +299,6 @@
 		"PreTextTags": "@s0.@a0.",
 		"TextJPN": "以上、ご勘案の上、明日の採択に望まれますよう深くお願い申し上げます。@r国立感染症研究所@r第１３室　担当：鰯",
 		"AfterTextTags": "@|@y",
-		"TextENG": "I hope that you will consider these factors before making your decision tomorrow.@rNational Institute of Infectious Diseases@rHead of Room 13: Iwashi@|@y"
+		"TextENG": "I hope that you will consider these factors before making your decision tomorrow.@rNational Institute of Infectious Diseases@rHead of Room 13: Iwashi"
 	}
 ]

--- a/outbreak_5.json
+++ b/outbreak_5.json
@@ -39,7 +39,7 @@
 		"type": "MSGSET",
 		"MessageID": 153698,
 		"TextJPN": "そして定刻をずっと過ぎても現れず、朝の行列はみるみる長くなり、……給水車がやって来ないことに対する怒りはやがて不安に変わり、最後にはある恐怖を突きつけた。",
-		"TextENG": "Once it was long past the scheduled delivery time, the morning line grew steadily longer..... .and the anger they felt at the water trucks for not arriving grew into anxiety, and finally into fear."
+		"TextENG": "Once it was long past the scheduled delivery time, the morning line grew steadily longer..... and the anger they felt at the water trucks for not arriving grew into anxiety, and finally into fear."
 	},
 	{
 		"type": "MSGSET",

--- a/outbreak_5.json
+++ b/outbreak_5.json
@@ -9,91 +9,91 @@
 		"type": "MSGSET",
 		"MessageID": 153693,
 		"TextJPN": "前原家などの、いわゆる外様を包み込む気持ち悪い雰囲気が色濃くなっていく中、さらに村人の不安感を煽る異変が起きた。",
-		"TextENG": "The Maebara family, the so-called outsiders, now seemed to be wrapped in an ever increasing unpleasant atmosphere. Furthermore, a certain accident occurred which has only served to fuel the sense of anxiety among villagers."
+		"TextENG": "As the disturbing atmosphere towards outsiders like the Maebara family grew stronger, there was another change that fanned the anxiety of the villagers."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153694,
 		"TextJPN": "村人の不安な生活を、それでも支えてくれることで精神的な支えになってくれていた自衛隊が突然、村から姿を消したのだ。",
-		"TextENG": "The villagers were leading such an uneasy life, but what support the Self-Defense Forces were giving them has now suddenly disappeared from the village."
+		"TextENG": "The SDF had been supporting the villagers' unstable lifestyles, as well as providing mental support, but they had suddenly disappeared from the village."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153695,
 		"TextJPN": "給水車の前に長く並ぶのが嫌なお年寄りたちは、早い時間から列を作っていた。……だがいつまでも経っても給水車は現れない。",
-		"TextENG": "The elderly who hate lining up before the water truck have been waiting for hours, making a line since the early hours of the day. ......But no matter how long passed, the water truck never appeared."
+		"TextENG": "The elders, who hated standing around in long lines before the water supply trucks, had already lined up early. ......But no matter how long they waited, the trucks weren't showing up."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153696,
 		"TextJPN": "始めは何かの都合で遅れているのだろうと多少は寛容だった。",
-		"TextENG": "Some are thinking they could be late on the account of something, so we should be a little tolerant."
+		"TextENG": "At first we made the generous assumption that something had delayed them."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153697,
 		"TextJPN": "だが、今日までの自衛隊の配給が、いつも時間通りびったりだったことがかえって仇となり、彼らの不安を掻き立てていった。",
-		"TextENG": "However, the distribution of the Self-Defense Forces relief to date has always been on time rather than the contrary, which has only aroused uneasiness."
+		"TextENG": "But the fact that the SDF's deliveries had always been punctual before only worked against them, fanning anxieties even higher."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153698,
 		"TextJPN": "そして定刻をずっと過ぎても現れず、朝の行列はみるみる長くなり、……給水車がやって来ないことに対する怒りはやがて不安に変わり、最後にはある恐怖を突きつけた。",
-		"TextENG": "It didn't appear even after the appointed time, meanwhile, the morning queue continues to grow...... Eventually, anger at the water truck not arriving changed to anxiety, thrusting a certain amount of fear inside us all."
+		"TextENG": "Once it was long past the scheduled delivery time, the morning line grew steadily longer..... .and the anger they felt at the water trucks for not arriving grew into anxiety, and finally into fear."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153699,
 		"TextJPN": "事態が急激に悪化し、ついに自衛隊にまで見限られたのではないか、という噂である。",
-		"TextENG": "The situation is rapidly deteriorating, it could be possible that the Self-Defense Forces have finally given up on us, but that's just a rumor."
+		"TextENG": "The situation rapidly grew worse, and finally people began whispering that the SDF had abandoned us."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153700,
 		"TextJPN": "この噂にほとんどの人はショックを免れなかった。",
-		"TextENG": "Most people weren't even shocked when they heard the rumor, maybe they expected this."
+		"TextENG": "Anyone would be shocked after hearing that rumor."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153701,
 		"TextJPN": "異常事態の村で理性を保つ最後の防波堤だったのが自衛隊の活動である。それが忽然と消えたのだから、それはつまり、この村が日本から切り捨てられたと見えてもおかしくなかった。",
-		"TextENG": "The reason for the Self-Defense Forces activities in such an abnormal situation was to maintain order in the village. But now they've suddenly disappeared, in other words, they must have considered cutting off the village from the rest of Japan a better option."
+		"TextENG": "The actions of the SDF were the final dam maintaining the village's sanity. With that dam suddenly removed, it was easy to feel as though the village had been cast out of Japan."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153702,
 		"TextJPN": "だが、自衛隊がいなくなったことを、不安に思うのではなく、隔離が解除されたということではないかのかと楽天的に解釈した村人もいた。",
-		"TextENG": "But, now that the Self-Defense Forces have disappeared, and rather than feeling uneasy, some of the villagers are optimistically interpreting this that the quarantine was lifted."
+		"TextENG": "However, there were a few villagers who weren't frightened by the SDF's disappearance. They had taken an optimistic view, and assumed the quarantine would be lifted."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153703,
 		"TextJPN": "彼らは村からの脱出を試みようとした。しかし、封鎖線のバリケードには異常が起こっていた。",
-		"TextENG": "So much that some are attempting to escape from the village. However, a certain abnormality happened to seal the road with a barricade."
+		"TextENG": "Those people even tried to leave the village. Yet something strange occurred at the barricades sealing us off."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153704,
 		"TextJPN": "バリケードの前で封鎖を行なっていた白い雨合羽の隊員たちに代わり、迷彩模様のもっともっと厳めしい、まるで宇宙服のようなもので身を包んだ兵士たちが立ち塞がっていたからだ。しかもその背後には、何と装甲車までがいた。",
-		"TextENG": "Instead of men in white raincoats in front of the barricades, there were men wearing severe camouflage patterns, soldiers blocking the road dressed in something that resembles a space suit. And behind them, an armoured vehicle."
+		"TextENG": "Instead of the personnel clad in white raincoats that had been manning the barricades before, there were soldiers blocking the path, wearing much tougher-looking camouflaged gear that was more like a space suit. They even had an armored car parked behind them too."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153705,
 		"TextJPN": "なぜ、村人たちはその姿を隊員でなく兵士と呼んだか。…それは、彼らの持つ銃があまりに物騒だったからだった。少なくとも災害救援の自衛隊員たちは銃など持っていなかった。",
-		"TextENG": "Why, why did the villagers say the soldiers were not regular personnel. ...Is, is it because they had guns so they deemed them dangerous. To say the least, the other Self-Defense Forces disaster relief personnel didn't carry any guns."
+		"TextENG": "Now why did the villagers insist on calling them soldiers? ...Because the guns they carried looked that dangerous. At the very least, none of the SDF members performing relief efforts had carried guns."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153706,
 		"TextJPN": "しかも彼らは、兵士たちの銃だけでなく、装甲車の上部ハッチにも重機関銃が設置され、その銃口を躊躇なく村人に向けていた。",
-		"TextENG": "However, not only the soldiers had guns. A heavy machine gun was also installed on the top hatch of the armored vehicle, and they pointed their weapons at the villagers without hesitation."
+		"TextENG": "Not only were the soldiers carrying their own guns, but the armored car also had a heavy machine gun stationed at its top hatch, and they aimed its muzzle at the villagers without hesitation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153707,
 		"TextJPN": "そしてその上で警告する。",
-		"TextENG": "That was just part of their warning."
+		"TextENG": "After aiming, they issued a warning too."
 	},
 	{
 		"type": "MSGSET",
@@ -102,162 +102,162 @@
 		"PreTextTags": "@vS24/00/NJIE_0050.",
 		"TextJPN": "「こちらは陸上自衛隊です。隔離地域内からの離脱は認められていません。速やかに自宅に戻ってください！」",
 		"NamesENG": "Self-Defense Force Member",
-		"TextENG": "``This is the Ground Self-Defense Force. Withdrawal from the quarantine area is not permitted. Please return to your homes immediately!``"
+		"TextENG": "``This is the JGSDF. You are not permitted to leave the quarantine zone. Please return to your homes at once!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153709,
 		"TextJPN": "それを見て、聞いて、彼らは確信した。",
-		"TextENG": "To see it, to hear it, they were convinced."
+		"TextENG": "Seeing and hearing that made them certain."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153710,
 		"TextJPN": "事態は激変したのだ。危険なウィルス騒ぎは今や自衛隊の手に負えないレベルにまで進行し、彼らは村の救援を放棄して村を封じ込めようとしている…！",
-		"TextENG": "The situation has changed drastically. The dangerous virus has created such an uproar reaching uncontrollable levels that the Self-Defense Forces are now abandoning aid and confining the village...!"
+		"TextENG": "Circumstances had changed. The commotion about this dangerous virus had progressed to the point where it was beyond the SDF's control, so they abandoned providing aid to the village, and were trying to seal it away...!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153711,
 		"TextJPN": "そこに生まれる感情は、救援を放棄した国への怒りより、そこまでに悪化している事態への恐怖の方がずっと強かった。",
-		"TextENG": "The emotions born from this, anger that our own country has abandoned aid, and fear growing ever stronger due to our deteriorating situation."
+		"TextENG": "That gave way to anger at the nation who abandoned their relief efforts, and even greater fear at the idea that things had progressed that poorly."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153712,
 		"TextJPN": "状況を説明してほしいと村人が食いかかろうとしたが……",
-		"TextENG": "Although the villagers tried to explain situation and that they have nothing to eat..."
+		"TextENG": "The villagers tried demanding an explanation of affairs from the soldiers..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153713,
 		"TextJPN": "彼らは威嚇のために実弾を容赦なく発砲し、直ちに退去しなければ次は足を狙うと宣告。村人たちは蜘蛛の子を散らすように村に逃げ帰るしかなかった。",
-		"TextENG": "They fired lived rounds as a threat without mercy, declaring that the next will be aimed at their feet if they do not leave immediately. The villagers had no choice but to flee back to the village like children."
+		"TextENG": "But they fired live ammo without remorse, intending to intimidate, and announced that they would target their legs next if they did not leave immediately."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153714,
 		"TextJPN": "その後、噂には尾ひれが付き、実際に撃たれて怪我をした村人がいる、あるいは撃たれて死んだ、等と混迷を極めていった。",
-		"TextENG": "Then, a tail fin was attached to the gossip, that some of the villagers were actually killed or injured by the gunshots. Village is in a state of utter confusion."
+		"TextENG": "The villagers then scattered like spiders and fled back to the village. Afterward their story grew exaggerated, and people started saying some of them were actually shot and wounded, or even dead, causing even further turmoil."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153715,
 		"TextJPN": "…いや、下手をすると威嚇射撃をしたという話すらもデマなのかもしれないが、もはやそれを確認することはできないし、する必要もない。それは拭えないデマ、つまり「事実」に昇格してしまったからだ。",
-		"TextENG": "...No, they only made a bad call and fired a warning shot, so this story might just be a hoax. It can't even be confirmed, but there's no need to. False rumor cannot be simply wiped away, because it will simply be promoted to ``fact``."
+		"TextENG": "...Actually, there's still a chance the part about warning fire was all made up too, but there's no way to verify that anymore, and no need to. Because that story wasn't being proven false, so it had already become truth."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153716,
 		"TextJPN": "しかも何かの妨害電波で村内の無線が突如、使用不能になってしまったのである。…よって、口コミ以外に連絡手段がなくなり、ますますに事態は混迷を深めていく…。",
-		"TextENG": "And now suddenly, the radios in the village have become jammed making them useless. ...Therefore, the only other means of communication is word of mouth, forcing situation into an ever increasing confusion..."
+		"TextENG": "On top of that, some kind of jamming wave was emitted from somewhere, suddenly making the radios useless. ...Leaving word of mouth as the only means of communication, which increased the turmoil even further..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153717,
 		"TextJPN": "その日、村内で初めて銃声が聞かれた。",
-		"TextENG": "That day, a gunshot was heard in the village for the first time."
+		"TextENG": "That day, the first gunshot rang out in the village."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153718,
 		"TextJPN": "噂が言うように、封鎖している隊員が村人に発砲したものなのか、それとも村人が猟銃を発砲したものなのかはわからない…。",
-		"TextENG": "Rumor says that the personnel on the blockade opened fire on the villagers, but maybe the villagers shot first with hunting rifles..."
+		"TextENG": "We couldn't know for sure if the soldiers trapping us in had fired on a villager, like the rumors suggested, or if some villager had fired their hunting rifle..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153719,
 		"TextJPN": "だが村中に轟き渡ったその一発の銃声は、村が昭和日本のモラルと治安から脱落したことを知らしめた…。",
-		"TextENG": "No matter what happened, a gunshot roared across the village, tearing away the fragile peace and order of Shouwa era Japan..."
+		"TextENG": "But as that gunshot roared through the village the whole population fell away from the law and order of civilized Japan......"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153720,
 		"TextJPN": "町会経由の連絡網で、自衛隊側の都合で救援体制にミスが出たこと。その為、救援の再開に時間が掛かるため、その間、村人同士の互助で助け合うよう連絡が流れた。",
-		"TextENG": "However, via the contact network of the neighborhood association, a message came through that under the circumstances, the cancellation of relief was a mistake on the Self-Defense Forces end. Therefore, it will take some time for aid to resume, but meanwhile, the villagers will have to mutually help one another for the time being."
+		"TextENG": "The town council used their network to reach out and explain there was a mistake in the organization of relief efforts on the SDF's side, and that due to the mistake, it would be some time before the relief efforts resumed. They also asked the villagers to help one another until that time."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153721,
 		"TextJPN": "この連絡が、これほど村に不安感が蔓延する以前に流れたなら、もう少し事態を改善できたのだろうか。今となってはもう遅いことだった。",
-		"TextENG": "I wonder if it would improve the situation a little bit if this information would be provided earlier. But, it's too late now."
+		"TextENG": "Had that message been sent out before such great anxiety spread throughout the village, then they might have been able to improve things a little. But it was all too late."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153722,
 		"TextJPN": "自衛隊の食料配給が途絶えたとは言え、各戸には多少の蓄えもあるだろう。だが、今後どれほどの間、配給が滞るのかわからない。……村に充満するキナ臭い瘴気は、人々から次第に正気を奪っていく。",
-		"TextENG": "Although food distribution of the Self-Defense Forces was cut off, each house should have their own supply. However, between now and the future, we don't know how long the food distribution will be delayed. ......That thought is stinking up the village, gradually eating away at everyone's sanity."
+		"TextENG": "Even though the SDF had ceased supplying food and water, every house had at least some stored up. However, no one knew how long this delay of provisions would last. ......The noxious, heated air permeating the village was steadily robbing people of their sanity."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153723,
 		"TextJPN": "食料を求めて暴徒が押し寄せるかもしれないという恐怖に、商店街は連帯して店舗の武装化、自警団の結成に踏み切った。",
-		"TextENG": "In fear that a mob might flock for food, the shopping district armed its stores in solidarity, deciding to form their own vigilance committee."
+		"TextENG": "Fearing that some insurgent might descend upon them in search of food, the shopping district had banded together and armed all the shops, forming their own neighborhood watch."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153724,
 		"TextJPN": "商店街の入り口にはダム現場から拾ってきたバリケードが並べられ、『無期限休業します。御用のない方の立入を禁止します。どうしてもご入用の方は個別にご相談下さい』と張り紙が出され、商店の主人たちが猟銃を構え立ち番に入った。",
-		"TextENG": "``Closed indefinitely. Entrance without permission is prohibited. Please consult individually on this matter.`` Posters were issued out, showing the owner of the shop holding a hunting rifle."
+		"TextENG": "Barricades taken from the dam site were lined up at the entrance to the shopping district. ``We are closed indefinitely. If you have no business here, you may not set foot within. If you still insist on entering, then please discuss it with us on a case-by-case basis,`` read the sign they had posted up where the residents of the shopping district took their turns standing watch with hunting rifles."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153725,
 		"TextJPN": "さらにその脇には別の張り紙も出された。",
-		"TextENG": "Furthermore, there was also a different poster on the other side."
+		"TextENG": "There was also another small flyer beside it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153726,
 		"TextJPN": "『高津戸にお住まいの方はご遠慮下さい』",
-		"TextENG": "``Takatsudo residents, please stay back``"
+		"TextENG": "``Those living in Takatsudo, please go away.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153727,
 		"TextJPN": "これは、高津戸に感染者がいるらしいという噂に基づくものだった。……だが、この張り紙の横には、これから感染の噂が増える度に、その地域を断る張り紙が増えていくことになる…。",
-		"TextENG": "That was based on a rumor that everyone from Takatsudo are infected. ......But, beside this poster, there was another about a rumor that the number of infected have increased, followed by another poster refusing to let it increase..."
+		"TextENG": "That one was based on the rumors of the infected in Takatsudo. ......However, as the rumors continued to grow, there would likely be more signs posted next to it prohibiting other regions as well..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153728,
 		"TextJPN": "自衛隊による町会区分の隔離がなくなったことにより、多少の交流が持てるようになったと思ったのも束の間。すぐに各町会青年団によってその隔離は引き継がれることになった。",
-		"TextENG": "Although the Self-Defense Forces disappeared from the quarantine zone, it is thought that their interactions with the neighborhood association were able to last, as the neighborhood associations youth league immediately succeeded their position in maintaining the quarantine."
+		"TextENG": "For a moment, we thought that we might be able to have more interaction now that the SDF was no longer quarantining us separately. But the youth groups in each town council quickly took up that mantle of isolation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153729,
 		"TextJPN": "皆、自分の町会にはまだ感染者がいない、他所から人を来させなければ大丈夫と思っていたためである。",
-		"TextENG": "As for them, there isn't yet a single person infected in the neighborhood association, this was thought to be fine since they were mostly from another area."
+		"TextENG": "Everyone believed that their area had yet to become infected, and they could remain safe if they kept out people from the other areas."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153730,
 		"TextJPN": "雛見沢は基本的に農業の村だが、古くに狩猟で生計を立てていた者たちもいて、猟銃を持つ者も少なくなかった。",
-		"TextENG": "Hinamizawa has always been an agricultural village, but there are those who make their living by hunting like in the old days, that's why alot of the people here have a hunting rifle."
+		"TextENG": "Hinamizawa was fundamentally a farming village, but there were several people who had made their living through hunting since long ago, so the number of hunting rifles wasn't exactly small."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153731,
 		"TextJPN": "そのため、それらを持つ者は率先して自警に当たった。その数がそのまま各町会の強さになった。……あるいは、彼らの被害妄想を現実のものにするため、妄想と現実の境を打ち崩す力の強さなのか。",
-		"TextENG": "For this reason, it has striked them to take the initiative and form a seemingly vigilante group. Their numbers and strength also come directly from the neighborhood association. ......Or, in order to make their persecution complex real, they just want to use their strength and power to rip apart the borders of reality and delusion."
+		"TextENG": "Because of that, those who owned one volunteered to serve as guards. The number who volunteered directly translated into that town council's power. ......Either that, or it became their power to blur the line between fantasy and reality, in order to realize their delusions of persecution."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153732,
 		"TextJPN": "そう。今日は７月７日。七夕の日。",
-		"TextENG": "Anyway. Today is July 7th. The day of Tanabata."
+		"TextENG": "That day... It was July 7th. The day of Tanabata."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153733,
 		"TextJPN": "テレビをつければ、短冊に願い事を書いて笹に吊るそうと背伸びする園児たちの可愛らしい姿が映し出されている。",
-		"TextENG": "On the TV you can see the cute appearance of children writing their wishing and stretching themselves forward trying to hang their strip of paper onto a piece of bamboo."
+		"TextENG": "When we turned the television on, it displayed images of cute young children writing their wishes on boards and stretching out to hang them up on bamboo stalks."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153734,
 		"TextJPN": "なのに、雛見沢の七夕は、物々しいバリケードに感染者を拒絶する張り紙を貼り付け、男たちが猟銃を手に睨みを利かせる。……同じ日本の中のこととは思えなかった……。",
-		"TextENG": "However, the Tanabata of Hinamizawa has been plastered with posters and barricades rejecting infected individuals, with seasoned men and hunting rifles on hand. ......This is hardly believable it's the same Japan......"
+		"TextENG": "Yet here in Hinamizawa, our Tanabata involved posted signs rejecting the infected up on violent-looking barricades while many took up hunting rifles and glared at each other suspiciously. ......It was hard to believe this was still the same Japan......"
 	}
 ]

--- a/outbreak_6.json
+++ b/outbreak_6.json
@@ -9,7 +9,7 @@
 		"type": "MSGSET",
 		"MessageID": 153735,
 		"TextJPN": "深夜。お袋がやって来た。手には封筒が握られていた。",
-		"TextENG": "Late at night. My mom comes to me. She has an envelope grasped in her hand."
+		"TextENG": "Late at night, my mother visited me. She was clutching an envelope in her hand."
 	},
 	{
 		"type": "MSGSET",
@@ -18,7 +18,7 @@
 		"PreTextTags": "@vS24/00/NKMO_0030.",
 		"TextJPN": "「圭一…。今ね、圭一宛の手紙が来たのよ」",
 		"NamesENG": "Keiichi's mom",
-		"TextENG": "``Keiichi... Just now, a letter came addressed to you.``"
+		"TextENG": "``Keiichi... Just now we received a letter for you, Keiichi.``"
 	},
 	{
 		"type": "MSGSET",
@@ -27,49 +27,49 @@
 		"PreTextTags": "@vS24/01/NKEI_0280.",
 		"TextJPN": "「手紙？　俺宛…？！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``A letter? Addressed to me...?!``"
+		"TextENG": "``A letter? To me...?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153738,
 		"TextJPN": "それをお袋から引っ手繰る。そこには、“圭ちゃんへ、魅音より”と記されていた。",
-		"TextENG": "I took it from my mom. It is labeled, ``To Kei-chan, from Mion``."
+		"TextENG": "I snatched it up at once. It read ``to Kei-chan, from Mion``."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153739,
 		"TextJPN": "こんな真っ暗な時間に何だろう。お袋が言うには、チャイムがあり、玄関へ行ってみたら扉の隙間に差し込まれていたのだと言う。",
-		"TextENG": "I wonder why she did this when it's completely dark outside. My mom said, there was a chime, and when she went to the front door it was inserted through the gap."
+		"TextENG": "What was this about, and during such a dark time? According to my mother, the doorbell rang, and by the time she reached our front door it was shoved through the gap."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153740,
 		"TextJPN": "家までわざわざ来たなら上がっていけばいいのに。……それを避けて、手紙だけ置いていくというやり方に、一抹の不安感を覚えずにはいられない。",
-		"TextENG": "I guess she would have got nervous if she came to my house personally. ......So to avoid that, she left the letter in such a manner, although I can't help but feel a sense of uncertainty."
+		"TextENG": "She could have just come in if she went out of her way to visit. ......So the fact that she avoided doing so, and left only a letter, had me feeling a tinge anxious."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153741,
 		"TextJPN": "でも、最近の村を取り巻く異常さを思えば、魅音が慎重に連絡を取ろうとするのも何となく頷けた。",
-		"TextENG": "But, remembering the certain anomalies surrounding the village recently, I can think of this as Mion trying to carefully contact me."
+		"TextENG": "Though considering the abnormal state of the village lately, it made sense that Mion would be careful about trying to make contact."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153742,
 		"TextJPN": "土着のウィルスがどうのこうの、オヤシロさまのお怒りがどうのこうの、という話はいつも最後には、引っ越してきた外様の家への疑いの目で締めくくられる。それを前原家も痛いぐらいに最近は理解していた。",
-		"TextENG": "An indigenous virus, the anger of Oyashiro-sama, the current talk of the village, all which concludes to suspicion of the new families that have moved in. I only recently understood that the Maebara family was one of them, set to be hurt."
+		"TextENG": "All the talk of this being an indigenous virus, or being Oyashiro-sama's wrath would ultimately end with those people suspecting the outsiders who'd moved into town recently. The whole Maebara family was made painfully aware of that lately."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153743,
 		"TextJPN": "園崎家の魅音と言えど、白昼堂々と前原家に接触できないような、そういう状況になってしまっているということを、この封筒を開けずとも理解できた。",
-		"TextENG": "Even Mion of the Sonozaki family cannot come into contact with one of the Maebara family in broad daylight, so we have to turn to such a situation, but I won't be able to fully understand without opening the envelope."
+		"TextENG": "Even before opening this letter, I could understand that things had reached the point where Mion, as a Sonozaki, couldn't visit us in broad daylight anymore."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153744,
 		"TextJPN": "そして、その中身はそれでもなお現状認識が甘いことを鋭く教えてくれた。",
-		"TextENG": "And its contents should allow me to fully recognize our current situation."
+		"TextENG": "And yet the contents of this letter quickly informed me that was still a naive point of view."
 	},
 	{
 		"type": "MSGSET",
@@ -78,7 +78,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0430.",
 		"TextJPN": "「圭ちゃんへ。気をつけて！　ウチの町会内で、前原家と竜宮家を槍玉に挙げようという意見が強くなってる。もう本当に馬鹿げてることだけれども、彼らは誰かを生贄にあげないと恐怖感に押しつぶされてしまうところまで追い詰められている」",
 		"NamesENG": "Mion",
-		"TextENG": "``To Kei-chan. Be careful! The neighborhood association are strongly considering making an example of the Maebara and Ryuugu families. This stupid idea is really getting out of hand, they're cornered and crushed by fear seeing a sacrifice as the only option.``"
+		"TextENG": "``To Kei-chan. Be careful! The idea that we should make an example out of the Maebaras and Ryuugus is gaining more strength in our council area. I know it's a really crazy idea, but they've already been driven to the point where they'll be consumed by fear if they don't sacrifice someone.``"
 	},
 	{
 		"type": "MSGSET",
@@ -87,7 +87,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0440.",
 		"TextJPN": "「そんなことしたって何の解決にもならないって反論できたのは最初の内だけ」",
 		"NamesENG": "Mion",
-		"TextENG": "``In the beginning, I was able to argue that it wouldn't solve anything."
+		"TextENG": "``I was only able to argue otherwise the first few times.``"
 	},
 	{
 		"type": "MSGSET",
@@ -96,7 +96,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0450.",
 		"TextJPN": "「数日前からそうであるように、少しでも反論すると、感染者を庇うのはお前も感染者だからだろうなんておかしな論法になっちゃって、誰もストップがかけられない！」",
 		"NamesENG": "Mion",
-		"TextENG": "But for the past few days, if you even try to argue with them, their reasoning becomes strange and they say you're only trying to protect infected people because you too are infected, the talk of lynching has seriously gotten out of hand!``"
+		"TextENG": "``But starting several days ago, if anyone tried to object, they argued that person was covering for the infected because they were infected too. Now no one's putting a stop to this talk of lynching you all!``"
 	},
 	{
 		"type": "MSGSET",
@@ -105,7 +105,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0460.",
 		"TextJPN": "「ウィルス派とオヤシロさまの崇り派が互角だった内は、双方が支離滅裂な論争をするだけだったから良かったんだけど、最近、オヤシロさまの崇り派が伸してきてね。全体をリードするようになりつつある」",
 		"NamesENG": "Mion",
-		"TextENG": "``But the faction for the curse of Oyashiro-sama and the faction for the virus are equally matched, I'm glad both sides are in nothing but incoherent debates, Although recently, the faction for the curse of Oyashiro-sama has expanded. It seems they'll soon lead the whole village.``"
+		"TextENG": "``It was fine back when they were all evenly split between the virus supporters and the Oyashiro-sama's curse supporters, since they'd both just argue incoherently with each other, but lately the curse supporters are gaining ground. It won't be long before they're leading the whole group.``"
 	},
 	{
 		"type": "MSGSET",
@@ -114,7 +114,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0470.",
 		"TextJPN": "「婆っちゃが元気だったならこんな暴走は許さないんだけど、実は数日前に高熱を出しちゃって起き上がることもできないんだよ」",
 		"NamesENG": "Mion",
-		"TextENG": "``If my grandma were healthy, I'm pretty sure she wouldn't have allowed any of this to happen, but a few days ago, she came down with a high fever and can't sit up.``"
+		"TextENG": "``If my granny were well, she'd never allow such a riot, but she actually came down with a fever a few days ago, and now she can't get out of bed.``"
 	},
 	{
 		"type": "MSGSET",
@@ -123,13 +123,13 @@
 		"PreTextTags": "@vS24/03/NMIO_0480.",
 		"TextJPN": "「一部の親類はそれを感染ではないかと吹聴していて、私の発言力もすでに危うい。いや、私自身、下手をすれば生贄にされかねないよ！　そんな立場の私には、これ以上、圭ちゃんやレナの家を庇う発言は難しい」",
 		"NamesENG": "Mion",
-		"TextENG": "``Some of my relatives are even spreading rumors that she may have become infected herself, and my influential voice was already in danger. No, even if I mess up, they wouldn't hesitate to consider me a sacrifice! For me to be in such a situation, no longer I can protect Kei-chan or Rena's family.``"
+		"TextENG": "``Some of my relatives have started spreading rumors that it's the infection, so I'm losing my ability to speak at the council too. Like, if I'm not careful, they could sacrifice me as well! With the position I'm in now, it's going to be hard for me to speak on behalf of your and Rena's family anymore.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153751,
 		"TextJPN": "……魅音の、文字が次第に焦り気味になり歪み始めるのがわかる。どんな心境でこれを記したのか、その胸の内を聞かずとも理解できた。",
-		"TextENG": "......Mion, from this letter I am beginning to understand how impatient and strained you are feeling. To even wonder what state of mind you wrote this in, I'm glad I was able to understand."
+		"TextENG": "......I could see that Mion's writing had steadily grown more hastened and sloppy as it went on. I didn't even have to ask to understand how she must have felt."
 	},
 	{
 		"type": "MSGSET",
@@ -138,7 +138,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0490.",
 		"TextJPN": "「これ以上、雛見沢に留まることは危険だと思う。少なくともこのまま自宅に閉じこもっていれば私たちはいずれ必ず殺される！　だから明日の夜に村から脱出しようと思う」",
 		"NamesENG": "Mion",
-		"TextENG": "``We can't stay here, it's too dangerous to remain in Hinamizawa. If we hold up in our homes any longer we'll be killed as it is! For this reason, I think we should escape from the village tomorrow night.``"
+		"TextENG": "``I think it's dangerous to stay in Hinamizawa any longer than this. At the very least, if we stay shut up in our homes like this, then sooner or later we'll be murdered! So I'm planning to escape the village tomorrow night.``"
 	},
 	{
 		"type": "MSGSET",
@@ -147,7 +147,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0500.",
 		"TextJPN": "「周囲は自衛隊に封鎖されているけど、園崎家は秘密のトンネルを持っていて、その内のひとつが封鎖線の外に出口を持ってるの。このトンネルは私と婆っちゃしか知らない」",
 		"NamesENG": "Mion",
-		"TextENG": "``Although the area is blocked off by the Self-Defense Forces, the Sonozaki family have a few secret tunnels, one of them leading beyond the blockade lines. Only grandma and I know about that one.``"
+		"TextENG": "``The SDF is blocking off the perimeter, but the Sonozakis have secret tunnels, and one of them exits out beyond the quarantine. Me and Granny are the only ones who know about these tunnels.``"
 	},
 	{
 		"type": "MSGSET",
@@ -156,7 +156,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0510.",
 		"TextJPN": "「婆っちゃの回復を待ちたかったけど、もう無理みたい…。さっき婆っちゃに、自分を置いて逃げろと言われたところ…」",
 		"NamesENG": "Mion",
-		"TextENG": "``I wanted to wait until my grandma recovered, but that idea's already impossible... My grandma said a while ago, that I should go and escape by myself...``"
+		"TextENG": "``I wanted to wait until after she recovered, but that doesn't look possible anymore... My Granny just told me to leave her behind and run...``"
 	},
 	{
 		"type": "MSGSET",
@@ -165,7 +165,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0520.",
 		"TextJPN": "「……婆っちゃはこの事態は、古代の伝承の、鬼ヶ淵の沼より鬼があふれ出し～の再来だと言ってる。今に村人たちに鬼が取り憑き、村人が村人を殺し出す地獄絵図になると！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Grandma says that this situation is exactly like the old legend. She calls it the second coming of the demons overflowing from Onigafuchi swamp. Where the demons will now possesses the villagers, turning this place into a picture of hell where everyone wants to kill each other!``"
+		"TextENG": "``......My Granny is saying that this is a return to the ancient legend of demons coming out from Onigafuchi Swamp. Right now all the villagers are possessed by demons, and they're going to start murdering each other!``"
 	},
 	{
 		"type": "MSGSET",
@@ -174,7 +174,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0530.",
 		"TextJPN": "「伝承ではオヤシロさまがそれを治めてくれるんだけど、治めてくれるまでの間、血みどろの争いが繰り返され、大勢の死者が出たと伝承に残している！」",
 		"NamesENG": "Mion",
-		"TextENG": "``And just like Oyashiro-sama in the old legends, during his period of reign, a bloody battle will be repeated, leaving behind it a large number of dead!``"
+		"TextENG": "``In those legends, Oyashiro-sama managed to calm everyone down, but before they were able to do so, the blood-soaked conflict they produced resulted in a massive number of casualties!``"
 	},
 	{
 		"type": "MSGSET",
@@ -183,7 +183,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0535.",
 		"TextJPN": "「私　た　ち　は　殺　さ　れ　る　よ　！」",
 		"NamesENG": "Mion",
-		"TextENG": "``W e a r e a l l g o i n g t o d i e !``"
+		"TextENG": "``They're going to kill us all!``"
 	},
 	{
 		"type": "MSGSET",
@@ -192,7 +192,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0540.",
 		"TextJPN": "「それで本題。今夜中に圭ちゃんの家族に話して準備をさせて。明日の夜、迎えに行くからみんなで脱出しよう。持ち物は現金、保険証や通帳、印鑑類。あと、重過ぎない範囲でリュックサックに着替えや日用品を詰め込んで。手荷物は厳禁！」",
 		"NamesENG": "Mion",
-		"TextENG": "``Onto the main subject. Talk to your family tonight, Kei-chan, and have them prepare to leave. Tomorrow night, I'm coming to pick you up and we're all going to escape together. Take personal belongings, cash, insurance cards, bankbooks, and a seal stamp. Followed by, a change of clothes and daily necessities, but make sure they won't be too heavy. Hand luggage is strictly prohibited!``"
+		"TextENG": "``That brings me to the main point. Tell your family tonight about all this and have them get ready, Kei-chan. I'll come for you all tomorrow night, and then we'll escape. Bring your cash, insurance card, bankbook, and family seal. Also, fill your backpack with clothes and daily necessities, but don't let it get too heavy. Don't bring anything you have to carry!``"
 	},
 	{
 		"type": "MSGSET",
@@ -201,7 +201,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0550.",
 		"TextJPN": "「絶対に両手は空けること。靴はスニーカー等の履きなれた歩きやすい物！　同じ手紙はレナにも送ってある」",
 		"NamesENG": "Mion",
-		"TextENG": "``Make sure both of your hands are free. And also make sure to wear sneakers or shoes you're used to and are easy to walk in! I've sent the same letter to Rena."
+		"TextENG": "``Make absolutely certain you can use both hands. For shoes, wear a comfortable pair you can walk easily in! I'm sending this same letter to Rena as well.``"
 	},
 	{
 		"type": "MSGSET",
@@ -210,7 +210,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0560.",
 		"TextJPN": "「……圭ちゃんにはあまりに突拍子もないことで、多分現実感が伴わないと思う」",
 		"NamesENG": "Mion",
-		"TextENG": "......I know this all sounds crazy, Kei-chan, and without a doubt not in the realms of reality.``"
+		"TextENG": "``......This might seem like it's coming out of left field, so I doubt it feels real to you just yet.``"
 	},
 	{
 		"type": "MSGSET",
@@ -219,7 +219,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0570.",
 		"TextJPN": "「…でも信じて！　私は御三家の集まりや町会の会合、そして無線で情報を集めていたからこの村を取り巻く異常さがどれほどおかしいかよくわかってる！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``...But believe me! The neighborhood association and a group from the big three will be meeting, and they'll be discussing all the anomalies surrounding this village they collected by radio no matter how strange they are!!``"
+		"TextENG": "``...But trust me! I've been to the town council meetings and the gatherings of the Three Families, so I have a very clear idea of just how crazy this village has become!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -228,13 +228,13 @@
 		"PreTextTags": "@vS24/03/NMIO_0580.",
 		"TextJPN": "「私と同じ危機感を持って！　圭ちゃんが私を信じて全ての行動を共にしてくれても、私は自分と圭ちゃん、レナ、その家族が全員無事で雛見沢を脱出できる確率は１０％なら高い方と見積もってる」",
 		"NamesENG": "Mion",
-		"TextENG": "``I hope you sense the impending danger as I do! Believe me, Kei-chan, we all have to act together - you, myself and Rena. But even if we do, I estimate the probability of our chances at escaping Hinamizawa unharmed to be around 10％.``"
+		"TextENG": "``You need to understand how dangerous this is! Even if you have faith in and do everything I've asked, I'm estimating only a 10% possibility at best of you, me, Rena, and our families all escaping Hinamizawa safely.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153763,
 		"TextJPN": "魅音の手紙はそこで終わりだった。",
-		"TextENG": "Mion's letter ends there."
+		"TextENG": "That was the end of Mion's letter."
 	},
 	{
 		"type": "MSGSET",
@@ -243,133 +243,133 @@
 		"PreTextTags": "@vS24/01/NKEI_0290.",
 		"TextJPN": "「な、……何なんだよこれはッ…！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Is... Is this for real...!!``"
+		"TextENG": "``Wha... What the hell...?!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153765,
 		"TextJPN": "飲み込めない事態の大きさに両手で頭を抱える。だが魅音はそれを見越した上で、自分を信じてくれとこの手紙に託している…！",
-		"TextENG": "I place both of my hands on my forehead in an attempt to try and swallow this situation. However, I'm pretty sure Mion anticipated my reaction, but she entrusted this letter to me, I have to believe in her...!"
+		"TextENG": "This whole situation was too much for me to take in, and so I gripped my head. Yet Mion had entrusted this letter to me and asked me to trust her, knowing I'd feel that way...!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153766,
 		"TextJPN": "３つも深呼吸をすれば、魅音の言っている異常事態が決して的外れでないことは理解できた。最近の雛見沢を包む空気の澱み方を思えば決しておかしな話ではなかった。ここに書いてあるのは紛れもない事実なのだ…！",
-		"TextENG": "If I take three deep breaths, I should be able to understand this abnormal situation without misinterpreting anything Mion said. No matter what I think of the stagnated air that now surrounds Hinamizawa, this isn't a joke. It's written as an obvious fact of life...!"
+		"TextENG": "Once I took three deep breaths, I was able to realize that the danger Mion spoke of wasn't too far-fetched. Considering the festering attitude that had filled Hinamizawa lately... What she had written here was unmistakably true...!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153767,
 		"TextJPN": "そして同時に、沙都子はという不安感も持った。",
-		"TextENG": "At the same time, I'm pretty sure Satoko is having the same feelings of anxiety I am."
+		"TextENG": "At the same time, that made me fear for Satoko."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153768,
 		"TextJPN": "自衛隊に収容された梨花ちゃんはともかく、ひとり村に残されている沙都子についてが、この手紙には一言も出てこない。出てくるのは俺とレナの名だけだ。",
-		"TextENG": "Aside from Rika-chan being held by the Self-Defense Forces, Satoko has been left all alone in the village by herself, and there isn't even a single mention of her in this letter. The only names that come up are Rena's and mine."
+		"TextENG": "It made sense the letter didn't mention Rika, who the SDF had in custody, but there wasn't a single word written here about Satoko, who'd been left in this village all alone. The only names on it were mine and Rena's."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153769,
 		"TextJPN": "……魅音が部活メンバーのことを忘れるわけがない。沙都子のことを書き漏らすわけはないのに！　何でだ？！　嫌な想像が次々と襲い掛かり俺を窒息させようとした。",
-		"TextENG": "......Mion can't forget the other club members. We can't leave without Satoko! What is this?! Terrible thoughts are hitting my imagination trying to suffocate me one after another."
+		"TextENG": "......There's no way Mion could have forgotten about the club members. So there's no way she'd forget to mention Satoko! So then why?! Terrible imaginations assailed my mind, each of them trying to suffocate me."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153770,
 		"TextJPN": "そうだ、魅音は言ってた。沙都子を生贄に捧げればオヤシロさまの怒りが鎮まるとか本気で思ってる連中がいると言っていた。",
-		"TextENG": "Yes, it's what Mion said. She told me that there was a group of people who truly believed the wrath of Oyashiro-sama could be subsided through a sacrifice."
+		"TextENG": "That's right, Mion already mentioned her. She told us there were those who seriously believed that Oyashiro-sama's anger would subside if Satoko were offered as a sacrifice."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153771,
 		"TextJPN": "まさか、……沙都子……？！",
-		"TextENG": "Could it be...... Satoko?!"
+		"TextENG": "No way...... Is Satoko......?!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153772,
 		"TextJPN": "がばっと立ち上がった時、本棚の脇に立てかけてあった金属バットが倒れて俺の足下に転がった。",
-		"TextENG": "When I stood up, the metal bat leaned beside my bookshelf fell down and rolled to my feet."
+		"TextENG": "I shot up from my seat and the metal bat leaning against the bookshelf fell down, stopping against my feet."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153773,
 		"TextJPN": "まるで、自分も連れて行ってくれというかのように。",
-		"TextENG": "I quickly began to mumble to myself about the possibility."
+		"TextENG": "It was almost like it was telling me to take it with me."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153774,
 		"TextJPN": "…その時、銃声を聞いた。",
-		"TextENG": "...Then, I heard a gunshot."
+		"TextENG": "...That was when I heard a gunshot."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153775,
 		"TextJPN": "平穏な普段なら、子供がふざけて鳴らした爆竹かロケット花火だとでも思うだろう。だが、こんな異常状況下だからこそ、俺は平和ボケした勘違いなどしなかった。",
-		"TextENG": "Things are mostly peaceful around here, so I would usually think it would be children playing with fireworks or firecrackers. But, precisely because I'm in this abnormal situation, I did not allow myself to take this as a misunderstanding becoming senile with peace."
+		"TextENG": "If this had been a normal, peaceful day, I would have assumed it was some kid having fun by setting off firecrackers or bottle rockets. But because we were in such an abnormal situation, I didn't make those wrong assumptions, encouraged as they were by times of peace."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153776,
 		"TextJPN": "カーテンを開け、夜の闇に目を凝らすと、再び銃声を聞いた。音はさっきより近い気がした。それに混じり何を言っているのかわからない怒号も聞こえた気がした。",
-		"TextENG": "When I opened the curtains, I squinted into the darkness of the night, and heard another gunshot. It sounds closer than the previous. It feels like a roar I've never known about, I don't want to hear it again."
+		"TextENG": "I opened my curtain and strained to peer into the darkness... when I heard another gunshot. It sounded like it was even closer this time. I thought I could hear someone shouting something nearby."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153777,
 		"TextJPN": "突然、連打されるチャイム音！",
-		"TextENG": "Suddenly, a chime sound begins to ring repeatedly!"
+		"TextENG": "Suddenly our doorbell began ringing frantically!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153778,
 		"TextJPN": "ピンポン、ピンポン、ピンポン、ピンポン、ピンポン！！",
-		"TextENG": "Ding dong, ding dong, ding dong, ding dong, ding dong!!"
+		"TextENG": "Bingbong, bingbong, bingbong, bingbong, bingbong!!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153779,
 		"TextJPN": "俺の頭の中から不要なノイズが全て消え去りクリアになる。",
-		"TextENG": "That unwanted noise in my head quickly becomes clear."
+		"TextENG": "My mind became clear. All unnecessary noise vanished from my thoughts."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153780,
 		"TextJPN": "呼吸の必要すらなくなった気がして、その真空状態の中、足下に転がる金属バットを拾うと玄関へ駆け下りていった。",
-		"TextENG": "I can't even feel the need to breath, it's like I'm in a vacuum. I grab the metal bat which rolled to my feet and run down the stairs to the entrance."
+		"TextENG": "It felt like I didn't even need to breathe, and in that vacuum state, I picked up the metal bat at my feet and raced for the front door."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153781,
 		"TextJPN": "玄関前には、怯えるお袋と、台所から包丁を持って駆けて来る親父の姿があった。",
-		"TextENG": "In front of the entrance, I can see my mom frightened, and my dad running over with a knife he got from the kitchen."
+		"TextENG": "At the entrance I found my mom cowering, and my dad running in from the kitchen with a carving knife."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153782,
 		"TextJPN": "……このような物騒な対応をする親父を、ついさっきまで異常だと思っていたが、今の瞬間に限ってだけは逆に、状況を適切に理解できていると思った。",
-		"TextENG": "......For my dad to give such a dangerous response, and I know something abnormal just happened. But he's the complete opposite of what he was a moment ago, I thought he would have been properly able to understand a situation like this."
+		"TextENG": "......Up until a moment ago I would've thought it strange for my dad to respond so violently, but in this exact moment, that actually felt like the proper response."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153783,
 		"TextJPN": "お袋が扉を開けてもいいものかと親父の様子をうかがう。親父は下がっていろとお袋を下がらせる。",
-		"TextENG": "I watch the state of my mom and dad as they consider whether to open the door or not. Not long after, they both choose to stand back."
+		"TextENG": "My mom looked back at my dad, wondering if it was safe to open the door. He had her step away from it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153784,
 		"TextJPN": "チャイムは門のところのボタンを押したものだ。その押した人物は、そのまま門内に入り今や扉の前にまで至っているようだった。",
-		"TextENG": "The chime is something you push at the front of the gate. That person must have pushed it, so they should have already entered through the gate and come up to the door by now."
+		"TextENG": "The button for our doorbell was pressed at our gate. So whoever had pressed it had now come through our gate, and was standing right in front of the house."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153785,
 		"TextJPN": "そして、ダンダンダンダンダンダン！　と激しいノック！！",
-		"TextENG": "Suddenly, thud, thud, thud, thud, thud, thud! Someone is knocking intensely at the door!!"
+		"TextENG": "Then there was a bangbangbangbangbangbang! knocking violently on our door!!"
 	},
 	{
 		"type": "MSGSET",
@@ -378,13 +378,13 @@
 		"PreTextTags": "@vS24/00/NKFA_0060.",
 		"TextJPN": "「だ、誰ですか！！」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``Who... Who is it!!``"
+		"TextENG": "``Wh-Who is it?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153787,
 		"TextJPN": "親父が叫ぶ。返事はすぐにあった。",
-		"TextENG": "My father cries. The reply was immediate."
+		"TextENG": "My father shouted. They answered immediately."
 	},
 	{
 		"type": "MSGSET",
@@ -393,7 +393,7 @@
 		"PreTextTags": "@vS24/02/NREN_0180.",
 		"TextJPN": "「こんばんは、竜宮です！　開けてください！」",
 		"NamesENG": "Voice",
-		"TextENG": "``Good evening, it's Ryuugu! Please open the door!``"
+		"TextENG": "``Good evening, it's Ryuugu! Please let me in!``"
 	},
 	{
 		"type": "MSGSET",
@@ -408,13 +408,13 @@
 		"type": "MSGSET",
 		"MessageID": 153790,
 		"TextJPN": "俺は親父の後から飛び出す。レナのその声色から、今すぐにここを開けなければならない緊急事態を感じ取ったからだ。",
-		"TextENG": "I jump past my dad. From Rena's tone, I can tell this is an emergency so we have to open the door right away."
+		"TextENG": "I leapt out from behind my father. From the sound of Rena's voice, this was an emergency, and we needed to open the door right away."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153791,
 		"TextJPN": "例え村人が、互いを疑い合い殺し合うような異常事態になっても、……俺たち部活メンバーは互いを絶対に疑わないッ！！",
-		"TextENG": "Even if there are other villagers coming to kill her, I can't doubt her in such an abnormal situation, because...... we club members never doubt each other!!"
+		"TextENG": "Even if we were plunged into a nightmare situation where the villagers had started a bloodbath...... we club members would never doubt each other!!"
 	},
 	{
 		"type": "MSGSET",
@@ -423,7 +423,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0310.",
 		"TextJPN": "「ぅ、うわ？！　み、魅音？！　大丈夫かッ？！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Wh-what?! Mi-Mion?! Is she okay?!``"
+		"TextENG": "``W-Wha?! M-Mion?! Are you all right?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -432,37 +432,37 @@
 		"PreTextTags": "@vS24/02/NREN_0190.",
 		"TextJPN": "「大丈夫なんかじゃない！　早く止血を…！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Of course she's not okay! We need to stop the bleeding...!``"
+		"TextENG": "``She's not all right! We need to hurry and stop the bleeding...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153794,
 		"TextJPN": "レナに背負われているのは、血塗れになって息も絶え絶えの魅音だった。それを見て、大丈夫か等と問い掛けるのは時間の無駄、社交辞令もいいところだ。",
-		"TextENG": "Rena is carrying Mion on her back, she's covered in blood and gasping for air. Seeing this, it was a complete waste of time to ask if she was okay, but at least she's somewhere safe now."
+		"TextENG": "Rena was carrying a blood-soaked Mion, whose breathing was fading fast. Asking if she was all right was just a waste of time, not even a social courtesy."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153795,
 		"TextJPN": "レナはそれを一喝すると、魅音を玄関に運び込んで床に寝かせる。魅音は左腕に怪我をしていて服を血で真っ赤に染めていた。",
-		"TextENG": "Rena charges past me, and lays Mion on the floor at the entrance. Mion's seriously injured in the left shoulder and her clothes are dyed red with blood."
+		"TextENG": "After that cry from Rena, we carried Mion in past our door and laid her down on the floor. Mion's left shoulder was badly injured and her clothes were stained red with blood."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153796,
 		"TextJPN": "…その服の色は本当は黄色だった。",
-		"TextENG": "...The color of her clothes were originally yellow."
+		"TextENG": "...Her clothes were supposed to be yellow."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153797,
 		"TextJPN": "私服の魅音が好んで着るシャツで、学校を終えてからこの清々しい黄色いシャツの魅音に会うことは、学校での時間に負けないくらいに楽しい時間が再び始まることを感じさせ、とてもうきうきとした気持ちにさせてくれたはずなのに…。",
-		"TextENG": "It's Mion's favorite shirt to wear, that refreshing yellow shirt she puts on right after finishing school to meet me, when the happy times begin again so we won't lose time by just fooling around in school, those are some very cheerful memories, but now..."
+		"TextENG": "The shirt Mion loved to wear in her free time―that bright, yellow shirt she always wore once school was over, that symbol of all our fun times together, that shirt that I was always happy to see―"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153798,
 		"TextJPN": "その黄色が、真っ赤に染まって塗り潰されている。",
-		"TextENG": "That yellow has been dyed deep red."
+		"TextENG": "Was now completely stained a purest red."
 	},
 	{
 		"type": "MSGSET",
@@ -471,19 +471,19 @@
 		"PreTextTags": "@vS24/01/NKEI_0320.",
 		"TextJPN": "「か、母さん！！　手当てをして！　何かタオルを…！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``M-Mom!! We need to treat her! Bring a towel or something...!!``"
+		"TextENG": "``H-Hey!! She needs help! Grab a towel or something...!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153800,
 		"TextJPN": "魅音はハンカチで傷口を押さえているが、血は溢れ続けているようだった。",
-		"TextENG": "Although Mion's wound was being suppressed by a handkerchief, blood continued flowing out."
+		"TextENG": "Mion was holding her wound with a handkerchief, but the blood continued to spill from it."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153801,
 		"TextJPN": "…絞ればぼたぼたと血を滴らせるに違いないそのハンカチが、本当はどんな色でどんな柄で、魅音のお気に入りだったかどうかなんて、もうわからない。",
-		"TextENG": "...That handkerchief would probably gush large amounts of blood if I squeezed it, who knows what color it'll become, will it still be Mion's favorite, I don't even know that."
+		"TextENG": "...Her handkerchief would've dripped blood if it were wrung out. It was impossible to tell what color or design it used to be, and whether it was Mion's favorite."
 	},
 	{
 		"type": "MSGSET",
@@ -492,43 +492,43 @@
 		"PreTextTags": "@vS24/00/NKFA_0070.",
 		"TextJPN": "「い、一体何があったんだ…？！　レナちゃん、これは一体…！！」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``Wh-What on earth happened...?! Rena-chan, what happened...!!``"
+		"TextENG": "``W-What on earth happened...?! Rena-chan, what's going on here...?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153803,
 		"TextJPN": "親父が包丁を隠さずに言う。",
-		"TextENG": "My dad said so while trying to hide the kitchen knife."
+		"TextENG": "My father asked, without putting away his knife."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153804,
 		"TextJPN": "レナは、何から説明したものかと面倒そうに顔を歪ませる。口で悠長に説明している時間すら惜しい、そう表情が語っていた。",
-		"TextENG": "Rena's face became warped having trouble thinking about how to explain what exactly happened. This also isn't the right time, her expression tells even that."
+		"TextENG": "Rena frowned, having difficulty deciding where to even begin. Her expression made it clear that we didn't have time for her to explain."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153805,
 		"TextJPN": "…だが説明は必要だろうか。魅音を背負った際に全身を汚した真っ赤な血は、彼女が語ろうとするどんな言葉よりも事態の急を教えてくれた。",
-		"TextENG": "...But, do we even need an explanation? The bright red stains over Mion's whole body say enough, that taught me immediately what this whole situation was before she even opened her mouth."
+		"TextENG": "...But did we even need an explanation? The bright red blood staining her body from when she carried Mion was better than any words at conveying the urgency of this situation."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153806,
 		"TextJPN": "そして、その説明はレナが想像するどんな説明方法よりも短く説明される。",
-		"TextENG": "Then this visual explanation was far more brief than anything Rena could have said. The bullets sounded frightening as they hit the front door."
+		"TextENG": "Also, we could soon explain it much faster than any explanation Rena might produce. Because moments later we heard a tremendous bang outside our front door."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153807,
 		"TextJPN": "銃痕ができた？",
-		"TextENG": "Bullets?"
+		"TextENG": "Did she have a gunshot wound?"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153808,
 		"TextJPN": "１秒の間髪を入れずに事態が理解される。撃たれた…！！　誰かが、この玄関へ向けて発砲したのだッ！！！",
-		"TextENG": "I understood this situation within the flash of a second. We were shot at...!! Somebody fired at the entrance hall!!!"
+		"TextENG": "We realized the situation without a moment to spare. She was shot...!! Someone had shot her outside our house!!!"
 	},
 	{
 		"type": "MSGSET",
@@ -537,13 +537,13 @@
 		"PreTextTags": "@vS24/02/NREN_0200.",
 		"TextJPN": "「うわあああぁああああぁッ！！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Uu... Uwaaa~aaaaa~a!!!``"
+		"TextENG": "``Uwaaaaaaaah!!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153810,
 		"TextJPN": "その発砲に弾かれるように、レナが身を翻す。魅音を背負っていた時にも、もう片方の手で持っていた大きな鉈を振り上げながら。",
-		"TextENG": "Attracted to the gunshots, Rena runs back outside. Even when she was carrying Mion, she must have been fighting with that big hatchet using her other hand."
+		"TextENG": "Rena spun around at the sound of that shot. All while raising the huge hatchet she had carried in one hand, even while carrying Mion."
 	},
 	{
 		"type": "MSGSET",
@@ -552,7 +552,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0330.",
 		"TextJPN": "「ぅ、うおおおぉおおおおッ！！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Uu... Uwaaa~aaaaa~a!!!``"
+		"TextENG": "````Uu...Uwaaaaaaaah!!!````"
 	},
 	{
 		"type": "MSGSET",
@@ -567,7 +567,7 @@
 		"type": "MSGSET",
 		"MessageID": 153813,
 		"TextJPN": "俺もバットを手に裸足のままレナを追うように飛び出す。その背に親父が俺の名を呼ぶが聞かなかった。",
-		"TextENG": "I chase after Rena, barefoot with a bat in my hand. My dad calls out my name, but I don't hear him."
+		"TextENG": "I gripped my bat and chased after Rena, my feet still bare. I didn't even hear my father calling for me behind us."
 	},
 	{
 		"type": "MSGSET",
@@ -576,61 +576,61 @@
 		"PreTextTags": "@vS24/01/NKEI_0340.",
 		"TextJPN": "「レ、レナぁああぁッ！！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Re... Rena!!!``"
+		"TextENG": "``Re-Renaaaaa!!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153815,
 		"TextJPN": "レナが、門の前に立つ誰かに飛びかかり、鉈を容赦なく振り下ろした。",
-		"TextENG": "Rena pounced on somebody standing at the front gate, and mercilessly beat his head in with a hatchet."
+		"TextENG": "Rena leapt on someone standing at our front gate, ruthlessly splitting his head open with her hatchet."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153816,
 		"TextJPN": "それは信じられないような、それでいて呆気ない光景。",
-		"TextENG": "I couldn't believe it, a disappointing scene nonetheless."
+		"TextENG": "The moment was unbelievable and all too short."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153817,
 		"TextJPN": "さらにレナはもう一人いた男に対し、大きな鉈を軽々と振り上げ、凄まじい投擲で投げつける！",
-		"TextENG": "Rena turns to the other man, and lightly raises her hatchet. She throws it with tremendous strength!"
+		"TextENG": "Rena easily brandished her huge hatchet at another man and threw it at him with tremendous force!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153818,
 		"TextJPN": "それは月の明かりに銀色の反射を閃かせながら飛んで男の肩口に叩き込まれる。小さな黒い飛沫を散らしながら。",
-		"TextENG": "It flies through the air glimmering like silver in the moonlight before smashing in the mans face. Scattering many small black dots."
+		"TextENG": "A silver glint of moonlight flashed off the blade as it soared into the man's face."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153819,
 		"TextJPN": "男が短い悲鳴をあげる。",
-		"TextENG": "The man lets out a short scream."
+		"TextENG": "The man let out a short cry as a small, dark spray spewed from his head."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153820,
 		"TextJPN": "俺の脳には、何をするんだレナ！という、通常時の社会モラルから紡がれる言葉と、…レナにここまでの反撃をさせるに値するどれほどの脅威だったのかということを探る２つが入り混じった。",
-		"TextENG": "I think inside my head, what has gotten into Rena! Words spin around inside me contrasting to the morality of our usual peaceful days... I know Rena has to fight back, but I don't think they deserve anything like this."
+		"TextENG": "My understanding of typical social morals made my brain want to shout, ``What are you doing, Rena?!`` ...but I also wanted to know who was such a threat that they warranted this reaction."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153821,
 		"TextJPN": "レナは肩口に鉈を受けてのた打ち回っている男に歩み寄ると乱暴に鉈を引き抜き、頭上に肉厚の刃の鉈を振り上げる。",
-		"TextENG": "Rena retrieves her hatchet and runs over to the writhing man, she violently raises it."
+		"TextENG": "Once Rena reached the man stumbling around with her hatchet in his face, she roughly yanked it out, then slammed the long hatchet into his head over and over."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153822,
 		"TextJPN": "男は、やめてくれと言葉を吐いたが、レナはまったく耳を貸さなかった。",
-		"TextENG": "And hammers the thick hatchet's blade into the man's head over and over. While the man, screamed several times telling her to stop, but Rena didn't listen to any of it."
+		"TextENG": "The man begged repeatedly for her to stop, but Rena didn't listen to him at all."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153823,
 		"TextJPN": "一息に振り下ろす。そして、動かなくなったのを見届けた後、言い放つ。",
-		"TextENG": "After making sure he is dead, Rena stops."
+		"TextENG": "Once she confirmed he wasn't moving anymore, she spoke."
 	},
 	{
 		"type": "MSGSET",
@@ -639,25 +639,25 @@
 		"PreTextTags": "@vS24/02/NREN_0215.",
 		"TextJPN": "「……ひ、…人を殺すってことはね、自分も殺されることを覚悟するってことだよ！　甘えるんじゃないッ！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``......If... If you want to kill somebody, you should be prepared to die yourself! Don't take that responsibility lightly!!``"
+		"TextENG": "``......Ki...Killing someone, means that you're ready to be killed in return! So don't take it lightly!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153825,
 		"TextJPN": "まるで、その言葉は俺に対して言われたかのようだった。",
-		"TextENG": "I feel like, those words were meant for me."
+		"TextENG": "It was almost like those words were meant for me."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153826,
 		"TextJPN": "…多分、レナから見たら、俺の表情はこの緊急事態をまるで理解していない平和ボケが浮かんでいたに違いないのだ。",
-		"TextENG": "...They probably were, because just by looking at Rena, she can tell from my expression that I don't fully understand this situation is an emergency."
+		"TextENG": "...From Rena's perspective, I probably looked like I was still too accustomed to peace to understand the emergency we faced."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153827,
 		"TextJPN": "その時、レナが振り返り鋭く叫ぶ！！",
-		"TextENG": "At that moment, Rena looks back and cries sharply!!"
+		"TextENG": "But that was when Rena turned and shouted―"
 	},
 	{
 		"type": "MSGSET",
@@ -666,7 +666,7 @@
 		"PreTextTags": "@vS24/02/NREN_0220.",
 		"TextJPN": "「そっちの男、まだ動いてるよ！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``That man is still alive!!``"
+		"TextENG": "``That man's still alive!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -675,25 +675,25 @@
 		"PreTextTags": "@vS24/01/NKEI_0350.",
 		"TextJPN": "「…え、……ぁッ、」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``...Eh......``"
+		"TextENG": "``...Huh? ......Oh!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153830,
 		"TextJPN": "最初にレナが倒した男、…つまり、家の玄関に銃を放った男が額を押さえながら立ち上がろうとしている。",
-		"TextENG": "The man who Rena defeated first... In other words, the man who shot the gun at the front door of my house, is trying to stand back up again."
+		"TextENG": "The man Rena first defeated―the man that fired a gun at our front door--was clutching his forehead and trying to stand."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153831,
 		"TextJPN": "あれだけの大怪我を負わせたならもう許してもいいのでは…。そう思うのは俺の平和ボケのせいなのか。",
-		"TextENG": "Can we even forgive him for giving Mion such a serious injury... Or have I already become senile with peace."
+		"TextENG": "He was already injured so badly we could probably let him go... but that thought was probably just me clinging to peace."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153832,
 		"TextJPN": "…レナはまったくそうは思わなかった。男は片手で額を押さえ、もう片手には未だ猟銃を持っている！　銃の引き金を引く力があるならば、この男の脅威は未だ拭われていない…！！",
-		"TextENG": "...Rena doesn't seem to think so. The man is holding his forehead with one hand, while grasping the hunting rifle with the other! He still has the power to pull the trigger, the threat this man poses has not yet been wiped out...!!"
+		"TextENG": "...Rena didn't have that thought at all. The man was holding his head with one hand, but his other was still holding his hunting rifle! The threat this man posed wasn't dealt with if he could still pull the trigger on his gun...!!"
 	},
 	{
 		"type": "MSGSET",
@@ -702,37 +702,37 @@
 		"PreTextTags": "@vS24/02/NREN_0230.",
 		"TextJPN": "「うらああああああああぁああぁッ！！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Uraaaaaaaaaaaaa!!!``"
+		"TextENG": "``Uraaaaaaaaaaah!!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153834,
 		"TextJPN": "再び、肉厚の鉄塊が振るわれた。",
-		"TextENG": "Again, that lump of iron is wielded."
+		"TextENG": "The thick lump of metal swung into him once more."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153835,
 		"TextJPN": "それは今度こそ、男の活動を停止させる。",
-		"TextENG": "Except this time, it smashes into the man's head."
+		"TextENG": "This time, the man's head cracked open."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153836,
 		"TextJPN": "キッとレナが振り返り睨む。それは俺に向けたもの。……この男に近いのはレナではなく俺だった。レナは、俺にその男を打ち倒せと言ったつもりだったのだ。それを俺がぼんやりしていたからレナが襲ったのだ。",
-		"TextENG": "Rena looks back and glares. It is directed at me. ......It's because I was closer to that man than Rena. Rena had intended for me to take him out. But because I was absentminded, Rena attacked him instead."
+		"TextENG": "Rena turned back and glared. Glared at me. ......I was closest to that man, not Rena. Rena had shouted so I could take him down. Yet I stood there spacing out, so Rena attacked him."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153837,
 		"TextJPN": "相手は銃だった。相手が素早かったら、レナの位置からは何もできなかった。だから俺に託したのに、俺は事態を未だ飲み込めてなくてぼんやりしていた…。",
-		"TextENG": "Our opponent had a gun. If he was quick, there wouldn't have been anything Rena could have done from where she was standing. It would have been up to me, she trusted me to do it, yet I was absentminded and didn't understand the situation..."
+		"TextENG": "He'd had a gun. If he had been quicker, Rena couldn't have done anything from her position. That's why she entrusted him to me, but I just stood there blankly, still unable to grasp the situation..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153838,
 		"TextJPN": "それが、その険しい表情からわかるから、咄嗟に謝ってしまう。",
-		"TextENG": "I understand this from her fierce expression, I apologize at once."
+		"TextENG": "Her stern expression made me realize that, so I immediately apologized."
 	},
 	{
 		"type": "MSGSET",
@@ -741,7 +741,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0360.",
 		"TextJPN": "「ご、………ごめん……！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``I'm......... I'm sorry......!``"
+		"TextENG": "``S......Sorry......!``"
 	},
 	{
 		"type": "MSGSET",
@@ -750,13 +750,13 @@
 		"PreTextTags": "@vS24/02/NREN_0240.",
 		"TextJPN": "「いいよ！　それより早く！」",
 		"NamesENG": "Rena",
-		"TextENG": "``It's fine! But we have to be quick!``"
+		"TextENG": "``It's fine! Just hurry!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153841,
 		"TextJPN": "レナは鉈を持ち上げ、もう片手で猟銃を拾う。",
-		"TextENG": "Rena pulls the hatchet out of the man's head, and picks up the hunting rifle with her other hand."
+		"TextENG": "Rena yanked her hatchet out of the man's head and picked up his gun with her other hand."
 	},
 	{
 		"type": "MSGSET",
@@ -765,7 +765,7 @@
 		"PreTextTags": "@vS24/02/NREN_0250.",
 		"TextJPN": "「銃はね、たとえ撃てなくても相手を怯ませることができる」",
 		"NamesENG": "Rena",
-		"TextENG": "``Even if you can't use a gun, you can still use it to intimidate people.``"
+		"TextENG": "``Even if you don't shoot, a gun can still be used to frighten opponents.``"
 	},
 	{
 		"type": "MSGSET",
@@ -774,7 +774,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0370.",
 		"TextJPN": "「ぅ、………そ、そうだな…」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Ugh......... Y-You're right...``"
+		"TextENG": "``Urk. ......R-Right...``"
 	},
 	{
 		"type": "MSGSET",
@@ -783,19 +783,19 @@
 		"PreTextTags": "@vS24/02/NREN_0260.",
 		"TextJPN": "「それより、早く逃げる準備を！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``We'll have to get away from here quickly!!``"
+		"TextENG": "``That's fine, just hurry up and get ready to run!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153845,
 		"TextJPN": "…え、魅音の手紙には明日と書いてなかったっけ…？",
-		"TextENG": "...Eh, didn't it say in Mion's letter we would leave tomorrow...?"
+		"TextENG": "...Huh? Didn't Mion say she'd come tomorrow in the letter she wrote...?"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153846,
 		"TextJPN": "そんな平和ボケはもうたくさんだッ！",
-		"TextENG": "No, I'm still being senile with peace!"
+		"TextENG": "There goes my false sense of security!"
 	},
 	{
 		"type": "MSGSET",
@@ -804,13 +804,13 @@
 		"PreTextTags": "@vS24/01/NKEI_0380.",
 		"TextJPN": "「あ、…あぁ！！　でも教えてくれ、一体何があったんだ？！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Y-Yeah!! But tell me, what on earth happened?!``"
+		"TextENG": "``Oh... Yeah!! But tell me, what on earth happened?!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153848,
 		"TextJPN": "レナと玄関に駆け戻りながら聞く。",
-		"TextENG": "I talk to Rena as she walks back to the front door."
+		"TextENG": "I asked Rena as we ran back to my front door."
 	},
 	{
 		"type": "MSGSET",
@@ -819,7 +819,7 @@
 		"PreTextTags": "@vS24/02/NREN_0270.",
 		"TextJPN": "「…圭一くんのところにも手紙が来たでしょ？　魅ぃちゃんは私の家にも同じ手紙を持ってきた」",
 		"NamesENG": "Rena",
-		"TextENG": "``...Did she bring a letter to your place too, Keiichi-kun? Mii-chan brought the same letter to my house.``"
+		"TextENG": "``...You got a letter from her too, right Keiichi-kun? Mii-chan brought the same letter over to my house.``"
 	},
 	{
 		"type": "MSGSET",
@@ -828,7 +828,7 @@
 		"PreTextTags": "@vS24/02/NREN_0280.",
 		"TextJPN": "「そこで夜回りの自警団に見付かって撃たれたんだよ！　魅ぃちゃんが何かしたわけじゃない。ただレナに手紙を持ってきただけなのに撃たれた…！」",
 		"NamesENG": "Rena",
-		"TextENG": "``But she was found by the night watch of the vigilance committee and shot! Mii-chan didn't do anything. She was shot only for bringing a letter to Rena's house...!``"
+		"TextENG": "``That was when the neighborhood watch discovered her and shot her! Mii-chan hadn't done anything to them. All she did was deliver a letter to me and they shot her...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -837,37 +837,37 @@
 		"PreTextTags": "@vS24/02/NREN_0290.",
 		"TextJPN": "「…竜宮家は感染患者だから、そこに接触するのは感染者の仲間だって勝手に決め付けられて、一方的に撃たれた！！　魅ぃちゃんが彼らに対し何かしたわけじゃないのに、構わずに撃たれたッ！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``...Because the Ryuugu family were infected, they labeled anyone and even their friends who came into contact with us also infected, so they shot her!! Mii-chan wasn't doing anything against them, but they shot her anyway without a second thought!!``"
+		"TextENG": "``...They said the Ryuugus were infected, and anyone interacting with them was an ally of the infected, but they decided that all on their own, and they shot her for it!! Mii-chan hadn't done anything to them, but they didn't care and they shot her anyway!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153852,
 		"TextJPN": "レナの目は怒りと悲しみでいっぱいになって、涙をぼろぼろと零していた。そんな激情のレナに掛けられる言葉などない…。",
-		"TextENG": "Rena's eyes are full of sorrow and anger, she's crying like rain. There's nothing I can say anything that can calm Rena down..."
+		"TextENG": "Rena's eyes were full of anger and sadness as tears spilled down her cheeks. There wasn't anything I could say to her while she was possessed by those powerful emotions..."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153853,
 		"TextJPN": "玄関に戻ると血塗れの魅音にはタオルが与えられ、お袋と一緒に傷口を押さえているところだった。",
-		"TextENG": "I return to the entrance hall and see Mion, my mom's suppressing her wound with a bloody towel."
+		"TextENG": "When we returned to my front door, Mion had been given a towel for the blood, and my mother was with her, helping her put pressure on the wound."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153854,
 		"TextJPN": "お袋はおろおろするばかり。…家にある常備薬は、せいぜい絆創膏と頭痛薬、風邪薬が関の山だ。銃で撃たれた傷の治療ができる薬なんてあるわけがない！",
-		"TextENG": "My mom doesn't know what to do. ...She got out medicine from our house, headache tablets, band-aids, and even cold medicine. There's no reason any of that crap should be out in the first place, stupid medicine like that can't treat a gunshot wound!"
+		"TextENG": "My mother was all shook up. ...The only medicines we kept in the house were band-aids, headache medicine, and cold medicine at best. We didn't have anything to help treat a gunshot wound!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153855,
 		"TextJPN": "戻ってきたレナの服に増えていた返り血と、それに染まった鉈。そして今の騒ぎと、レナが持ってきた猟銃を見て、親父は状況を全て理解したようだった。",
-		"TextENG": "Rena comes back with the victim's blood dyed into her clothes, her hatchet also stained in it. And with all the commotion just now, my dad looks at the hunting rifle Rena brought back, he seems to understand the situation."
+		"TextENG": "Rena came back into our house with more blood splattered on her clothes and staining her hatchet. Given the commotion that just happened, my father understood everything once he saw the hunting rifle in Rena's hands."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153856,
 		"TextJPN": "…親父が全て理解したことをレナもまた理解し、言った。",
-		"TextENG": "...Rena notices my dad's expression, he knows what she is about to say."
+		"TextENG": "...Once Rena understood that he did too, she spoke."
 	},
 	{
 		"type": "MSGSET",
@@ -876,7 +876,7 @@
 		"PreTextTags": "@vS24/02/NREN_0300.",
 		"TextJPN": "「おじさま、今すぐここから逃げなければ死にます。……私のお父さんはもう殺されました！！　さっき！　魅ぃちゃんを助けようとして、…あいつらは躊躇わなかった！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Mr. Maebara, we'll die if we don't escape here right now. ......My father has already been killed!! A little while ago! When he tried to help Mii-chan, they didn't hesitate!``"
+		"TextENG": "``Sir, if we don't flee this place right now, we'll die. ......My own father was already murdered!! Just now! He tried to save Mii-chan ...so they didn't even hesitate!``"
 	},
 	{
 		"type": "MSGSET",
@@ -885,13 +885,13 @@
 		"PreTextTags": "@vS24/02/NREN_0310.",
 		"TextJPN": "「カラスか何かを追っ払うかのようにいとも簡単に撃ったッ！！　信じられない…、信じられないッ！！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``They shot him as easily as shooting at crows to drive them away!! I couldn't believe it... I couldn't believe it!!!``"
+		"TextENG": "``They shot him as easily as if they were driving off crows!! I can't believe it... I can't believe it!!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153859,
 		"TextJPN": "その叫びに、魅音が弱々しく口を開く…。",
-		"TextENG": "Hearing Rena cry, Mion weakly opens her mouth..."
+		"TextENG": "Mion's mouth opened feebly after hearing Rena's screams..."
 	},
 	{
 		"type": "MSGSET",
@@ -900,7 +900,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0590.",
 		"TextJPN": "「…………ごめん……レナ…。……私がドジらなきゃ、…………。……本当に……ごめん……」",
 		"NamesENG": "Mion",
-		"TextENG": "``............I'm sorry...... Rena... ......If only I hadn't messed up............ ......Truly...... I'm sorry......``"
+		"TextENG": "``........I'm sorry...... Rena... ......If I hadn't screwed up......... ......I'm really...... sorry......``"
 	},
 	{
 		"type": "MSGSET",
@@ -909,7 +909,7 @@
 		"PreTextTags": "@vS24/02/NREN_0320.",
 		"TextJPN": "「…魅ぃちゃんは悪くないよ。そしてレナは誰も恨んでなんかいない。私が恨むべき人間は、全員然るべき清算をさせたもの。もちろん、魅ぃちゃんを撃った人にもね」",
 		"NamesENG": "Rena",
-		"TextENG": "``...It's not your fault, Mii-chan. Rena doesn't bear a grudge against anyone. Except the men that did this, but I've already settled the score with them. Of course, also the people that shot Mii-chan.``"
+		"TextENG": "``...It's not your fault, Mii-chan. And I don't hate anyone anymore. Those who deserved my hatred... have all paid the proper price. So did the man who shot you, Mii-chan.``"
 	},
 	{
 		"type": "MSGSET",
@@ -918,19 +918,19 @@
 		"PreTextTags": "@vS24/03/NMIO_0600.",
 		"TextJPN": "「………………………」",
 		"NamesENG": "Mion",
-		"TextENG": "``...........................``"
+		"TextENG": "``..................``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153863,
 		"TextJPN": "…レナは、ついさっき、目の前で魅音を撃たれ父親を殺され、自らの命も脅かされる地獄から自分の力で脱出してきた。",
-		"TextENG": "...Rena, just moments ago, watched Mion get shot and her father killed before her very eyes, and still managed to escape from that hell using her own power even when her life was threatened."
+		"TextENG": "...Just moments ago, Rena watched her father get murdered, and Mion get shot, and then she dragged herself out of that hell, where even her own life was in danger."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153864,
 		"TextJPN": "そこを経たレナの、日常では垣間見ることも叶わぬその表情が、…どれほどの地獄だったかを、見ぬ自分にも理解させる。",
-		"TextENG": "Rena just came from that, her face gave me a glimpse on what our daily life will truly become... Hell in itself, I never saw what she went through, but I can understand."
+		"TextENG": "The expression on her face was one I had never glimpsed in our daily life... and it made me realize just how hellish it all had been for her."
 	},
 	{
 		"type": "MSGSET",
@@ -939,19 +939,19 @@
 		"PreTextTags": "@vS24/02/NREN_0330.",
 		"TextJPN": "「………とにかく、…すぐに逃げる準備を……。もうすぐみんな押し寄せてくる…！」",
 		"NamesENG": "Rena",
-		"TextENG": "``.........Anyway... make preparations to leave immediately...... More of them will be coming soon...!``"
+		"TextENG": "``.........Anyway... you need to get ready to run right now...... The others are already closing in...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153866,
 		"TextJPN": "なぜ、どうして、ここに村人が押し寄せてくるのか。そして何をしようというのか。それを問い掛ける必要は、血塗れの魅音の口から出る言葉に限り、なかった。",
-		"TextENG": "Why, why are the villagers rushing here. And for what reason. I don't even need to ask myself that, the only words I need to hear are the ones from Mion's bloody mouth."
+		"TextENG": "Why? What are the villagers coming here for? What are they trying to do? There was no need to ask for an answer from Mion's bloody mouth."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153867,
 		"TextJPN": "だから親父は混乱をぐっと飲み込んで押さえ、一回咳き込んでから聞いた。",
-		"TextENG": "Therefore, my dad is trying to strongly swallow this distributing situation, I hear him cough only once."
+		"TextENG": "That was why my father swallowed his confusion, and after clearing his throat, simply asked one thing."
 	},
 	{
 		"type": "MSGSET",
@@ -960,7 +960,7 @@
 		"PreTextTags": "@vS24/00/NKFA_0090.",
 		"TextJPN": "「に、逃げるって、…どこへ…！」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``E-Escape... to where...!``"
+		"TextENG": "``R-Run? ...To where...?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -969,7 +969,7 @@
 		"PreTextTags": "@vS24/02/NREN_0340.",
 		"TextJPN": "「魅ぃちゃんの家の秘密の地下に、村人は誰も知らない隠しトンネルがあるんです！　そこまで逃げ延びれば、何とかなるかもって…！」",
 		"NamesENG": "Rena",
-		"TextENG": "``It's a secret in the basement of Mii-chan's house, a hidden tunnel that none of the villagers know about! If we can safety escape to there, we'll manage to survive...!``"
+		"TextENG": "``There's a hidden tunnel in Mii-chan's secret basement that none of the villagers know about! So long as we can make it there, we should be able to pull through...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -978,13 +978,13 @@
 		"PreTextTags": "@vS24/03/NMIO_0610.",
 		"TextJPN": "「……げほ、…げほ…！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......*Cough*... *cough*...!``"
+		"TextENG": "``......*Cough*...*Cough*...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153871,
 		"TextJPN": "レナが魅音に代わって、俺宛の手紙にも書いてあったことを説明する。魅音は説明を引き継ごうとしたのだろうが、咽こんでしまった。",
-		"TextENG": "Rena, on the behalf of Mion, explains what was written on the letter that was addressed to me. Mion tries to take over, but her throat gets clogged."
+		"TextENG": "Rena explained what was written in the letter on Mion's behalf. Mion still tried to explain, but ended up coughing instead."
 	},
 	{
 		"type": "MSGSET",
@@ -993,7 +993,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0390.",
 		"TextJPN": "「父さん、母さん、…い、一刻の猶予もないよ…！　逃げよう！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Dad, mom... W-We don't have a moment to lose...! We have to escape!``"
+		"TextENG": "``Dad, Mom... W-We don't have a moment to waste...! Let's run!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1002,13 +1002,13 @@
 		"PreTextTags": "@vS24/00/NKFA_0100.",
 		"TextJPN": "「……そ、…そうだな、そうしよう！」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``......O-Okay, let's do that!``"
+		"TextENG": "``......R-Right. Let's go!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153874,
 		"TextJPN": "親父は、差し迫っている緊急事態を把握し、平均的な社会人として持つ日常のモラルを捨てるために数瞬を経てから頷いた。…だが、お袋は即断できなかった。",
-		"TextENG": "My dad, able to understand the impending emergency, nods at Rena, ready to abandon the everyday morals he had kept as an average member of society. ...But, my mom could not make the same decision."
+		"TextENG": "My father registered the pressing danger and it only took several seconds to abandon his morals as an average member of normal society before nodding. ...But my mother couldn't make a quick decision."
 	},
 	{
 		"type": "MSGSET",
@@ -1017,49 +1017,49 @@
 		"PreTextTags": "@vS24/00/NKMO_0040.",
 		"TextJPN": "「で、でも！　逃げたらこの家はどうなるんですか！？　何が起こるかわからないのよ？！」",
 		"NamesENG": "Keiichi's mom",
-		"TextENG": "``B-But! What will happen to our house if we run away!? Do we even know what will happen to it?!``"
+		"TextENG": "``B-But! If we run, what'll happen to our home?! We don't know what's going to happen!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153876,
 		"TextJPN": "暴徒化した村人がやって来たら、放火くらいのことはされるかもしれない。…でも、そこまでわかっているならお袋の躊躇は矛盾していた。",
-		"TextENG": "Once the village mob arrives, they'll probably commit arson. ...But, my mom hesitated to admit or understand the fact it could happen."
+		"TextENG": "If the villagers come here, they may very well burn our house down. ...But if my Mother understood that, then her hesitation didn't make any sense."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153877,
 		"TextJPN": "放火すらしかねない暴徒がやって来るというのに、ここに立て篭もって何ができるというのか。自分たちがどういう目に遭わされるのか…！",
-		"TextENG": "The mob will eventually arrive and commit arson, we can't be inside when that happens. What kind of experience are they trying to force people through...!"
+		"TextENG": "If they were willing to burn down our home, then what good would holing up inside do? Who knows what they would do to us then...!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153878,
 		"TextJPN": "…お袋は決して馬鹿じゃない。いや、だからこそ頭が空回りして混乱してしまったのかもしれない。今この場においては、隔離の当日から神経質だった親父の方がむしろ冷静と言えた。",
-		"TextENG": "...My mom's not stupid at all. No, she's probably just confused on what to do. Even right now, she's become the nervous one rather than my dad was since the day of the quarantine."
+		"TextENG": "...My mother wasn't an idiot. Well, maybe that's exactly why she was so confused. At this moment, my father, who had been on edge since the first day of the quarantine, was the one acting reasonable."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153879,
 		"TextJPN": "お袋はそれでも何とか冷静さを取り戻し、通帳類を入れたハンドバッグだけを取りに戻る。",
-		"TextENG": "Still, my mom regained her composure somehow, she has begun to collect the bankbooks and decided to bring only a handbag to put stuff in."
+		"TextENG": "Still, my mother managed to regain some sense, so she went back in and grabbed only her handbag with our bank book."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153880,
 		"TextJPN": "親父はレナから猟銃を受け取っていた。",
-		"TextENG": "Meanwhile, my dad received the hunting rifle from Rena."
+		"TextENG": "My father took the hunting rifle from Rena."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153881,
 		"TextJPN": "……よく似たタイプの空気銃を持っていたことがあるから扱いはわかると豪語するが、それが頼もしい言葉なのか、頼りない言葉なのかは聞き手によって異なるだろう。",
-		"TextENG": "......He boasts the handling should be similar to an air rifle, but I guess it depends on the listener if those words are reliable or not."
+		"TextENG": "......He boasted that he knew how to handle one after using a similar type of air gun, but it was up to the listener to determine how reassuring that sounded."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153882,
 		"TextJPN": "魅音は、自分が足手まといになるから置いていけと言っていたが、レナはその頬を容赦なく叩く。",
-		"TextENG": "Mion tells us to leave her behind because she would only slow us down, but Rena slaps her cheek mercilessly."
+		"TextENG": "Mion told us to leave her behind since she'd only slow us down, but Rena slapped her hard after that suggestion."
 	},
 	{
 		"type": "MSGSET",
@@ -1068,7 +1068,7 @@
 		"PreTextTags": "@vS24/02/NREN_0350.",
 		"TextJPN": "「ダメだよ！　魅ぃちゃんじゃなきゃ、秘密の地下はわからない！　軽々しく責任を放棄しないで！！　私たちを導いてッ！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``There's no point! Without you, Mii-chan, we don't know how to find the secret basement! You can't just carelessly abandon your responsibility!! Lead us there!!``"
+		"TextENG": "``No! Without you, we won't know where the secret basement is! Don't abandon your responsibility so lightly!! Now take us there!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1077,19 +1077,19 @@
 		"PreTextTags": "@vS24/03/NMIO_0620.",
 		"TextJPN": "「……はは、………レナにかかっちゃ、…おちおち死なせてももらえないや…」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Ha ha......... I can always depend on Rena... you won't even let me die in peace...``"
+		"TextENG": "``......Haha......... With you around, I can't die an easy death at all...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153885,
 		"TextJPN": "魅音は悪態をつく程度には気力を回復できたようだった。",
-		"TextENG": "Mion seemed to recover her spirit, to an almost curse like extent."
+		"TextENG": "It looked like Mion had recovered enough energy to talk back, at least."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153886,
 		"TextJPN": "だが、傷口をいつまでも放置はできない。然るべき医師に見せなければ大量の出血で大事を免れなくなるだろう。",
-		"TextENG": "But, we can't leave her wound like that forever. It will become a serious matter if we don't get her to a doctor to stop the mass bleeding."
+		"TextENG": "But we couldn't leave her wound untreated forever. If we don't get a proper doctor to look at her, then all that blood loss will lead to disaster."
 	},
 	{
 		"type": "MSGSET",
@@ -1098,13 +1098,13 @@
 		"PreTextTags": "@vS24/02/NREN_0360.",
 		"TextJPN": "「…ねぇ、魅ぃちゃん。………問答してる時間はないから素直に教えて」",
 		"NamesENG": "Rena",
-		"TextENG": "``...Hey, Mii-chan. .........We don't have time to discuss it, so be honest with me.``"
+		"TextENG": "``...Hey, Mii-chan. .........We don't have time to debate this, so give me an answer.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153888,
 		"TextJPN": "レナが乾いた表情のまま、睨みを利かせて魅音に聞く。",
-		"TextENG": "Rena's expression is dry, she glares at Mion and waits for an answer."
+		"TextENG": "Rena glared at Mion with a dry expression and asked her just one thing."
 	},
 	{
 		"type": "MSGSET",
@@ -1113,7 +1113,7 @@
 		"PreTextTags": "@vS24/02/NREN_0370.",
 		"TextJPN": "「どうして沙都子ちゃんを抜きにして脱出しようなんて言うの？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Why are you asking us to leave Satoko-chan behind and escape by ourselves?``"
+		"TextENG": "``Why were you suggesting we should escape without Satoko-chan?``"
 	},
 	{
 		"type": "MSGSET",
@@ -1122,7 +1122,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0400.",
 		"TextJPN": "「……そ、そうだ！　それは俺も思ってた！！　沙都子はどうしたんだよ魅音！　状況的には俺やレナよりもずっとまずいんだろ？！　沙都子だけ置いてなんかいけないぞ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......Th-That's right! I was wondering that, too!! Tell us what's going to happen to Satoko, Mion! Is she in a worse situation than me or Rena?! Did you do something to put Satoko in danger!!``"
+		"TextENG": "``......Y-Yeah! I wondered that myself!! What's going on with Satoko, Mion?! She's in a worse position than me and Rena, right?! We can't just leave Satoko behind!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1131,13 +1131,13 @@
 		"PreTextTags": "@vS24/03/NMIO_0630.",
 		"TextJPN": "「………………………沙都子は…」",
 		"NamesENG": "Mion",
-		"TextENG": "``...........................Satoko...``"
+		"TextENG": "``...............Satoko's...``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153892,
 		"TextJPN": "魅音が言いよどむ。だがレナはその誤魔化しを受け付けなかった。",
-		"TextENG": "Mion fumbles for the right words. But Rena doesn't accept her deception."
+		"TextENG": "Mion trailed off. But Rena wasn't allowing her to get away with just that."
 	},
 	{
 		"type": "MSGSET",
@@ -1146,25 +1146,25 @@
 		"PreTextTags": "@vS24/02/NREN_0380.",
 		"TextJPN": "「死んだなら死んだってちゃんと言って…！！　じゃなきゃ私は、沙都子ちゃんは生きているって信じるッ！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``If she's dead just tell us she's dead...!! Because if not, I want to believe that Satoko-chan is still alive!!``"
+		"TextENG": "``If she's dead, then just tell us...!! If you don't, then we're going to believe she's still alive!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153894,
 		"TextJPN": "俺は思わず目を堅く絞るように閉じてしまう…。その最悪の想像は俺の脳裏を一度や二度ならずかすめていた。",
-		"TextENG": "I unintentionally squeeze my eyes shut... And imagine the worst possibilities as they pass through my mind."
+		"TextENG": "Without thinking I narrowed my eyes tight... That image of the worst possible outcome crossed my mind more than once or twice."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153895,
 		"TextJPN": "……魅音は沙都子のことを絶対に忘れやしない。なのに手紙からは沙都子の名が抜け落ちていた。",
-		"TextENG": "......Mion would never forget about Satoko. However, Satoko's name was missing from the letter."
+		"TextENG": "......There's no way Mion would ever forget about Satoko. Yet her name was absent from the letters she wrote us."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153896,
 		"TextJPN": "だとしたら、考えられる理由はただひとつ……！　そのただひとつは俺だって思いついていた。でもそれを口にできなかった…！！",
-		"TextENG": "So if that was the case, I can only imagine one thing......! Even though I had considered it, the words could not escape from my mouth...!!"
+		"TextENG": "That left only one possible reason...! Even I was able to imagine why. But I couldn't put it into words...!!"
 	},
 	{
 		"type": "MSGSET",
@@ -1173,7 +1173,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0640.",
 		"TextJPN": "「……さ、沙都子は、……さっき、暴徒に連れ去られたらしい…。話では鬼ヶ淵に引き連れてったって…。伝承の生贄の儀に沿って、三日かけて沈めて殺す気らしい…」",
 		"NamesENG": "Mion",
-		"TextENG": "``......Sa-Satoko was... ...A little while ago, taken away by the mob... They all believe the Onigafuchi solution will fix things... She's to be the sacrifice for the ceremony from the legend of Onigafuchi, they intend to drown her at the end of a three day ritual...``"
+		"TextENG": "``......Sa .........Satoko's............ ......been taken away by those rioters from before... They said they were dragging her to Onigafuchi... Apparently they're going spend three days submerging her, according to the rituals passed down in the village...``"
 	},
 	{
 		"type": "MSGSET",
@@ -1182,25 +1182,25 @@
 		"PreTextTags": "@o75.@vS24/01/NKEI_0410|S24/02/NREN_0390.",
 		"TextJPN": "「まだ、生きてるんだなッ？！」@r@t「まだ、生きてるのねッ？！」",
 		"NamesENG": "Keiichi & Rena",
-		"TextENG": "``So she's alive?!``@r@t``So she's alive?!``"
+		"TextENG": "``So she's alive?!``@r@t``She's still alive then?! At least for now?!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153899,
 		"TextJPN": "俺とレナが同時に魅音に食いかかる。",
-		"TextENG": "Rena and I speak at the same time after Mion."
+		"TextENG": "Rena and I both latched on Mion at once."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153900,
 		"TextJPN": "だが、魅音が沙都子を見殺しにしようとしたことを責めようなんて馬鹿な考えはこれっぽっちも浮かばなかった。",
-		"TextENG": "But, we shouldn't blame Mion for what happened to Satoko, it's stupid to think she could have stopped them."
+		"TextENG": "However, neither of us had any thought of blaming Mion for nearly abandoning Satoko."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153901,
 		"TextJPN": "……魅音は、園崎家の立場として聞き及んだ情報を冷静に判断して、どうやっても救えないと判断したのだ…！　苦渋の末にだ！",
-		"TextENG": "......Mion probably took in the information she heard and calmly made a judgement from the viewpoint of a member of the Sonozaki family, and determined that she couldn't save her no matter what she did...! In the end, it must have been an agonizing decision!"
+		"TextENG": ".........Mion used the information she was able to gather as a Sonozaki to make a logical decision, and after bitter deliberation... she decided she wouldn't be able to save her!"
 	},
 	{
 		"type": "MSGSET",
@@ -1209,7 +1209,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0650.",
 		"TextJPN": "「……どうしようもない…！　どうしようもないんだよ…！！　ううぅぅ！」",
 		"NamesENG": "Mion",
-		"TextENG": "``......There's nothing we can do...! We can't do anything...!! Uuuuuu!``"
+		"TextENG": "``...I couldn't do anything...! I couldn't do anything about it...!! Nnnh!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1218,7 +1218,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0660.",
 		"TextJPN": "「町会役員たちが音頭を取って、神社部と青年部、防犯部がさらに村の有志も加えて１００人以上に膨れ上がってるらしい！！　防犯部には猟友会も合流してて少なくとも２０丁以上のショットガン、ライフルで武装してる！」",
 		"NamesENG": "Mion",
-		"TextENG": "``With the Neighborhood association officers taking the helm, partnered with the Youth league and the Shrine association, they have bolstered security in the village swelling their ranks with over 100 volunteers!! They've even joined up with the Hunters association, who are armed with more than 20 shotguns and hunting rifles!``"
+		"TextENG": "``The council's officials took the lead and after they added the Shrine group, the youth group, the neighborhood watch, and other volunteers from the village, their numbers swelled past a hundred people!! The watch is close with the hunting club too, so they're armed with at least 20 shotguns and rifles!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1227,7 +1227,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0670.",
 		"TextJPN": "「みんなオヤシロさまの名を連呼しながら狂気に取り憑かれてる暴徒なんだよ！！　連中は容赦ない！　沙都子を庇おうとした村人に躊躇なく発砲してる！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``They're an insane mob obsessed with madness chanting the name of Oyashiro-sama!! Those people are merciless! They shot and killed without hesitation the villagers who tried to protect Satoko!!``"
+		"TextENG": "``Everyone keeps spouting Oyashiro-sama, Oyashiro-sama like they've all been possessed!! There's no mercy left in them! If I tried to protect Satoko, the villagers would've shot me to death without hesitation!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1236,13 +1236,13 @@
 		"PreTextTags": "@vS24/02/NREN_0400.",
 		"TextJPN": "「魅ぃちゃんや、私のお父さんのように…？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Mii-chan, you mean just like my dad...?``"
+		"TextENG": "``Like they did to you and to my father...?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153906,
 		"TextJPN": "魅音は涙を零しながら悔しそうに頷く。それを食い止められなかった自身の無力さに涙し、そしてこの狂気の村の中で正義を貫いて命を失った村人のためにも涙を流した。",
-		"TextENG": "Mion nods in regret while crying. Shedding tears at how powerless she was, and tears for the villagers who lost their lives through the insane justice of this mad village."
+		"TextENG": "Mion nodded bitterly as tears spilled from her eyes. She wept at her own lack of power to stop them, and for the lost lives of the villagers who still tried to uphold justice."
 	},
 	{
 		"type": "MSGSET",
@@ -1251,7 +1251,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0680.",
 		"TextJPN": "「………何でかわかんないよッ！！　みんなつい３日前までは普通だった、冷静だったッ！！　この７２時間でみるみるおかしくなっていった！　みんな目が血走ったようになって、冷静さを失っていった！」",
 		"NamesENG": "Mion",
-		"TextENG": "``.........I don't know what to do!! They were completely normal just three days ago!! But they all started acting strange after 72 hours! Their eyes are so bloodshot, they've lost all composure!``"
+		"TextENG": "``......I don't understand why!! Everyone was normal just three days ago! They were reasonable then!! But they've gone mad in just the past 72 hours! Their eyes are bloodshot, and they've lost all reason!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1260,7 +1260,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0690.",
 		"TextJPN": "「自衛隊がいなくなったからおかしくなったんじゃない！　その前からもうおかしかったんだよ！！　今や怖いのは殺人ウィルスなんかじゃない、村のみんななんだ…ッ！！」",
 		"NamesENG": "Mion",
-		"TextENG": "``They only started to act like this after the Self-Defense Forces left! There was nothing wrong with them before that!! I'm not scared of this killer virus, people of this village are scarier...!!``"
+		"TextENG": "``They didn't go crazy just because the SDF left! They were crazy before then!! The killer virus isn't what's scary now, it's everyone in the village...!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1269,7 +1269,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0700.",
 		"TextJPN": "「……………私、……思うんだよ。………このウィルスってさ。……人を死に至らしめるんじゃなくて、人を狂気に駆り立てるウィルスなんじゃないかなって」",
 		"NamesENG": "Mion",
-		"TextENG": "``...............I...... I Think. .........This virus... ...Rather than just kill us, the virus wants to force everyone to go insane."
+		"TextENG": "``............I..... have a few thoughts. .........This virus... it isn't one that drives people to death, but one that drives people to madness, making the villagers become demons one after another."
 	},
 	{
 		"type": "MSGSET",
@@ -1278,7 +1278,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0705.",
 		"TextJPN": "「……そして村人を次々、鬼に変えていって、……オヤシロさま伝説をもう一度なぞり直すんだよ…！」",
 		"NamesENG": "Mion",
-		"TextENG": "......Then one after another, the villagers will take the place of the demon ......and they will once again re-enact the legend of Oyashiro-sama...!``"
+		"TextENG": "...Just try retracing the legend of Oyashiro-sama once more...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1287,7 +1287,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0710.",
 		"TextJPN": "「この事態を何とかできるのはオヤシロさましかいない！　そしてその生まれ変わりの梨花ちゃんはいない！」",
 		"NamesENG": "Mion",
-		"TextENG": "``The only one who can do anything about this situation is Oyashiro-sama, but he is not with us! Rika-chan, his reincarnation, is not even with us!"
+		"TextENG": "``Oyashiro-sama is the only one who can resolve this situation! And her reincarnation, Rika-chan, is nowhere to be found!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1296,7 +1296,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0715.",
 		"TextJPN": "「それにそもそもオヤシロさまは神さまなんだよ？　人間じゃないんだよ？！　私たち人間には何もできないんだよ、何もッ！！！」",
 		"NamesENG": "Mion",
-		"TextENG": "Isn't Oyashiro-sama god in the first place? Then what about us?! We human beings can't do anything! Nothing!!!``"
+		"TextENG": "``Besides, Oyashiro-sama was a god anyway, right? They weren't human, were they?! There's nothing we humans can do! Nothing!!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1305,13 +1305,13 @@
 		"PreTextTags": "@vS24/01/NKEI_0420.",
 		"TextJPN": "「………落ち着け、魅音……！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``.........Calm down, Mion......!``"
+		"TextENG": "``.........Calm down, Mion...!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153914,
 		"TextJPN": "俺はしゃがみ、傷に障るのを承知で、魅音の頭を力強く抱き俺の鼓動を聞かせてやった…。",
-		"TextENG": "I squat down beside her, and notice the wound, I can hear Mion's strong heartbeat as I embrace her head..."
+		"TextENG": "I crouched down, and even knowing it would aggravate her wound, I held her head tight and let her hear my heartbeat..."
 	},
 	{
 		"type": "MSGSET",
@@ -1320,7 +1320,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0430.",
 		"TextJPN": "「…………ありがとうな。…俺やレナが事態を把握できずのんびりしている間にも、魅音は村の裏側で、妙なデマを押さえるために色々と苦労していてくれたんだよな…。……だから、きっと今日までこの村は狂気に飲み込まれなかった…」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``............Thank you. ...While Rena and I were relaxing and didn't understand the situation, you were there at the back of the village, Mion, struggling in order to suppress those fake rumors... ......So, I'm sure this village was only swallowed up in madness today...``"
+		"TextENG": "``...............Thank you. ...While Rena and I were taking it easy without realizing what was going on, you were working hard behind the scenes to try and stop the rumors... ......I'm sure that's why the village wasn't swallowed by madness until today...``"
 	},
 	{
 		"type": "MSGSET",
@@ -1329,7 +1329,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0440.",
 		"TextJPN": "「……魅音の頑張りがなかったら、……いずれ迎えていたかもしれない惨劇の今日は、…とっくに俺たちを飲み込んでいた」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......If it was not for your best efforts, Mion...... this tragedy would have already greeted us... we would have been swallowed a long time ago.``"
+		"TextENG": "``......If it wasn't for your hard work, the inevitable tragedy we faced today... would've consumed us long ago.``"
 	},
 	{
 		"type": "MSGSET",
@@ -1347,6 +1347,6 @@
 		"PreTextTags": "@vS24/03/NMIO_0720.",
 		"TextJPN": "「…………………ぁ………ぅ、……………ぅああ…ああぁああああぁあぁあぁ…」",
 		"NamesENG": "Mion",
-		"TextENG": "``.....................Ah... ......uu......... ......uuah... aaaaahhhhh...``"
+		"TextENG": "``........................Ah............Nh..................Nh, aah... aaahaaaaaaahhaahaah...``"
 	}
 ]

--- a/outbreak_6.json
+++ b/outbreak_6.json
@@ -876,7 +876,7 @@
 		"PreTextTags": "@vS24/02/NREN_0300.",
 		"TextJPN": "「おじさま、今すぐここから逃げなければ死にます。……私のお父さんはもう殺されました！！　さっき！　魅ぃちゃんを助けようとして、…あいつらは躊躇わなかった！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Sir, if we don't flee this place right now, we'll die. ......My own father was already murdered!! Just now! He tried to save Mii-chan ...so they didn't even hesitate!``"
+		"TextENG": "``Sir, if we don't flee this place right now, we'll die. ......My own father was already murdered!! Just now! He tried to save Mii-chan... so they didn't even hesitate!``"
 	},
 	{
 		"type": "MSGSET",
@@ -1182,7 +1182,7 @@
 		"PreTextTags": "@o75.@vS24/01/NKEI_0410|S24/02/NREN_0390.",
 		"TextJPN": "「まだ、生きてるんだなッ？！」@r@t「まだ、生きてるのねッ？！」",
 		"NamesENG": "Keiichi & Rena",
-		"TextENG": "``So she's alive?!``@r@t``She's still alive then?! At least for now?!!``"
+		"TextENG": "``So she's alive?!``@r@t``She's still alive then?!``"
 	},
 	{
 		"type": "MSGSET",

--- a/outbreak_end.json
+++ b/outbreak_end.json
@@ -9,13 +9,13 @@
 		"type": "MSGSET",
 		"MessageID": 153919,
 		"TextJPN": "……園崎家の最深奥に位置し、俺たちと同じ子供の立場でありながら、魅音は今日まで戦った。ぎりぎりの淵まで村が狂気に飲み込まれることに抗い、戦ってきた。",
-		"TextENG": "......Even though she is at the top of the Sonozaki family, Mion is a child just like us, and she fought her hardest. Even up until the last minute against a whole village swallowed with insanity, she fought."
+		"TextENG": "......Mion was in the deepest ranks of the Sonozakis, and even though she's just a kid like us, she fought all this time. She fought against the overwhelming madness of the village up until the very end."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153920,
 		"TextJPN": "それを認められ、………魅音は圭一の胸で涙を零した。それはさっきまで流していた涙とは少しだけ違うものだった…。",
-		"TextENG": "Granted permission......... Mion cries into Keiichi's chest. She cries the tears which drained themselves just a moment ago..."
+		"TextENG": "With her efforts acknowledged, she cried into Keiichi's chest. The tears she was shedding now were slightly different than the ones she'd shed before..."
 	},
 	{
 		"type": "MSGSET",
@@ -24,7 +24,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0460.",
 		"TextJPN": "「…レナ。魅音を責めたい気持ちもあるだろうが…、」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``...Rena. You probably want to blame Mion for this but...``"
+		"TextENG": "``...Rena. I know you might want to blame Mion, but...``"
 	},
 	{
 		"type": "MSGSET",
@@ -33,19 +33,19 @@
 		"PreTextTags": "@vS24/02/NREN_0410.",
 		"TextJPN": "「責める気なんかないよ。それどころか朗報だと思ってる」",
 		"NamesENG": "Rena",
-		"TextENG": "``I don't feel the need to blame anyone. Actually, I think this is good news.``"
+		"TextENG": "``I don't plan on blaming her at all. That's actually good to hear.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153923,
 		"TextJPN": "レナはあっさりと言う。……不思議なヤツだ。レナってヤツは鉄火場になればなるほど。修羅場になればなるほど冷静になっていく気がする。",
-		"TextENG": "Rena said so very frankly. ......What a strange girl. As much as the guy who hangs around with her. But even so, after that scene of bloodshed, I feel calm."
+		"TextENG": "Rena said casually. ...She's a strange one. Though it feels like the bigger the gamble, or the more dangerous the situation, the more composed she gets."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153924,
 		"TextJPN": "……例えるなら青い炎。それは一見静かに燃えながら、赤い炎よりもずっと高い温度で燃え盛るという。…だから俺も応えた。",
-		"TextENG": "......Especially when compared to a blue flame. It burns quietly at first glance, but its temperature is actually much higher than a red flame. ...And so I reply."
+		"TextENG": "...Just like a blue flame. At first glance it looks like it's just burning quietly, but it burns far hotter than a red one does. ...That's why I answered in turn."
 	},
 	{
 		"type": "MSGSET",
@@ -54,7 +54,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0470.",
 		"TextJPN": "「あぁ、そうだな。間違いなく、こいつぁ朗報だぜ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Oh, you're right. Without a doubt, this is good news.``"
+		"TextENG": "``Yeah, that's true. This is good news, without a doubt.``"
 	},
 	{
 		"type": "MSGSET",
@@ -63,7 +63,7 @@
 		"PreTextTags": "@vS24/02/NREN_0420.",
 		"TextJPN": "「うん、朗報だね。だって、沙都子ちゃんは生きてる」",
 		"NamesENG": "Rena",
-		"TextENG": "``Yeah, good news indeed. Because, Satoko-chan is alive.``"
+		"TextENG": "``Yeah, it's great news. I mean, Satoko-chan's alive.``"
 	},
 	{
 		"type": "MSGSET",
@@ -72,19 +72,19 @@
 		"PreTextTags": "@vS24/01/NKEI_0480.",
 		"TextJPN": "「しかも、７２時間は生かしておいてくれるというオマケ付きだ。確かにこいつぁ朗報だぜ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Moreover, they'll be keeping her alive for 72 hours. This is indeed good news.``"
+		"TextENG": "``On top of that, we know they'll keep her alive for another 72 hours. That's fantastic to hear!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153928,
 		"TextJPN": "ずっと握り締めていたバットが、ぼぅっと熱を帯びた気がした。……それはまるで、バットを灼熱の炎の中にくべ、その熱気が手にまで伝わってくるような、ジリジリと伝わる熱さ。",
-		"TextENG": "I clench my bat very hard, I can feel it's charged with an intense heat. ......It's as if the scorching flames are burning through the bat, steaming out like hot air and reaching my hand, transmitting itself into my body."
+		"TextENG": "The bat I had been gripping began to grow hot in my grasp... almost as if the bat had been immersed in a blazing fire, the heat stinging the palms of my hands."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153929,
 		"TextJPN": "…あぁ、わかってるぜ、悟史。お前まで本気になられたら怖い物ナシだぜ。コイツでぶん殴られたヤツぁ、頭部が原型留めねぇぞ…！",
-		"TextENG": "...Oh, I know, Satoshi. There's nothing to be afraid of when you get serious. I'll beat these guys hard with you, they can't stop us...!"
+		"TextENG": "...Yeah, I know, Satoshi. There's nothing to fear when even you get serious. One hit from this will smash their heads in...!"
 	},
 	{
 		"type": "MSGSET",
@@ -93,7 +93,7 @@
 		"PreTextTags": "@vS24/00/NKFA_0110.",
 		"TextJPN": "「……け、圭一、まさか、……沙都子ちゃんを助け出すつもりなのか…」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``......Ke-Keiichi, you...... you aren't thinking of going to rescue Satoko-chan, right...?``"
+		"TextENG": "``...K-Keiichi, don't tell me ......you're planning on rescuing Satoko-chan...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -102,7 +102,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0490.",
 		"TextJPN": "「父さんは、母さんと一緒に魅音を連れて裏口から逃げて。あとは俺とレナでやる」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Dad, escape through the back door with mom and Mion. Rena and I will meet up with you afterwards.``"
+		"TextENG": "``Dad, take Mom and Mion and escape through the secret exit. Rena and I will handle the rest.``"
 	},
 	{
 		"type": "MSGSET",
@@ -111,7 +111,7 @@
 		"PreTextTags": "@vS24/00/NKMO_0050.",
 		"TextJPN": "「け、…圭一…！」",
 		"NamesENG": "Keiichi's mom",
-		"TextENG": "``Ke-Keiichi...!``"
+		"TextENG": "``K-Keiichi...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -120,7 +120,7 @@
 		"PreTextTags": "@vS24/02/NREN_0430.",
 		"TextJPN": "「おばさま、ごめんなさい。魅ぃちゃんをよろしくお願いします」",
 		"NamesENG": "Rena",
-		"TextENG": "``Mrs. Maebara, I'm sorry. Please take good care of Mii-chan.``"
+		"TextENG": "``I'm sorry, ma'am. Please take care of Mii-chan.``"
 	},
 	{
 		"type": "MSGSET",
@@ -129,7 +129,7 @@
 		"PreTextTags": "@vS24/02/NREN_0440.",
 		"TextJPN": "「そして目を離さないでください。魅ぃちゃんはおいしいところだけを持っていこうとするズルっ子だから、のこのこと私たちを追い掛けて来るかもしれない。大怪我してて辛いにもかかわらず」",
 		"NamesENG": "Rena",
-		"TextENG": "``And please keep an eye on her. Mii-chan likes to hog all the glory for herself, so she might try and chase after us. Even though it would be painful with her serious injury.``"
+		"TextENG": "``Also, don't take your eyes off of her. Mii-chan doesn't play fair and likes to steal the spotlight. So she might try sneaking off after us. Even though she's badly wounded and in a lot of pain.``"
 	},
 	{
 		"type": "MSGSET",
@@ -138,31 +138,31 @@
 		"PreTextTags": "@vS24/03/NMIO_0730.",
 		"TextJPN": "「……………ちぇ、……人を足手まとい扱いにしてさ……」",
 		"NamesENG": "Mion",
-		"TextENG": "``...............Heh... ......Don't treat me like I'm a burden......``"
+		"TextENG": "``............Tsk. ......Treating me like I'm dead weight......``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153936,
 		"TextJPN": "今の魅音の状況を見る限り、とてもそんな余力があるとは思えない。…でも、俺たちの背中を黙って見送るような薄情者では断じてありえない！",
-		"TextENG": "As far as Mion's condition goes, I don't even think she has the energy for it. ...But, it's impossible to think she would just let us go without a fight!"
+		"TextENG": "Judging from Mion's current state, she didn't really have the energy to do that. ...But she'd never be so heartless as to silently watch us head off!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153937,
 		"TextJPN": "必ず魅音は俺たちの後を追い加勢しようとするだろう。例え両足がもげていたとしてもだ…！",
-		"TextENG": "Even if Mion did chase after us. She would have to move both her legs...!"
+		"TextENG": "Mion absolutely would try to follow us and provide backup. Even if both of her legs were falling off...!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153938,
 		"TextJPN": "だが、魅音は死なせられない。俺たちは仲間を誰一人失わないし、失わせない。魅音は俺たちのリーダー。",
-		"TextENG": "But, I won't let Mion die. As for us, if we lose any of our friends, everything is lost. Mion is our leader."
+		"TextENG": "But we can't allow Mion to die. We're not going to lose a single one of our friends. We won't let that happen. And Mion is our leader."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153939,
 		"TextJPN": "失えば俺たちみたいなじゃじゃ馬を統率できるヤツはいなくなる。…それに、村から脱出する方法を知る唯一の人物なんだからな。",
-		"TextENG": "I don't think a guy like me could stomach leadership. ...Besides, there's only one person who knows how to escape this village."
+		"TextENG": "Without her, there'd be no one to wrangle us wild horses together. ...Besides, she's also the only one who knows how to escape from this village."
 	},
 	{
 		"type": "MSGSET",
@@ -171,7 +171,7 @@
 		"PreTextTags": "@vS24/00/NKMO_0060.",
 		"TextJPN": "「け、………圭一………！！」",
 		"NamesENG": "Keiichi's mom",
-		"TextENG": "``Ke.........Keiichi.........!!``"
+		"TextENG": "``Ke-.........Keiichi.........!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -180,7 +180,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0500.",
 		"TextJPN": "「みっともない顔すんなよ母さん。こういう時は火打石で見送るもんだぜ…！　父さん、後で園崎家で会おうぜ…！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Mom, please don't look at me like that. We have to light the flint at a time like this...! Dad, we'll meet you later at the Sonozaki house...!``"
+		"TextENG": "``Don't give me such a sad look, Mom. At times like these, you gotta send us off with a smile...! Dad, I'll meet up with you later at the Sonozaki house...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -189,7 +189,7 @@
 		"PreTextTags": "@vS24/00/NKFA_0120.",
 		"TextJPN": "「け、圭一たちも一緒に逃げるんだ…！　たった二人で立ち向かったところで…、」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``Ke...Keiichi, you should escape with us...! What can the two of you do against them...``"
+		"TextENG": "``Ke-Keiichi, you two should come with us...! You can't face them alone...``"
 	},
 	{
 		"type": "MSGSET",
@@ -198,31 +198,31 @@
 		"PreTextTags": "@vS24/02/NREN_0450.",
 		"TextJPN": "「おじさま、お気持ちはうれしいけど、…もう手遅れなんです。ほら」",
 		"NamesENG": "Rena",
-		"TextENG": "``Mr. Maebara, I'm glad you're concerned... but it's already too late. Look.``"
+		"TextENG": "``Sir, I appreciate the sentiment, but it's already too late. See?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153944,
 		"TextJPN": "レナが玄関を開け放つと、大勢の人間が近付いてくる雑踏と、不気味な経文でオヤシロさまの名を繰り返す声が聞こえてくる。もたもたし過ぎたのだ…！！",
-		"TextENG": "Rena opens the front door, and we hear the loud movements of a large number of people approaching, all chanting the name Oyashiro-sama in an eerie sutra. We were too slow...!!"
+		"TextENG": "Rena flung open the door, and we heard the hustling movements of a huge crowd, chanting Oyashiro-sama over and over like some creepy sutra. We wasted too much time dawdling...!!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153945,
 		"TextJPN": "全員が健在で全力で疾走できたなら、親父が言う通りこの場を逃げ出す選択肢もあっただろう。…だが、部活的思考で慣らされていない親父では考えが一手鈍い。",
-		"TextENG": "If everyone was alive and well and able to sprint, we would have had the option to escape from this place like my dad said. ...But, my dad on one hand, is terrible at running."
+		"TextENG": "If we were all in top condition and ran at full speed, then we would have had the option of running away from here like my father suggested. ...But since my father wasn't used to thinking like we do in our club activities, he was a move behind."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153946,
 		"TextJPN": "…重症の魅音がいる以上、その魅音を連れて離脱するには時間稼ぎが必要なのだ。そして、ここまで追い詰められてなお覚悟が決められない一般人の親父たちでは戦力にならない！",
-		"TextENG": "...And since Mion is seriously injured, we need to buy time so they can escape. Plus, they haven't prepared to leave yet, so I can't force my dad to help us out!"
+		"TextENG": "...So long as Mion was heavily wounded, we needed someone to buy time for them to take Mion and escape. And a normal person like my father, who still hadn't steeled his resolve after we were driven into this corner, wasn't going to be useful in the fight!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153947,
 		"TextJPN": "魅音に徹底的に鍛え上げられ、瞬時に状況が把握でき、リミッターを解除できる部活メンバーでなければ戦力にならないのさ…！！",
-		"TextENG": "I have trained thoroughly under Mion, I can instantly grasp any situation, the club has no limits...!!"
+		"TextENG": "The only ones who could fight were the club members thoroughly trained by Mion, who were able to release their limiters and grasp the severity of the situation instantly."
 	},
 	{
 		"type": "MSGSET",
@@ -231,7 +231,7 @@
 		"PreTextTags": "@vS24/02/NREN_0460.",
 		"TextJPN": "「行こっか。圭一くん…！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Let's go. Keiichi-kun...!``"
+		"TextENG": "``Let's go, Keiichi-kun...!``"
 	},
 	{
 		"type": "MSGSET",
@@ -240,37 +240,37 @@
 		"PreTextTags": "@vS24/01/NKEI_0510.",
 		"TextJPN": "「そうだなぁ、そんじゃちょっくら行ってくるわ！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Yeah, I'll see you soon!``"
+		"TextENG": "``Right. Let's go take care of this real quick!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153950,
 		"TextJPN": "レナと圭一が爽やかに両親に掛ける言葉は、まるで朝の登校を思わせる。",
-		"TextENG": "The words that Rena and Keiichi gave to his parents refreshed them, reminiscent of heading to school in the morning."
+		"TextENG": "The bright farewell Rena and Keiichi left for his parents was almost the same as when they headed to school in the morning."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153951,
 		"TextJPN": "でも鞄も持っていなかった。その代わりに鉈と金属バットを持っている。そして二人は制服も着ていなかったが、……いや、制服は充分かもしれない。",
-		"TextENG": "But, they were not carrying their bags. Instead, a hatchet and a metal bat. And they aren't wearing their uniforms either...... No, school uniforms aren't necessary."
+		"TextENG": "But they didn't have their bags. Instead they carried a hatchet and a metal bat. They weren't wearing their uniforms either. ...No, what they wore was enough of a uniform."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153952,
 		"TextJPN": "この紅色に狂乱した血塗れの深夜には、二人の血染めの服はこの上なく相応しい制服だったから。",
-		"TextENG": "They would only be turned bloody red in the midnight fury, so they are wearing the utmost appropriate uniforms for blood-stained clothes."
+		"TextENG": "Their blood-soaked clothes were a more than fitting uniform for that mad and crimson night."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153953,
 		"TextJPN": "俺たちは玄関を出て扉を閉める。その隙に逃げろという無言の言葉を込めて。",
-		"TextENG": "They close the door and head out the front entrance. Speaking only silent words for evasion."
+		"TextENG": "We exited out the front and closed the door behind us, silently willing the others to run in that time."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153954,
 		"TextJPN": "門の向こうには、怪物たちの吐息を思わせるような懐中電灯の明かりの柱が何本も揺れる。皆、口々にオヤシロさまの名を繰り返しながら、ますますに近付いてくる。人数は……、ウチのクラスと同じくらいかもしれない。",
-		"TextENG": "Beyond the gates, several pillars of flashlights hang in the air reminiscent of a monster in the night. Every single one of them, while repeating the name of Oyashiro-sama, become closer and closer. The number of people...... it's about the same as our class."
+		"TextENG": "Beyond the door, there were the lights of several flashlights swaying like the breaths of ravenous beasts. Every one of them was chanting Oyashiro-sama's name as they drew closer. There were... probably the same number of people as our class."
 	},
 	{
 		"type": "MSGSET",
@@ -279,7 +279,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0520.",
 		"TextJPN": "「ひゅう…。２０人ちょいかぁ。…連中、勝てると思ってるかねぇ？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Hugh... So there's little over 20 of them. ...Do they really think they can win?``"
+		"TextENG": "``Wow... Just over 20, huh? ...You think they think they can win?``"
 	},
 	{
 		"type": "MSGSET",
@@ -288,7 +288,7 @@
 		"PreTextTags": "@vS24/02/NREN_0470.",
 		"TextJPN": "「思ってるんじゃないかな。まぁ、素人なら２０人も群れればそう思うだろうね。あはは」",
 		"NamesENG": "Rena",
-		"TextENG": "``I'm sure they do. Well, like most amateurs, they think they're safe in a crowd of 20. Ha ha.``"
+		"TextENG": "``I'm betting they do. Well, amateurs would believe that when there's 20 of them together. Ahaha.``"
 	},
 	{
 		"type": "MSGSET",
@@ -297,7 +297,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0530.",
 		"TextJPN": "「……馬鹿な連中だぜ。…穏便に済ましてりゃ、もう少し永らえただろうによ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......What a bunch of idiots. ...If they had just stayed quietly at home, they could have lived a little longer.``"
+		"TextENG": "``...What a foolish bunch they are. ...If they tried to settle things peacefully, they might have held out a little longer.``"
 	},
 	{
 		"type": "MSGSET",
@@ -306,7 +306,7 @@
 		"PreTextTags": "@vS24/02/NREN_0480.",
 		"TextJPN": "「でもあいつらは間違いを犯した」",
 		"NamesENG": "Rena",
-		"TextENG": "``But they committed several grave mistakes.``"
+		"TextENG": "``But they've made a grave mistake.``"
 	},
 	{
 		"type": "MSGSET",
@@ -315,7 +315,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0540.",
 		"TextJPN": "「あぁ、犯した」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Yeah, two in particular."
+		"TextENG": "``Yeah, they did.``"
 	},
 	{
 		"type": "MSGSET",
@@ -324,7 +324,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0550.",
 		"TextJPN": "「魅音を撃った！　沙都子をさらった！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "They shot Mion! And kidnapped Satoko!``"
+		"TextENG": "``They attacked Mion! They kidnapped Satoko!``"
 	},
 	{
 		"type": "LOGSET",
@@ -341,19 +341,19 @@
 		"PreTextTags": "@vS24/01/NKEI_0570.",
 		"TextJPN": "「こいつぁ絶体絶命のとんでもないミステイクだぜッ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``They made a terrible mistake in a desperate situation!!``"
+		"TextENG": "``And that sealed their fate!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153962,
 		"TextJPN": "俺とレナは滑るように走り、左右の門柱の影に身を潜める。その軽やかな仕草はまるで豹が獲物を狙うが如し…！",
-		"TextENG": "Rena and I run for cover, into the left and right shadows of the gatepost. We wait like a leopard ready to hunt its prey...!"
+		"TextENG": "Rena and I practically slid forward as we ran and hid behind the gateposts on the sides. Our quick movements were like a panther's after its prey...!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153963,
 		"TextJPN": "それは断じて、襲われる側が窮鼠猫を噛む仕草ではない。この状況では、…いや、二人のこの余裕では、どっちが獲物かわかったものじゃない！！",
-		"TextENG": "This is simply not a gesture, even cornered rats can bite back at the cat. In this context... No, with the two of us, we'll let them discover who the prey really is!!"
+		"TextENG": "They certainly weren't the movements of a cornered rat. In this situation it was... no, with the composure they showed, it was hard to tell who was being hunted!!"
 	},
 	{
 		"type": "MSGSET",
@@ -362,7 +362,7 @@
 		"PreTextTags": "@vS24/02/NREN_0490.",
 		"TextJPN": "「何でだろうね。私たち、これだけの人数を相手にするのに、全然怖くないね」",
 		"NamesENG": "Rena",
-		"TextENG": "``Why is that. Even, against this many people, I'm not the least bit afraid.``"
+		"TextENG": "``I wonder why? Even though we're facing so many people, I'm not afraid at all.``"
 	},
 	{
 		"type": "MSGSET",
@@ -371,19 +371,19 @@
 		"PreTextTags": "@vS24/01/NKEI_0580.",
 		"TextJPN": "「それは確かに不思議だな。どうしてだろうな」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``That's really strange indeed. I wonder why.``"
+		"TextENG": "``That much is strange. I wonder why too.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153966,
 		"TextJPN": "もしも夢や白昼夢の世界が実在するならば。…俺たちはどこか別の世界で、彼らよりもっともっと強大で恐ろしくてはるかに人数の多い相手と戦ったことがある。それでも自分たちは圧勝したッ！！",
-		"TextENG": "Is it because the world of dreams and daydreams really exist. ...That we are in another world somewhere, fighting much more powerful and heartless foes than ourselves. Aiming to achieve the impossible victory!!"
+		"TextENG": "If there was a world of dreams and daydreams... then in some other world, we must have already fought against much, much more powerful, frightening, and vast numbers. Yet we still overwhelmed them!!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153967,
 		"TextJPN": "だからこの程度のヤツラに遅れを取る気がまったくしないのだ！",
-		"TextENG": "Therefore, I cannot delay, I'm willing to take all of them on!"
+		"TextENG": "So it didn't feel like we were going to lose to people like this!"
 	},
 	{
 		"type": "MSGSET",
@@ -392,7 +392,7 @@
 		"PreTextTags": "@vS24/02/NREN_0500.",
 		"TextJPN": "「ねぇ、圭一くん。さっき魅ぃちゃんの話を聞いてさ。圭一くんも朗報だって言ってくれたけどさ。私は他の意味でも朗報だ、って思ったよ」",
 		"NamesENG": "Rena",
-		"TextENG": "``Hey, Keiichi-kun. When you were listening to Mii-chan's story a while ago. You said it was good news, Keiichi-kun. But I meant good news in a different way.``"
+		"TextENG": "``Hey, Keiichi-kun. When Mii-chan was talking to us earlier? When you said you thought that was good news too, I thought it was good news for a different reason.``"
 	},
 	{
 		"type": "MSGSET",
@@ -401,13 +401,13 @@
 		"PreTextTags": "@vS24/01/NKEI_0590.",
 		"TextJPN": "「何だよ、他の意味って。面白そうだから聞かせてくれ。…いや、あるいは俺、もう気付いてるか？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``What, what other way? It sounds interesting, tell me. ...No, or did you notice something I should know?``"
+		"TextENG": "``What? What other reason? It sounds fun, so tell me. ...Or wait, have I already figured it out?``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153970,
 		"TextJPN": "今、俺が浮かべている表情を、レナもまったく同じに浮かべ、不敵に笑ってくれた。",
-		"TextENG": "At this moment, I look over and smile, Rena has the exact same expression as I do, she is smiling fearlessly."
+		"TextENG": "Right now Rena was wearing the same expression as me, and smiling with confidence."
 	},
 	{
 		"type": "MSGSET",
@@ -416,7 +416,7 @@
 		"PreTextTags": "@vS24/02/NREN_0510.",
 		"TextJPN": "「圭一くんの場合は、気付いてるっていうより、別にそんなのはまったくどうでもいいって感じかな」",
 		"NamesENG": "Rena",
-		"TextENG": "``When it comes to you, Keiichi-kun, I always notice, but what I think is unimportant right now.``"
+		"TextENG": "``It's not so much that you've figured it out, as it just doesn't matter to you at all, really.``"
 	},
 	{
 		"type": "MSGSET",
@@ -425,7 +425,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0600.",
 		"TextJPN": "「へへへ、教えてくれよ。レナにとってのもうひとつの朗報ってヤツをよ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Hee hee hee, just tell me. A guy like me always needs to hear good news from you, Rena.``"
+		"TextENG": "``Heh heh heh, then tell me. What was this good news for you?``"
 	},
 	{
 		"type": "MSGSET",
@@ -434,7 +434,7 @@
 		"PreTextTags": "@vS24/02/NREN_0520.",
 		"TextJPN": "「あは、だってさぁ。敵は町会神社部と青年部と防犯部で、だいたい１００人ちょっとなんでしょ？　それでさらに猟友会が加わって鉄砲が２０丁以上」",
 		"NamesENG": "Rena",
-		"TextENG": "``Ha, I guess so. We're up against the security section of the Neighborhood association, Youth league, and Shrine unit, about 100 people, right? Also, take into account the 20 guns from the Hunters association.``"
+		"TextENG": "``Aha, well... Our enemies are the town council's shrine group, the youth group, and the neighborhood watch, totaling a little over a hundred, right? On top of that there's the hunting club with about 20 rifles.``"
 	},
 	{
 		"type": "MSGSET",
@@ -443,7 +443,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0610.",
 		"TextJPN": "「……やれやれ、まったくにもこいつぁツイてるぜ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......Well well, ain't that a lucky break for us.``"
+		"TextENG": "``...Good grief. Luck is totally on our side, isn't it?``"
 	},
 	{
 		"type": "MSGSET",
@@ -452,7 +452,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0620.",
 		"TextJPN": "「敵がたったの１００人程度だってんだからな！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Because there's only 100 of them!``"
+		"TextENG": "``Because there's only a hundred to face!``"
 	},
 	{
 		"type": "MSGSET",
@@ -461,7 +461,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0630.",
 		"TextJPN": "「まったく足りちゃあいないねッ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``On second thought, that's not enough at all!!``"
+		"TextENG": "``There's not enough of them to go around!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -470,7 +470,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0640.",
 		"TextJPN": "「俺ぁ、てっきり村全部が敵でよ、雛見沢２０００人を丸々ぶっ潰すつもりだったから、あんまりの少なさに拍子抜けしちまってたところだぜッ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``You're right, the entire village is our enemy, so I intend to crush all 2,000 of them living in Hinamizawa completely, what an anticlimactic outcome to their plan!!``"
+		"TextENG": "``I was convinced the whole village was our enemy. I was ready to crush all 2,000 people in Hinamizawa, so I was almost disappointed to hear there were so few!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -479,7 +479,7 @@
 		"PreTextTags": "@vS24/02/NREN_0530.",
 		"TextJPN": "「１００人を７２時間で？　そして今ここにいるのが２０人？」",
 		"NamesENG": "Rena",
-		"TextENG": "``100 people in 72 hours? And is that 20 of them heading here right now?``"
+		"TextENG": "``A hundred people in 72 hours? And there's only twenty here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -488,7 +488,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0650.",
 		"TextJPN": "「馬鹿にしてやがるぜ、まったくにもって馬鹿にしてやがるぜ！　本気の俺とレナを相手に、１００人を７２時間でだって？！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Those idiots are really underestimating us! Going against a serious Rena and me, can we take all 100 of them in 72 hours?!``"
+		"TextENG": "``They're underestimating us. They're absolutely underestimating us! Taking down a hundred foes in 72 hours when Rena and I are both serious?!``"
 	},
 	{
 		"type": "MSGSET",
@@ -497,7 +497,7 @@
 		"PreTextTags": "@vS24/02/NREN_0540.",
 		"TextJPN": "「時間が余っちゃうかな？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Will we have time to spare?``"
+		"TextENG": "``Think we'll have time to spare?``"
 	},
 	{
 		"type": "MSGSET",
@@ -506,7 +506,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0660.",
 		"TextJPN": "「むしろ足りないね」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Rather too much.``"
+		"TextENG": "``Nah, there won't be enough.``"
 	},
 	{
 		"type": "MSGSET",
@@ -515,7 +515,7 @@
 		"PreTextTags": "@vS24/02/NREN_0550.",
 		"TextJPN": "「やっぱりてこずる？」",
 		"NamesENG": "Rena",
-		"TextENG": "``Will you have a hard time after all?``"
+		"TextENG": "``You think they'll give us trouble?``"
 	},
 	{
 		"type": "MSGSET",
@@ -524,13 +524,13 @@
 		"PreTextTags": "@vS24/01/NKEI_0670.",
 		"TextJPN": "「…ばぁか。違うだろ？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``...Stupid question. How are you any different?``"
+		"TextENG": "``...Idiot. That's not what I meant.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153984,
 		"TextJPN": "くすくす。二人して笑い合う。魅音に上等を決めてくれた暴徒ども２０余名が近付いてくる。そしていよいよ攻撃圏へ……！",
-		"TextENG": "*Giggles*. Both of us begin to laugh. As the mob of more than 20 approaches who are hunting because Mion decided to help us. They will soon enter our attack zone......!"
+		"TextENG": "I chuckled. Together we laughed. The twenty that had picked a fight with Mion were drawing closer. Then they finally got in range to attack...!"
 	},
 	{
 		"type": "MSGSET",
@@ -539,7 +539,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0680.",
 		"TextJPN": "「さぁてお楽しみだぜッ！！　７２時間、たっぷり楽しませてもらおうじゃねぇかッ！！」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Now, let's have some fun!! 72 hours, that's plenty of time to entertain ourselves!!``"
+		"TextENG": "``Now, let's have some fun!! Let's have lots and lots of fun over these next 72 hours!!``"
 	},
 	{
 		"type": "MSGSET",
@@ -548,79 +548,79 @@
 		"PreTextTags": "@vS24/02/NREN_0560.",
 		"TextJPN": "「沙都子ちゃん、待っててねッ！！」",
 		"NamesENG": "Rena",
-		"TextENG": "``Satoko-chan, wait for us!!``"
+		"TextENG": "``Satoko-chan, wait up for us!!``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153987,
 		"TextJPN": "紅色の惨劇の三日間が、今、幕を開ける……！！！",
-		"TextENG": "The three days of crimson tragedy has now opened it's curtains......!!!"
+		"TextENG": "The three day long crimson tragedy was about to begin...!!!"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153988,
 		"TextJPN": "部活メンバーの姿は、彼方に興宮を見下ろせる丘の上にあった。",
-		"TextENG": "All the club members appear, they overlook from a hill onto Okinomiya and beyond."
+		"TextENG": "The club members were stationed on a hill overlooking Okinomiya."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153989,
 		"TextJPN": "圭一、レナ、魅音。そして、救い出した梨花と沙都子の姿もあった。",
-		"TextENG": "Keiichi, Rena, Mion. And, also Rika and Satoko, who they rescued."
+		"TextENG": "There was Keiichi, Rena, and Mion. Also, Rika and Satoko, who they had rescued."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153990,
 		"TextJPN": "皆、全身ぼろぼろで土汚れや埃、あるいは返り血で汚れていた。",
-		"TextENG": "Everyone, battered head to toe with soil and dirt, or the blood of their victims."
+		"TextENG": "They were all in worn-out clothes, covered in dirt stains and dust or otherwise soiled with blood."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153991,
 		"TextJPN": "激しいほどに長く、……そして、一睡もする暇がないほどにあっという間に、真っ赤な三日間が過ぎ去った。",
-		"TextENG": "Their long and intense fight is over...... With no sleep or time to rest their eyes, after three long crimson red days passed in the blink of an eye."
+		"TextENG": "Those three bright-red days were violently long... and passed by without a moment to spare on sleep."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153992,
 		"TextJPN": "彼らはひとりも欠けることなく、ここにいた。",
-		"TextENG": "Without leaving anyone behind, they are all here."
+		"TextENG": "All of them were there, without anyone missing."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153993,
 		"TextJPN": "凄惨な戦いは紛れもなくあった。",
-		"TextENG": "After an unquestionably gruesome fight."
+		"TextENG": "The ferocious battle certainly did take place."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153994,
 		"TextJPN": "しかし、部活メンバーにとって、勝利するという結果のみが重要なのであって、……それに至るまでの死闘など、今となっては記憶に留める価値もない。",
-		"TextENG": "However, for the club members only the result of victory is important...... Such the desperate struggle leading up till now is not worth to keep inside one's memory."
+		"TextENG": "But to the club members, only the result, their victory, was important. ...The deadly combat that led to this point was no longer worth remembering."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153995,
 		"TextJPN": "ただ、一同が無事にここに集っていることだけが、重要だった。",
-		"TextENG": "But, everyone gathered here safely, that is what's important."
+		"TextENG": "All that mattered, was that everyone had safely gathered here."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153996,
 		"TextJPN": "そして、それ以上に重要なのは、彼方の興宮の光景だった。",
-		"TextENG": "Although, there is something far more important, the sight of Okinomiya and beyond."
+		"TextENG": "What was even more important than that was the sight of Okinomiya in the distance."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153997,
 		"TextJPN": "何も終わっていない。",
-		"TextENG": "Nothing has ended."
+		"TextENG": "It hadn't ended."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 153998,
 		"TextJPN": "この狂乱の騒ぎは、今や雛見沢だけに留まらないことが、ここから見てもわかる。",
-		"TextENG": "The madness and frenzy, which was thought to be only confined to Hinamizawa, can now be seen everywhere from atop the hill."
+		"TextENG": "From here it was plain to the see that the madness hadn't remained limited to Hinamizawa."
 	},
 	{
 		"type": "MSGSET",
@@ -629,7 +629,7 @@
 		"PreTextTags": "@vS24/02/NREN_0570.",
 		"TextJPN": "「興宮の街が…………」",
 		"NamesENG": "Rena",
-		"TextENG": "``The town of Okinomiya............``"
+		"TextENG": "``The town of Okinomiya too.........``"
 	},
 	{
 		"type": "MSGSET",
@@ -638,7 +638,7 @@
 		"PreTextTags": "@vS24/04/NSAT_0000.",
 		"TextJPN": "「………薄々そんな気はしていましてよ。まだまだ、……終わらないのですわね」",
 		"NamesENG": "Satoko",
-		"TextENG": "``.........This vague feeling is really bothering me. Still...... this isn't over.``"
+		"TextENG": "``.........I had a faint suspicion about this. This still... isn't over yet, is it?``"
 	},
 	{
 		"type": "MSGSET",
@@ -647,7 +647,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0740.",
 		"TextJPN": "「ウィルス騒ぎは興宮にだけ広がったのか。……それとも、もっともっと広大な範囲に広がったのか。……ここから見るだけじゃわからないね」",
 		"NamesENG": "Mion",
-		"TextENG": "``I never would have thought the virus would have spread to Okinomiya. ......Or maybe, its range was further than we ever thought. ......I don't know what I'm looking at from here.``"
+		"TextENG": "``Has this virus commotion only spread to Okinomiya? ......Or do you think it's spread even further? ......I can't tell by looking from here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -656,7 +656,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0690.",
 		"TextJPN": "「……世界は、滅びちまったわけなのか……？」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``......The world, is this really the end......?``"
+		"TextENG": "``...Has the whole world gone to ruin...?``"
 	},
 	{
 		"type": "MSGSET",
@@ -665,7 +665,7 @@
 		"PreTextTags": "@vS24/02/NREN_0580.",
 		"TextJPN": "「わからない。……でも、私たちはここにいる。雛見沢の人たちだって、全員がおかしくなったわけじゃない」",
 		"NamesENG": "Rena",
-		"TextENG": "``I don't know. ......But, we are all here. Even when the people of Hinamizawa went crazy, all of us stayed calm.``"
+		"TextENG": "``I don't know. ......But we're all here. It's not like everyone in Hinamizawa went crazy, either.``"
 	},
 	{
 		"type": "MSGSET",
@@ -674,7 +674,7 @@
 		"PreTextTags": "@vS24/04/NSAT_0010.",
 		"TextJPN": "「そうですわ。未だに冷静を保ってる人たちだってまだまだいますもの。興宮にだって、きっといるに決まってますわ」",
 		"NamesENG": "Satoko",
-		"TextENG": "``That's right. But I'm sure there are others who managed to stay calm. Even in Okinomiya, I'm sure of it.``"
+		"TextENG": "``That's true. There are still those who retain their sanity even now. I'm sure there are some in Okinomiya as well.``"
 	},
 	{
 		"type": "MSGSET",
@@ -683,7 +683,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0750.",
 		"TextJPN": "「……偵察の必要が、あるかもねぇ」",
 		"NamesENG": "Mion",
-		"TextENG": "``......We'll need to do a little reconnaissance then.``"
+		"TextENG": "``......We might need to scout it out first.``"
 	},
 	{
 		"type": "MSGSET",
@@ -692,7 +692,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0700.",
 		"TextJPN": "「へっ、言うと思ったぜ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Heh, I was thinking the same thing.``"
+		"TextENG": "``Heh, I figured you'd say that.``"
 	},
 	{
 		"type": "MSGSET",
@@ -701,7 +701,7 @@
 		"PreTextTags": "@vS24/03/NMIO_0760.",
 		"TextJPN": "「世界が本当に滅びたのかどうか。私たちは見届けなきゃならない」",
 		"NamesENG": "Mion",
-		"TextENG": "``Even if this really is the end of the world. We have to survive.``"
+		"TextENG": "``We have to see for ourselves whether the world's really been destroyed or not.``"
 	},
 	{
 		"type": "MSGSET",
@@ -710,7 +710,7 @@
 		"PreTextTags": "@vS24/02/NREN_0590.",
 		"TextJPN": "「村は食料も生活必需品もなくなりかけてる。……追手も撒いたけど、村に留まる理由もない」",
 		"NamesENG": "Rena",
-		"TextENG": "``The village has probably wasted all of its food supply already. ......I'm sure our pursuers are thinking the same thing, there isn't a reason to stay in the village any longer.``"
+		"TextENG": "``The village is about to run out of food and daily necessities. ......We threw off our pursuers, but there's no need to stay in the village.``"
 	},
 	{
 		"type": "MSGSET",
@@ -728,7 +728,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0710.",
 		"TextJPN": "「となりゃ、決まりだな。……行こうぜ、街へ。興宮へ」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Then it's settled. ......Let's go, to Okinomiya.``"
+		"TextENG": "``In that case, it's settled. ...Let's go into town. To Okinomiya.``"
 	},
 	{
 		"type": "MSGSET",
@@ -737,7 +737,7 @@
 		"PreTextTags": "@vS24/05/NRIK_0000.",
 		"TextJPN": "「……………………」",
 		"NamesENG": "Rika",
-		"TextENG": "``........................``"
+		"TextENG": "``..................``"
 	},
 	{
 		"type": "MSGSET",
@@ -755,7 +755,7 @@
 		"PreTextTags": "@vS24/05/NRIK_0010.",
 		"TextJPN": "「ボクは、ここに残りますのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``I will stay here.``"
+		"TextENG": "``I'll stay here.``"
 	},
 	{
 		"type": "MSGSET",
@@ -773,19 +773,19 @@
 		"PreTextTags": "@vS24/05/NRIK_0020.",
 		"TextJPN": "「ボクは、雛見沢に残るのです。……この騒ぎが落ち着いた時、……彼らに、戻るべき場所がここであることを、教える為に」",
 		"NamesENG": "Rika",
-		"TextENG": "``I will remain in Hinamizawa. ......Until this turmoil has calmed down...... for them, to stay here in the place where they are meant to return, in order to tell them that.``"
+		"TextENG": "``I'll stay behind in Hinamizawa. ......Because once this commotion has settled... ......I'll need to tell them this is where they belong.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154016,
 		"TextJPN": "梨花が何を言っているのか、一同には理解できない。",
-		"TextENG": "All of the club members cannot understand a word Rika is saying."
+		"TextENG": "I couldn't understand all of what Rika was saying."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154017,
 		"TextJPN": "しかし、彼女がひとりで村に残ると言っていることだけは理解できた。",
-		"TextENG": "However, she is the only one who understands why she has to stay in the village alone."
+		"TextENG": "But I could understand she said she'd remain in the village by herself."
 	},
 	{
 		"type": "MSGSET",
@@ -794,7 +794,7 @@
 		"PreTextTags": "@vS24/04/NSAT_0050.",
 		"TextJPN": "「そんな……！　危険でしてよ、梨花！　まだ連中が私たちを探し回ってるに決まってますわ！」",
 		"NamesENG": "Satoko",
-		"TextENG": "``What are you saying......! It's dangerous to stay here, Rika! Who knows what'll happen if the people searching for us find you!``"
+		"TextENG": "``No way...! That's dangerous, Rika! Those guys are still out searching for you, you know!``"
 	},
 	{
 		"type": "MSGSET",
@@ -803,19 +803,19 @@
 		"PreTextTags": "@vS24/05/NRIK_0030.",
 		"TextJPN": "「大丈夫なのです。隠れん坊は得意なのですよ、にぱ～☆」",
 		"NamesENG": "Rika",
-		"TextENG": "``It's okay. I'm good at hide and seek, nipah~☆.``"
+		"TextENG": "``I'll be alright. I'm good at hide-and-seek. Nipah~☆``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154020,
 		"TextJPN": "梨花はいつもの様子で微笑むが、決意を決して翻すつもりはないようだった。",
-		"TextENG": "Rika smiles in her usual manner, but, she doesn't seem to have an intent to go back on her determination."
+		"TextENG": "Rika smiled like she usually did, showing us that we had no chance of breaking her resolve."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154021,
 		"TextJPN": "親友の沙都子だからこそ、……こんな目を見せる梨花は、絶対に説得できないと理解する……。",
-		"TextENG": "Simply because Satoko is her best friend...... Rika shows her such eyes, to make her understand there is nothing she can do to persuade her......"
+		"TextENG": "Because Satoko was her best friend... ...She understood there was no convincing Rika once she gave us that look..."
 	},
 	{
 		"type": "MSGSET",
@@ -824,7 +824,7 @@
 		"PreTextTags": "@vS24/01/NKEI_0720.",
 		"TextJPN": "「梨花ちゃん……」",
 		"NamesENG": "Keiichi",
-		"TextENG": "``Rika-chan......``"
+		"TextENG": "``Rika-chan...``"
 	},
 	{
 		"type": "MSGSET",
@@ -833,25 +833,25 @@
 		"PreTextTags": "@vS24/05/NRIK_0040.",
 		"TextJPN": "「ボクのことは気にしないでいいのです。……それより、世界を見てきてほしいのです。……この騒ぎは、終わりの始まりなのか。それとももう、終わるのか。……それを、見届けて欲しいのです」",
 		"NamesENG": "Rika",
-		"TextENG": "``You don't need to worry about me. ......From this, I want you all to see the world for what it is. ......This turmoil, is it the beginning or the end. Or possibly, the end of something else. ......I want you to make sure of that.``"
+		"TextENG": "``You don't need to worry about me. ...I'd rather you go check on the world. ......Is this the beginning of the end to this commotion? Or is it already over? ......I want you to figure that out.``"
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154024,
 		"TextJPN": "梨花はそれを伝えると、見送るかのように手を振る。",
-		"TextENG": "Rika tells us this, and waves her hand to see us off."
+		"TextENG": "After telling us that, Rika waved her hand goodbye."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154025,
 		"TextJPN": "一同は、梨花の無事を祈り、ゆっくりと歩き出す。",
-		"TextENG": "All of us, pray for the safety of Rika, and begin to slowly walk away."
+		"TextENG": "We all prayed for Rika's safety and then slowly set off."
 	},
 	{
 		"type": "MSGSET",
 		"MessageID": 154026,
 		"TextJPN": "その背中に、梨花は飛び切りの笑顔と声で、こう言うのだ。",
-		"TextENG": "We look back, and see Rika with an exceptional smile and voice, she says this."
+		"TextENG": "Behind us, Rika spoke with a beautiful smile and a clear voice."
 	},
 	{
 		"type": "MSGSET",
@@ -860,6 +860,6 @@
 		"PreTextTags": "@vS24/05/NRIK_0050.",
 		"TextJPN": "「ふぁいと、おーっ、なのですっ」",
 		"NamesENG": "Rika",
-		"TextENG": "``Fight on.``"
+		"TextENG": "``Fight, oh! You guys!``"
 	}
 ]

--- a/outbreak_end.json
+++ b/outbreak_end.json
@@ -93,7 +93,7 @@
 		"PreTextTags": "@vS24/00/NKFA_0110.",
 		"TextJPN": "「……け、圭一、まさか、……沙都子ちゃんを助け出すつもりなのか…」",
 		"NamesENG": "Keiichi's dad",
-		"TextENG": "``...K-Keiichi, don't tell me ......you're planning on rescuing Satoko-chan...?``"
+		"TextENG": "``...K-Keiichi, don't tell me...... you're planning on rescuing Satoko-chan...?``"
 	},
 	{
 		"type": "MSGSET",


### PR DESCRIPTION
- [x] Hinamizawa Bus Stop
- [x] Higurashi Outbreak
- [x] Kamikashimashi

4 lines are still machine translated because they are different than on PC:
Their MessageIDs: 155551, 155552, 155563, 155564 in kamikashimashi_end.json

There are other lines different on PC, but context is the same, so I decided to use PC translation.